### PR TITLE
feat(mcp): emit recalled memory_events from recall + infer_action (issue #11)

### DIFF
--- a/docs/affect-observables.md
+++ b/docs/affect-observables.md
@@ -201,16 +201,20 @@ updated without a schema change.
 
 The issue is explicitly too big for one tick. Suggested order:
 
-1. **This doc** — observables → formulas mapping. (current tick)
-2. Snapshot-migration: freeze the current `agent_affect` row into a
+1. **Doc** — observables → formulas mapping. (done, PR #15)
+2. **`recalled` event emission** — MCP tools emit `recalled` memory_events
+   with `{hits, score, query_length}` so the future triggers have input
+   data from day one. Additive; doesn't replace `affect_apply`. (done)
+3. Snapshot-migration: freeze the current `agent_affect` row into a
    historical anchor table before `compute_affect()` starts overwriting.
-3. Migration: `compute_affect()` as a pure SQL function returning JSONB
+4. Migration: `compute_affect()` as a pure SQL function returning JSONB
    (no side-effects yet, so it can be tested against live data first).
-4. Migration: triggers on `experiences` and `memory_events` that call
+5. Migration: triggers on `experiences` and `memory_events` that call
    `compute_affect()` and patch `agent_affect`.
-5. MCP-server refactor: stop calling `affect_apply` from `remember` /
-   `recall` / `absorb` / `digest`; log to `memory_events` instead.
-6. CLAUDE.md — link this doc under the Roadmap.
-7. Post-observation tuning pass (after ~2 weeks of live data).
+6. MCP-server refactor: stop calling `affect_apply` from `remember` /
+   `recall` / `absorb` / `digest`; keep the `memory_events` log as the
+   authoritative input.
+7. CLAUDE.md — link this doc under the Roadmap. (done, PR #15)
+8. Post-observation tuning pass (after ~2 weeks of live data).
 
 Each step should be a separate PR so the diff stays reviewable.

--- a/mcp-server/src/__tests__/handlers.test.ts
+++ b/mcp-server/src/__tests__/handlers.test.ts
@@ -87,6 +87,7 @@ class FakeService implements Partial<MemoryService> {
   async touch(_ids: string[]): Promise<void> {}
   async coactivate(_ids: string[]): Promise<void> {}
   async spread(_ids: string[]): Promise<never[]> { return []; }
+  async emitRecalled(_h: number, _s: number, _q: number, _src: string): Promise<void> {}
 
   async get(id: string): Promise<Memory | null> {
     return this.opts.getResult === undefined ? makeMemory({ id }) : this.opts.getResult;

--- a/mcp-server/src/services/supabase.ts
+++ b/mcp-server/src/services/supabase.ts
@@ -202,6 +202,31 @@ export class MemoryService {
   }
 
   /**
+   * Emit one `recalled` event per recall call with hit count and top score
+   * in the context payload. Consumed by the compute_affect() triggers
+   * (see docs/affect-observables.md): `hits=0` feeds empty_recalls, and
+   * `score<0.4` feeds low_conf_recalls.
+   *
+   * Non-fatal on error — this is telemetry, not a correctness dependency.
+   */
+  async emitRecalled(
+    hits: number,
+    topScore: number,
+    queryLength: number,
+    source: string
+  ): Promise<void> {
+    const { error } = await this.db.rpc("log_memory_event", {
+      p_memory_id:  null,
+      p_event_type: "recalled",
+      p_source:     source,
+      p_context:    { hits, score: topScore, query_length: queryLength },
+      p_trace_id:   null,
+      p_created_by: null,
+    });
+    if (error) console.error(`emitRecalled(${source}) failed:`, fmtErr(error));
+  }
+
+  /**
    * Emit one `used_in_response` event per id, all sharing a trace_id.
    * Consumed by the CoactivationAgent (Migration 047 event-bus). Non-fatal
    * on error — this is telemetry, not a correctness dependency.

--- a/mcp-server/src/tools/belief.ts
+++ b/mcp-server/src/tools/belief.ts
@@ -48,6 +48,9 @@ export async function inferAction(
     0.7
   );
   const topScore = hits[0]?.effective_score ?? 0;
+  // Observability: feed the `recalled` stream that compute_affect() will
+  // consume (docs/affect-observables.md).
+  void memory.emitRecalled(hits.length, topScore, input.task_description.length, "mcp:infer_action");
 
   // ---- Step 1b: fetch current serotonin (modulates ask_teacher_cost) ---
   let serotonin: number | undefined;

--- a/mcp-server/src/tools/recall.ts
+++ b/mcp-server/src/tools/recall.ts
@@ -78,11 +78,17 @@ export async function recall(
     input.vector_weight
   );
 
+  // ---- Observability: emit a `recalled` memory_event ----------------------
+  // Forward-compatible with the trigger-based compute_affect() described in
+  // docs/affect-observables.md — empty_recalls / low_conf_recalls read from
+  // memory_events, not from the affect.apply path below.
+  const topScore = results[0]?.effective_score ?? 0;
+  void service.emitRecalled(results.length, topScore, input.query.length, "mcp:recall");
+
   // ---- Auto-update affect from recall outcome -----------------------------
   // Empty recalls nudge curiosity up / confidence down; rich recalls confirm
   // confidence. Touches (single weak hit) don't move state.
   if (!input.ignore_affect) {
-    const topScore = results[0]?.effective_score ?? 0;
     if (results.length === 0) {
       void affect.apply("recall_empty", 0.5);
     } else if (results.length >= 5 && topScore >= 0.6) {


### PR DESCRIPTION
## Summary

Forward-compatible prep for the trigger-based `compute_affect()` described in [docs/affect-observables.md](docs/affect-observables.md). Every recall call now logs a `recalled` memory_event with `{hits, score, query_length}` — the exact shape that `compute_affect()`'s empty_recalls and low_conf_recalls formulas will read from.

**Additive only.** Existing `affect.apply` calls stay in place, so behavior is unchanged today. When the follow-up SQL migrations land (steps 3–5 in the updated decomposition), the triggers will already have historical `recalled` data to aggregate from, instead of starting from an empty stream.

## What changed

- `MemoryService.emitRecalled(hits, topScore, queryLength, source)` — new telemetry helper, symmetric with the existing `emitUsedInResponse`.
- `recall.ts` — emits one `recalled` event per call (source `mcp:recall`).
- `belief.ts` (`infer_action`) — emits one `recalled` event per probe (source `mcp:infer_action`).
- `docs/affect-observables.md` — decomposition list updated: this is step 2 of 8.
- `handlers.test.ts` — `FakeService` gets a no-op `emitRecalled`; all 47 tests green.

## What this deliberately does NOT do

- No SQL migration, no schema change. The hard process rule for the autonomy loop.
- Does not remove `affect.apply` from recall/belief — that refactor belongs in step 6 of the decomposition, after `compute_affect()` lands.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 47/47 pass
- [ ] Manual smoke after merge: confirm a `recalled` row appears in `memory_events` after one `recall` call

## Constitution affirmation

Touches **Pillar 6 (Cyber security)** indirectly by adding observability of memory access patterns into the canonical event log. No pillar is weakened:
- No trust bypass — uses the existing `log_memory_event` RPC under the same grants.
- No central dependency introduced (Pillar 1).
- No agent-self-breeding change (Pillar 2).
- No agent autonomy expansion beyond telemetry (Pillars 3–5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)