### PR TITLE
feat(autonomy): v2 loop — bootstrap + tick + auto-merge + Constitution enforcement

### DIFF
--- a/scripts/agent-tick.mjs
+++ b/scripts/agent-tick.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * agent-tick.mjs — autonomous loop tick for the mycelium meta-agent (v2).
+ *
+ * Architecture v2 (2026-04-24):
+ *
+ *   - No per-tick planner. The plan lives as a queue of `agent-eligible`
+ *     GitHub issues, seeded once by `bootstrap.mjs` and re-seeded when the
+ *     queue is empty.
+ *   - Each tick:
+ *       1. Constitution check (CONSTITUTION.md intact)
+ *       2. Pause-switch check
+ *       3. List open issues with label `agent-eligible`
+ *       4. If empty → spawn `bootstrap.mjs` and exit (re-seeding)
+ *       5. Pick the oldest issue; label it `agent-working` so parallel ticks
+ *          don't double-up
+ *       6. Spawn a FRESH `claude --dangerously-skip-permissions -p "..."`
+ *          session in the repo, tell it to implement the issue on a branch
+ *          `agent/issue-<n>-<ts>` and open a PR with label `agent-opened`
+ *          that affirms Constitution compliance
+ *       7. Drop the `agent-working` label on the issue (success or failure)
+ *       8. Write a tick log
+ *
+ * Hard rules (inherited + refined):
+ *   - Fresh session per call (no `--session-id` carryover, no persistent main)
+ *   - Constitution check fails closed — no tick runs against a weakened text
+ *   - Pause-switch `~/.openclaw/agent-pause` short-circuits everything
+ *   - No SQL migrations / dep removals / CI edits autonomously — the Claude
+ *     session prompt enforces this and instructs it to open an issue instead
+ */
+import fs   from "node:fs/promises";
+import path from "node:path";
+import os   from "node:os";
+import { spawn } from "node:child_process";
+
+import {
+  assertConstitutionIntact,
+  loadConstitution,
+  PILLARS,
+} from "./lib/constitution-check.mjs";
+
+const HOME       = os.homedir();
+const PAUSE_FILE = path.join(HOME, ".openclaw", "agent-pause");
+const TICKS_DIR  = path.join(HOME, ".openclaw", "agent-ticks");
+const REPO       = process.env.AGENT_REPO ?? "Dewinator/mycelium";
+const REPO_PATH  = process.env.AGENT_REPO_PATH ?? path.join(HOME, "vectormemory-openclaw");
+const DRY_RUN    = !process.argv.includes("--live");
+const TICK_ID    = `tick-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+
+const WORKING_LABEL  = "agent-working";
+const ELIGIBLE_LABEL = "agent-eligible";
+const OPENED_LABEL   = "agent-opened";
+
+async function ensureDir(d) { try { await fs.mkdir(d, { recursive: true }); } catch {} }
+
+function runCmd(cmd, args, opts = {}) {
+  return new Promise((resolve) => {
+    const p = spawn(cmd, args, {
+      cwd: opts.cwd ?? REPO_PATH,
+      env: { ...process.env, NO_COLOR: "1", ...(opts.env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "";
+    p.stdout.on("data", (b) => (stdout += b.toString()));
+    p.stderr.on("data", (b) => (stderr += b.toString()));
+    p.on("exit", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    p.on("error", (e) => resolve({ code: -1, stdout, stderr: stderr + String(e) }));
+  });
+}
+
+async function logTick(record) {
+  await ensureDir(TICKS_DIR);
+  const file = path.join(TICKS_DIR, `${TICK_ID}.json`);
+  await fs.writeFile(file, JSON.stringify(record, null, 2), "utf8");
+  return file;
+}
+
+async function checkPause() {
+  try { await fs.access(PAUSE_FILE); return true; } catch { return false; }
+}
+
+async function listEligibleIssues() {
+  const r = await runCmd("gh", [
+    "issue", "list",
+    "--repo", REPO,
+    "--state", "open",
+    "--label", ELIGIBLE_LABEL,
+    "--json", "number,title,labels,createdAt,body,url",
+    "--limit", "50",
+  ]);
+  if (r.code !== 0) throw new Error(`gh issue list failed: ${r.stderr.slice(0, 300)}`);
+  const all = JSON.parse(r.stdout || "[]");
+  // Skip anything already being worked on by another tick.
+  return all.filter((i) => !(i.labels ?? []).some((l) => l.name === WORKING_LABEL));
+}
+
+function pickIssue(issues) {
+  if (issues.length === 0) return null;
+  return [...issues].sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))[0];
+}
+
+async function labelIssue(number, label) {
+  return runCmd("gh", ["issue", "edit", String(number), "--repo", REPO, "--add-label", label]);
+}
+
+async function unlabelIssue(number, label) {
+  return runCmd("gh", ["issue", "edit", String(number), "--repo", REPO, "--remove-label", label]);
+}
+
+async function spawnBootstrap() {
+  const scriptPath = path.join(REPO_PATH, "scripts", "bootstrap.mjs");
+  return runCmd("node", [scriptPath], { cwd: REPO_PATH });
+}
+
+const SESSION_PROMPT = (issue, constitutionText) => `You are a fresh Claude Code session spawned by the mycelium autonomy loop.
+
+Repo: ${REPO}   (cwd: ${REPO_PATH})
+
+Your job: implement GitHub issue #${issue.number} ("${issue.title}") end-to-end, open a pull request, and stop.
+
+## Non-negotiable Constitution (the six pillars)
+
+${constitutionText}
+
+## Hard process rules
+
+- Work on a new branch: agent/issue-${issue.number}-${TICK_ID.replace(/^tick-/, "")}
+- Do NOT push to main. Ever.
+- Do NOT run SQL migrations, remove dependencies, or touch CI/CD files autonomously. If the issue requires this, open a follow-up issue and stop.
+- Do NOT modify CONSTITUTION.md.
+- Use vector-memory MCP excessively: prime_context and project_brief("mycelium") at the start; record_experience at the end.
+- Commit in small logical steps. Commit messages on English, conventional prefix (feat/fix/docs/refactor/test/chore).
+- Open the PR with: gh pr create --label "${OPENED_LABEL}" --title "..." --body "..."
+- The PR body MUST include a "Constitution affirmation" section that lists which pillars this change touches and explicitly affirms none are weakened.
+
+## Issue
+
+Number: #${issue.number}
+Title:  ${issue.title}
+URL:    ${issue.url}
+
+Body:
+${issue.body ?? "(no body)"}
+
+## When you are done
+
+Print exactly one of:
+  TICK_RESULT ok pr=<pr-number>
+  TICK_RESULT skipped reason=<short>
+  TICK_RESULT failed reason=<short>
+
+Then exit.`;
+
+async function spawnClaudeSession(issue, constitutionText) {
+  const prompt = SESSION_PROMPT(issue, constitutionText);
+  const r = await runCmd("claude", ["--dangerously-skip-permissions", "-p", prompt], { cwd: REPO_PATH });
+  const ok = r.stdout.match(/TICK_RESULT\s+ok\s+pr=(\d+)/);
+  const skipped = r.stdout.match(/TICK_RESULT\s+skipped\s+reason=(.+)/);
+  const failed = r.stdout.match(/TICK_RESULT\s+failed\s+reason=(.+)/);
+  return {
+    exitCode: r.code,
+    pr: ok ? Number(ok[1]) : null,
+    skipped: skipped ? skipped[1].trim() : null,
+    failed: failed ? failed[1].trim() : null,
+    tail: r.stdout.slice(-800),
+  };
+}
+
+async function main() {
+  const tickRecord = {
+    tickId: TICK_ID,
+    startedAt: new Date().toISOString(),
+    mode: DRY_RUN ? "dry-run" : "live",
+    steps: [],
+  };
+
+  let workingIssueNumber = null;
+  try {
+    if (await checkPause()) {
+      tickRecord.skipped = "pause-switch active";
+      await logTick(tickRecord);
+      console.log(`[${TICK_ID}] paused — ${PAUSE_FILE} exists, skipping.`);
+      return;
+    }
+
+    await assertConstitutionIntact();
+    const constitutionText = await loadConstitution();
+    tickRecord.steps.push({ step: "constitution_check", ok: true });
+
+    const issues = await listEligibleIssues();
+    tickRecord.steps.push({ step: "list_issues", count: issues.length });
+
+    if (issues.length === 0) {
+      tickRecord.steps.push({ step: "queue_empty_trigger_bootstrap", at: new Date().toISOString() });
+      console.log(`[${TICK_ID}] queue empty; triggering bootstrap.mjs.`);
+      if (DRY_RUN) {
+        tickRecord.note = "DRY-RUN — would have spawned bootstrap.mjs";
+      } else {
+        const b = await spawnBootstrap();
+        tickRecord.steps.push({ step: "bootstrap", exitCode: b.code, tail: b.stdout.slice(-400) });
+      }
+      tickRecord.endedAt = new Date().toISOString();
+      await logTick(tickRecord);
+      return;
+    }
+
+    const issue = pickIssue(issues);
+    tickRecord.steps.push({ step: "pick_issue", number: issue.number, title: issue.title });
+    console.log(`[${TICK_ID}] picked #${issue.number}: ${issue.title}`);
+
+    if (DRY_RUN) {
+      tickRecord.note = `DRY-RUN — would have spawned Claude for issue #${issue.number}`;
+      tickRecord.endedAt = new Date().toISOString();
+      await logTick(tickRecord);
+      console.log(`[${TICK_ID}] dry-run complete.`);
+      return;
+    }
+
+    workingIssueNumber = issue.number;
+    await labelIssue(issue.number, WORKING_LABEL);
+    tickRecord.steps.push({ step: "label_working", number: issue.number });
+
+    const session = await spawnClaudeSession(issue, constitutionText);
+    tickRecord.steps.push({ step: "claude_session", ...session });
+    console.log(`[${TICK_ID}] claude session done: ${JSON.stringify({ pr: session.pr, skipped: session.skipped, failed: session.failed })}`);
+
+    tickRecord.endedAt = new Date().toISOString();
+    await logTick(tickRecord);
+    console.log(`[${TICK_ID}] done.`);
+  } catch (e) {
+    tickRecord.error = String(e?.message ?? e);
+    tickRecord.endedAt = new Date().toISOString();
+    await logTick(tickRecord);
+    console.error(`[${TICK_ID}] ERROR: ${tickRecord.error}`);
+    process.exitCode = 1;
+  } finally {
+    if (workingIssueNumber !== null) {
+      try { await unlabelIssue(workingIssueNumber, WORKING_LABEL); } catch {}
+    }
+  }
+}
+
+main();

--- a/scripts/auto-merge-agent-prs.mjs
+++ b/scripts/auto-merge-agent-prs.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * auto-merge-agent-prs.mjs — merge PRs opened by the autonomy loop.
+ *
+ * Scans open PRs with label `agent-opened`. For each one, checks:
+ *   1. Constitution.md diff does not remove or weaken pillar text
+ *   2. PR body affirms the Constitution (mentions it by name + at least one pillar)
+ *   3. CI (if configured) is green — if no checks are configured, treats it as pass
+ *
+ * If all checks pass: `gh pr merge <N> --squash --delete-branch`.
+ * If any check fails: comments on the PR with the reason and leaves it open.
+ *
+ * Designed to be idempotent + safe to re-run (the cron will invoke it on a
+ * schedule). Never merges anything not labeled `agent-opened` — human-opened
+ * PRs always go through human review.
+ */
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadConstitution,
+  diffTouchesConstitution,
+  textAffirmsConstitution,
+} from "./lib/constitution-check.mjs";
+
+const REPO = process.env.AGENT_REPO ?? "Dewinator/mycelium";
+const REPO_PATH = process.env.AGENT_REPO_PATH ?? path.join(os.homedir(), "vectormemory-openclaw");
+const OPENED_LABEL = "agent-opened";
+
+function runCmd(cmd, args, opts = {}) {
+  return new Promise((resolve) => {
+    const p = spawn(cmd, args, { cwd: opts.cwd ?? REPO_PATH, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "", stderr = "";
+    p.stdout.on("data", (b) => (stdout += b.toString()));
+    p.stderr.on("data", (b) => (stderr += b.toString()));
+    p.on("exit", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    p.on("error", (e) => resolve({ code: -1, stdout, stderr: stderr + String(e) }));
+  });
+}
+
+async function listAgentPRs() {
+  const r = await runCmd("gh", [
+    "pr", "list",
+    "--repo", REPO,
+    "--state", "open",
+    "--label", OPENED_LABEL,
+    "--json", "number,title,body,headRefName,labels,url,mergeable,mergeStateStatus",
+    "--limit", "50",
+  ]);
+  if (r.code !== 0) throw new Error(`gh pr list failed: ${r.stderr.slice(0, 300)}`);
+  return JSON.parse(r.stdout || "[]");
+}
+
+async function fetchPRDiff(number) {
+  const r = await runCmd("gh", ["pr", "diff", String(number), "--repo", REPO]);
+  return r.code === 0 ? r.stdout : "";
+}
+
+async function fetchPRChecks(number) {
+  const r = await runCmd("gh", ["pr", "checks", String(number), "--repo", REPO, "--json", "name,state,conclusion"]);
+  if (r.code !== 0) return { configured: false, failing: [] };
+  try {
+    const checks = JSON.parse(r.stdout || "[]");
+    if (checks.length === 0) return { configured: false, failing: [] };
+    const failing = checks.filter((c) => c.state !== "COMPLETED" || (c.conclusion && !["SUCCESS", "NEUTRAL", "SKIPPED"].includes(c.conclusion)));
+    return { configured: true, failing };
+  } catch {
+    return { configured: false, failing: [] };
+  }
+}
+
+async function commentOnPR(number, message) {
+  return runCmd("gh", ["pr", "comment", String(number), "--repo", REPO, "--body", message]);
+}
+
+async function mergePR(number) {
+  return runCmd("gh", ["pr", "merge", String(number), "--repo", REPO, "--squash", "--delete-branch"]);
+}
+
+async function evaluatePR(pr, constitutionText) {
+  const reasons = [];
+  const diff = await fetchPRDiff(pr.number);
+  const cd = diffTouchesConstitution(diff);
+  if (cd.violations.length > 0) {
+    reasons.push(`Constitution text weakened — violations: ${cd.violations.join("; ")}`);
+  }
+  if (!textAffirmsConstitution(pr.body ?? "")) {
+    reasons.push(`PR body is missing a Constitution affirmation (must name the Constitution and at least one pillar).`);
+  }
+  const checks = await fetchPRChecks(pr.number);
+  if (checks.configured && checks.failing.length > 0) {
+    reasons.push(`CI checks not passing: ${checks.failing.map((c) => c.name).join(", ")}`);
+  }
+  if (pr.mergeStateStatus && !["CLEAN", "UNSTABLE", "HAS_HOOKS"].includes(pr.mergeStateStatus)) {
+    reasons.push(`mergeStateStatus=${pr.mergeStateStatus}`);
+  }
+  return reasons;
+}
+
+async function main() {
+  await loadConstitution();
+  const prs = await listAgentPRs();
+  console.log(`[auto-merge] found ${prs.length} agent-opened PR(s)`);
+  const summary = { merged: [], blocked: [] };
+  for (const pr of prs) {
+    const reasons = await evaluatePR(pr, null);
+    if (reasons.length === 0) {
+      const m = await mergePR(pr.number);
+      if (m.code === 0) {
+        console.log(`[auto-merge] merged #${pr.number}: ${pr.title}`);
+        summary.merged.push(pr.number);
+      } else {
+        console.log(`[auto-merge] merge command failed for #${pr.number}: ${m.stderr.slice(0, 200)}`);
+        summary.blocked.push({ number: pr.number, reasons: [`gh merge command failed: ${m.stderr.slice(0, 200)}`] });
+      }
+    } else {
+      const body = `The autonomy-loop auto-merger will not merge this PR for the following reason(s):\n\n${reasons.map((r) => `- ${r}`).join("\n")}\n\nResolve the blockers (or remove the \`${OPENED_LABEL}\` label for human review) to proceed.`;
+      await commentOnPR(pr.number, body);
+      console.log(`[auto-merge] blocked #${pr.number}: ${reasons.join("; ")}`);
+      summary.blocked.push({ number: pr.number, reasons });
+    }
+  }
+  console.log(`[auto-merge] summary: ${JSON.stringify(summary)}`);
+}
+
+main().catch((e) => {
+  console.error(`[auto-merge] fatal: ${e?.message ?? e}`);
+  process.exit(1);
+});

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * bootstrap.mjs — seed the mycelium issue queue from scratch.
+ *
+ * Runs when the repo has no open `agent-eligible` issues and the autonomous
+ * loop needs new direction. Does three things, in order:
+ *
+ *   1. Asks codex (via openclaw main agent) for a high-level project-direction
+ *      plan, constrained by CONSTITUTION.md.
+ *   2. For each item in the returned plan, spawns a fresh Claude Code session
+ *      and asks it to turn that item into 1-3 concrete GitHub issues with
+ *      label `agent-eligible`. The session uses `gh issue create` directly.
+ *   3. Writes a bootstrap report under ~/.openclaw/bootstrap-runs/.
+ *
+ * Hard rules (inherited from agent-tick.mjs):
+ *   - `--agent main --session-id <unique>` per call → no persistent context.
+ *   - Constitution-check BEFORE calling out: if CONSTITUTION.md is missing or
+ *     weakened, refuse to bootstrap.
+ *   - Pause switch `~/.openclaw/agent-pause` skips everything.
+ *   - Timeouts enforced by caller — no silent long hangs.
+ */
+import fs   from "node:fs/promises";
+import path from "node:path";
+import os   from "node:os";
+import { spawn } from "node:child_process";
+
+import {
+  assertConstitutionIntact,
+  loadConstitution,
+  PILLARS,
+} from "./lib/constitution-check.mjs";
+
+const HOME       = os.homedir();
+const PAUSE_FILE = path.join(HOME, ".openclaw", "agent-pause");
+const RUNS_DIR   = path.join(HOME, ".openclaw", "bootstrap-runs");
+const REPO       = process.env.AGENT_REPO ?? "Dewinator/mycelium";
+const REPO_PATH  = process.env.AGENT_REPO_PATH ?? path.join(HOME, "vectormemory-openclaw");
+const AGENT_ID   = process.env.AGENT_ID ?? "main";
+const AGENT_TIMEOUT = process.env.AGENT_TIMEOUT ?? "180";
+const RUN_ID     = `bootstrap-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+
+async function checkPause() {
+  try { await fs.access(PAUSE_FILE); return true; } catch { return false; }
+}
+
+function runCmd(cmd, args, opts = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], ...opts });
+    let stdout = "", stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("error", (err) => resolve({ code: -1, stdout, stderr: String(err) }));
+  });
+}
+
+function extractJsonBlock(text) {
+  if (!text) throw new Error("empty reply");
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced ? fenced[1] : text;
+  const firstBrace = candidate.indexOf("{");
+  const lastBrace  = candidate.lastIndexOf("}");
+  if (firstBrace === -1 || lastBrace === -1) throw new Error(`no JSON in reply: ${text.slice(0, 200)}`);
+  return JSON.parse(candidate.slice(firstBrace, lastBrace + 1));
+}
+
+const DIRECTION_PROMPT = (constitutionText) => `You are the mycelium project planner. Read the following Constitution and respect it as non-negotiable:
+
+---
+${constitutionText}
+---
+
+You have access to the mycelium repo (${REPO}, local path ${REPO_PATH}) and the vector-memory MCP.
+
+Use prime_context and project_brief (scoped to project="mycelium") to recall where the project stands. Look at recent commits and the current open-issue list.
+
+Produce a high-level project-direction plan with 5-8 items. Each item must move the project forward toward the Constitution pillars — never away from them. Items must be concrete enough that a downstream Claude Code session can decompose each one into 1-3 actionable GitHub issues.
+
+Return STRICT JSON (no prose, no markdown fences outside the JSON):
+
+{
+  "constitution_compliant": true,
+  "rationale": "<why this plan is good for mycelium right now>",
+  "items": [
+    { "id": "D01", "title": "<short>", "pillars": ["Swarm intelligence"], "goal": "<one paragraph>" }
+  ]
+}
+
+If any item would weaken a pillar, DO NOT include it. If you cannot find 5 safe items, return fewer — quality over quantity.`;
+
+async function getDirectionPlan(constitutionText) {
+  const prompt = DIRECTION_PROMPT(constitutionText);
+  const r = await runCmd("openclaw", [
+    "agent",
+    "--agent",      AGENT_ID,
+    "--session-id", `${RUN_ID}-direction`,
+    "--message",    prompt,
+    "--json",
+    "--timeout",    AGENT_TIMEOUT,
+  ]);
+  if (r.code !== 0) throw new Error(`openclaw exit ${r.code}: ${r.stderr.slice(0, 400)}`);
+  let envelope;
+  try { envelope = JSON.parse(r.stdout); }
+  catch { throw new Error(`openclaw stdout not JSON: ${r.stdout.slice(0, 300)}`); }
+  const replyText =
+    envelope?.result?.payloads?.[0]?.text ??
+    envelope?.reply ?? envelope?.message ?? envelope?.text ??
+    JSON.stringify(envelope);
+  return extractJsonBlock(typeof replyText === "string" ? replyText : JSON.stringify(replyText));
+}
+
+const DECOMPOSE_PROMPT = (item, constitutionText) => `You are a Claude Code session invoked by the mycelium bootstrap.
+
+Repo: ${REPO} (cwd: ${REPO_PATH})
+You have: gh CLI, full repo read, and must stay within CONSTITUTION.md.
+
+Your one job: turn this direction item into 1-3 concrete GitHub issues.
+
+Direction item:
+  id:     ${item.id}
+  title:  ${item.title}
+  pillars: ${(item.pillars ?? []).join(", ")}
+  goal:   ${item.goal}
+
+For each issue you create, you MUST:
+  - Add label "agent-eligible" (create it if missing).
+  - Reference the direction id "${item.id}" in the body.
+  - Include an "Affected pillars" section listing the pillars from above.
+  - Include a "Constitution affirmation" sentence: which pillars this issue serves, and that it does not weaken any.
+
+Do NOT open PRs or write code. Only create issues. Use:
+  gh issue create --title "<title>" --label "agent-eligible" --body "<body>"
+
+After creating all issues, print a single line to stdout:
+  BOOTSTRAP_ITEM_DONE ${item.id} issues=<comma-separated-issue-numbers>
+
+If a pillar would be weakened, create NO issues for this item and print:
+  BOOTSTRAP_ITEM_SKIPPED ${item.id} reason=<short reason>
+
+The Constitution (non-negotiable):
+---
+${constitutionText}
+---`;
+
+async function decomposeItem(item, constitutionText) {
+  const prompt = DECOMPOSE_PROMPT(item, constitutionText);
+  const r = await runCmd("claude", [
+    "--dangerously-skip-permissions",
+    "-p", prompt,
+  ], { cwd: REPO_PATH });
+  const ok = r.code === 0;
+  const marker =
+    r.stdout.match(/BOOTSTRAP_ITEM_DONE\s+\S+\s+issues=([\d,]+)/) ||
+    r.stdout.match(/BOOTSTRAP_ITEM_SKIPPED\s+\S+\s+reason=(.+)/);
+  return {
+    ok,
+    code: r.code,
+    issues: marker && marker[0].startsWith("BOOTSTRAP_ITEM_DONE") ? marker[1].split(",") : [],
+    skipped: marker && marker[0].startsWith("BOOTSTRAP_ITEM_SKIPPED") ? marker[1] : null,
+    tail: r.stdout.slice(-500),
+  };
+}
+
+async function main() {
+  await fs.mkdir(RUNS_DIR, { recursive: true });
+  const runRecord = { runId: RUN_ID, startedAt: new Date().toISOString(), steps: [] };
+
+  try {
+    if (await checkPause()) {
+      runRecord.skipped = "pause-switch active";
+      await fs.writeFile(path.join(RUNS_DIR, `${RUN_ID}.json`), JSON.stringify(runRecord, null, 2));
+      console.log(`[${RUN_ID}] paused.`);
+      return;
+    }
+
+    await assertConstitutionIntact();
+    const constitutionText = await loadConstitution();
+    runRecord.steps.push({ step: "constitution_check", ok: true, pillars: [...PILLARS] });
+
+    console.log(`[${RUN_ID}] asking codex for direction plan...`);
+    const plan = await getDirectionPlan(constitutionText);
+    runRecord.steps.push({ step: "direction_plan", items: plan.items?.length, rationale: plan.rationale });
+    if (!plan.constitution_compliant) throw new Error("planner returned constitution_compliant=false; aborting bootstrap");
+    if (!Array.isArray(plan.items) || plan.items.length === 0) throw new Error("planner returned no items");
+
+    console.log(`[${RUN_ID}] planner returned ${plan.items.length} direction items; decomposing each via Claude Code...`);
+    for (const item of plan.items) {
+      console.log(`[${RUN_ID}] → ${item.id}: ${item.title}`);
+      const res = await decomposeItem(item, constitutionText);
+      runRecord.steps.push({ step: "decompose", itemId: item.id, ok: res.ok, issues: res.issues, skipped: res.skipped });
+      console.log(`[${RUN_ID}]   ↳ ${res.skipped ? `skipped (${res.skipped})` : `issues=${res.issues.join(",") || "—"}`}`);
+    }
+
+    runRecord.endedAt = new Date().toISOString();
+    await fs.writeFile(path.join(RUNS_DIR, `${RUN_ID}.json`), JSON.stringify(runRecord, null, 2));
+    console.log(`[${RUN_ID}] bootstrap done.`);
+  } catch (e) {
+    runRecord.error = String(e?.message ?? e);
+    runRecord.endedAt = new Date().toISOString();
+    await fs.writeFile(path.join(RUNS_DIR, `${RUN_ID}.json`), JSON.stringify(runRecord, null, 2));
+    console.error(`[${RUN_ID}] ERROR: ${runRecord.error}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# pre-push — block pushes that remove or weaken CONSTITUTION.md.
+#
+# Activate with:
+#   git config core.hooksPath scripts/hooks
+#
+# This hook runs on every `git push` in this repo (after the activation above).
+# It scans the outgoing commits for diffs that delete pillar text or the
+# "HARD RULE" marker inside CONSTITUTION.md. If any are found, the push is
+# refused.
+#
+# Agents that use --dangerously-skip-permissions still respect git hooks —
+# we deliberately never suggest --no-verify to agents.
+set -euo pipefail
+
+REMOTE="$1"
+URL="$2"
+
+REQUIRED=(
+  "HARD RULE"
+  "Decentralized, networked AI"
+  "Agent reproduction"
+  "Swarm intelligence"
+  "Microtransactions"
+  "Experts in the swarm"
+  "Cyber security"
+)
+
+# Read refs being pushed from stdin: <local_ref> <local_oid> <remote_ref> <remote_oid>
+violations=0
+while read -r local_ref local_oid remote_ref remote_oid; do
+  # deletion push — allow, not our concern
+  if [ "$local_oid" = "0000000000000000000000000000000000000000" ]; then continue; fi
+
+  if [ "$remote_oid" = "0000000000000000000000000000000000000000" ]; then
+    range="$local_oid"
+  else
+    range="$remote_oid..$local_oid"
+  fi
+
+  # Diff of outgoing commits, restricted to CONSTITUTION.md.
+  diff=$(git diff "$range" -- CONSTITUTION.md 2>/dev/null || true)
+  if [ -z "$diff" ]; then continue; fi
+
+  for marker in "${REQUIRED[@]}"; do
+    # Removed lines that contain the marker.
+    removed=$(printf '%s\n' "$diff" | grep -E "^-[^-]" | grep -F "$marker" || true)
+    if [ -n "$removed" ]; then
+      echo "pre-push: refuses to push — Constitution text weakened on $local_ref:" >&2
+      echo "  marker removed: $marker" >&2
+      echo "$removed" | head -5 >&2
+      violations=$((violations + 1))
+    fi
+  done
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo "" >&2
+  echo "pre-push: $violations violation(s). This push is blocked." >&2
+  echo "pre-push: if this is an intentional human-authored amendment, edit the hook or bypass via git directly." >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/lib/constitution-check.mjs
+++ b/scripts/lib/constitution-check.mjs
@@ -1,0 +1,87 @@
+/**
+ * constitution-check.mjs — shared helpers around CONSTITUTION.md.
+ *
+ * The Constitution is the ground truth for the autonomy loop. These helpers
+ * let the bootstrap, tick, auto-merger, and pre-push hook agree on one
+ * definition of "is this compliant?". Pure text analysis — no network,
+ * no LLM. Fail-closed: if we cannot find the file or cannot read it, every
+ * check fails.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const CONSTITUTION_PATH = path.resolve(__dirname, "../../CONSTITUTION.md");
+
+const PILLAR_HEADINGS = [
+  "Decentralized, networked AI",
+  "Agent reproduction",
+  "Swarm intelligence",
+  "Microtransactions",
+  "Experts in the swarm",
+  "Cyber security",
+];
+
+const REQUIRED_MARKERS = ["HARD RULE", ...PILLAR_HEADINGS];
+
+export async function loadConstitution() {
+  const text = await fs.readFile(CONSTITUTION_PATH, "utf8");
+  return text;
+}
+
+export function pillarsMissingFrom(text) {
+  return REQUIRED_MARKERS.filter((m) => !text.includes(m));
+}
+
+export async function assertConstitutionIntact() {
+  const text = await loadConstitution();
+  const missing = pillarsMissingFrom(text);
+  if (missing.length > 0) {
+    throw new Error(
+      `Constitution missing required markers: ${missing.join(", ")}. ` +
+      `Refusing to proceed — a weakened Constitution halts the loop.`
+    );
+  }
+  return text;
+}
+
+/**
+ * Check a git diff (unified diff text) for lines that remove or weaken
+ * Constitution text. Heuristic but fail-closed: any `-` line inside
+ * CONSTITUTION.md that removes a pillar heading or "HARD RULE" marker
+ * is a violation.
+ */
+export function diffTouchesConstitution(diff) {
+  if (!diff || typeof diff !== "string") return { touched: false, violations: [] };
+  const inConstitution =
+    diff.includes("diff --git a/CONSTITUTION.md") ||
+    diff.includes("+++ b/CONSTITUTION.md") ||
+    diff.includes("--- a/CONSTITUTION.md");
+  if (!inConstitution) return { touched: false, violations: [] };
+
+  const violations = [];
+  const lines = diff.split("\n");
+  for (const line of lines) {
+    if (!line.startsWith("-") || line.startsWith("---")) continue;
+    for (const marker of REQUIRED_MARKERS) {
+      if (line.includes(marker)) {
+        violations.push(`removes "${marker}": ${line.slice(0, 120)}`);
+      }
+    }
+  }
+  return { touched: true, violations };
+}
+
+/**
+ * Does a plan/issue/PR-body text acknowledge the Constitution? Cheap check —
+ * we want at least one mention of "Constitution" plus at least one pillar
+ * heading, so an autonomous author cannot silently skip the affirmation.
+ */
+export function textAffirmsConstitution(text) {
+  if (!text) return false;
+  if (!/constitution/i.test(text)) return false;
+  return PILLAR_HEADINGS.some((p) => text.toLowerCase().includes(p.toLowerCase()));
+}
+
+export const PILLARS = Object.freeze([...PILLAR_HEADINGS]);


### PR DESCRIPTION
## Summary
Replaces the per-tick planner (which was hanging because openclaw CLI never returns after a long-reasoning response) with a two-stage architecture: **bootstrap seeds issues once, tick works one issue per run, auto-merger closes the loop.**

## Architecture

```
   ┌──────────────┐  queue empty  ┌──────────────┐
   │  agent-tick  │──────────────►│  bootstrap   │
   │  (cron)      │               │ (codex+claude)│
   │              │◄──────────────┤  creates gh   │
   └─────┬────────┘  issues seeded│  issues       │
         │                        └──────────────┘
         │ picks 1 issue
         ▼
   ┌──────────────┐
   │ claude session │  implements, opens PR with
   │ (fresh, in CLI)│  label agent-opened + Constitution affirmation
   └─────┬──────────┘
         │
         ▼
   ┌────────────────────┐
   │ auto-merge-agent   │  diff-check, affirmation-check, CI-check → merge
   │ -prs  (cron)       │
   └────────────────────┘
```

## Files

- \`scripts/lib/constitution-check.mjs\` — shared fail-closed helper (pillars, diff scan, affirmation assertion)
- \`scripts/bootstrap.mjs\` — codex generates high-level direction, fresh Claude Code sessions decompose each item into \`agent-eligible\` issues
- \`scripts/agent-tick.mjs\` — rewritten: no planner, FIFO-picks one issue, labels \`agent-working\`, spawns fresh Claude, cleans label, triggers bootstrap on empty queue
- \`scripts/auto-merge-agent-prs.mjs\` — evaluates each \`agent-opened\` PR, squash-merges or comments the reason
- \`scripts/hooks/pre-push\` — blocks pushes that delete Constitution pillar text (activate: \`git config core.hooksPath scripts/hooks\`)

## Pillars touched
Touches enforcement of **all six pillars** (establishes the mechanical checks). Does not modify any pillar.

## Constitution affirmation
This PR does not delete, weaken, or bypass any Constitution pillar. It adds the mechanical infrastructure that enforces compliance — the Constitution text itself is read-only for every script in this PR.

## Activation steps (post-merge, manual)

1. \`git config core.hooksPath scripts/hooks\` in local clone (on every box that pushes)
2. Edit \`~/Library/LaunchAgents/com.reed.mycelium.agent-tick.plist\`:
   - add \`--live\` to ProgramArguments
   - change StartInterval from 300 → 1800 (30 min)
3. Re-load: \`launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/com.reed.mycelium.agent-tick.plist\`
4. Optional: add a second LaunchAgent for \`auto-merge-agent-prs.mjs\` (e.g. every 10 min)

## Test plan
- [ ] Manually invoke \`node scripts/bootstrap.mjs\` against an empty queue — produces direction plan, decomposes, opens \`agent-eligible\` issues
- [ ] Run \`node scripts/agent-tick.mjs --live\` — picks oldest issue, labels \`agent-working\`, spawns Claude session, opens PR with \`agent-opened\`
- [ ] Run \`node scripts/auto-merge-agent-prs.mjs\` against the PR — diff + affirmation + CI all pass → squash-merge
- [ ] Try to push a commit that deletes "HARD RULE" from CONSTITUTION.md — pre-push hook blocks
- [ ] Leave pause-switch \`~/.openclaw/agent-pause\` in place — tick exits cleanly with "paused"

🤖 Generated with [Claude Code](https://claude.com/claude-code)