### PR TITLE
feat(mcp): emit mark_useful + agent_completed/agent_error events (issue #11)

### DIFF
--- a/docs/affect-observables.md
+++ b/docs/affect-observables.md
@@ -201,16 +201,20 @@ updated without a schema change.
 
 The issue is explicitly too big for one tick. Suggested order:
 
-1. **This doc** — observables → formulas mapping. (current tick)
-2. Snapshot-migration: freeze the current `agent_affect` row into a
+1. **Doc** — observables → formulas mapping. (done, PR #15)
+2. **`recalled` event emission** — MCP tools emit `recalled` memory_events
+   with `{hits, score, query_length}` so the future triggers have input
+   data from day one. Additive; doesn't replace `affect_apply`. (done)
+3. Snapshot-migration: freeze the current `agent_affect` row into a
    historical anchor table before `compute_affect()` starts overwriting.
-3. Migration: `compute_affect()` as a pure SQL function returning JSONB
+4. Migration: `compute_affect()` as a pure SQL function returning JSONB
    (no side-effects yet, so it can be tested against live data first).
-4. Migration: triggers on `experiences` and `memory_events` that call
+5. Migration: triggers on `experiences` and `memory_events` that call
    `compute_affect()` and patch `agent_affect`.
-5. MCP-server refactor: stop calling `affect_apply` from `remember` /
-   `recall` / `absorb` / `digest`; log to `memory_events` instead.
-6. CLAUDE.md — link this doc under the Roadmap.
-7. Post-observation tuning pass (after ~2 weeks of live data).
+6. MCP-server refactor: stop calling `affect_apply` from `remember` /
+   `recall` / `absorb` / `digest`; keep the `memory_events` log as the
+   authoritative input.
+7. CLAUDE.md — link this doc under the Roadmap. (done, PR #15)
+8. Post-observation tuning pass (after ~2 weeks of live data).
 
 Each step should be a separate PR so the diff stays reviewable.

--- a/mcp-server/src/__tests__/handlers.test.ts
+++ b/mcp-server/src/__tests__/handlers.test.ts
@@ -87,6 +87,7 @@ class FakeService implements Partial<MemoryService> {
   async touch(_ids: string[]): Promise<void> {}
   async coactivate(_ids: string[]): Promise<void> {}
   async spread(_ids: string[]): Promise<never[]> { return []; }
+  async emitRecalled(_h: number, _s: number, _q: number, _src: string): Promise<void> {}
 
   async get(id: string): Promise<Memory | null> {
     return this.opts.getResult === undefined ? makeMemory({ id }) : this.opts.getResult;

--- a/mcp-server/src/services/experiences.ts
+++ b/mcp-server/src/services/experiences.ts
@@ -266,6 +266,35 @@ export class ExperienceService {
       }
     }
 
+    // (d) outcome signal for compute_affect() — 'success'/'partial' → agent_completed,
+    // 'failure' → agent_error. Fed into frustration.retry_rate.
+    // See docs/affect-observables.md. Non-fatal.
+    const outcome = input.outcome ?? "unknown";
+    const outcomeEventType =
+      outcome === "failure"                     ? "agent_error"
+      : outcome === "success" || outcome === "partial" ? "agent_completed"
+      :                                            null;
+    if (outcomeEventType) {
+      try {
+        const { error: evErr } = await this.db.rpc("log_memory_event", {
+          p_memory_id:  null,
+          p_event_type: outcomeEventType,
+          p_source:     "mcp:record_experience",
+          p_context:    {
+            experience_id: id,
+            outcome,
+            task_type:     input.task_type ?? null,
+            difficulty:    input.difficulty ?? null,
+          },
+          p_trace_id:   null,
+          p_created_by: null,
+        });
+        if (evErr) console.error(`emit ${outcomeEventType} failed (non-fatal):`, fmtErr(evErr));
+      } catch (err) {
+        console.error(`emit ${outcomeEventType} threw (non-fatal):`, err);
+      }
+    }
+
     return { id, cross_links: crossLinks, intentions_touched: intentionsTouched, person_id: personId };
   }
 
@@ -390,6 +419,20 @@ export class ExperienceService {
       p_experience_id: experienceId,
     });
     if (error) throw new Error(`mark_experience_useful failed: ${fmtErr(error)}`);
+
+    // Mirror `MemoryService.emitMarkUseful` — fed into compute_affect() via
+    // memory_events, see docs/affect-observables.md. memory_id is null because
+    // the subject is an experience, not a memory; the experience id goes into
+    // context so downstream consumers can still correlate. Non-fatal.
+    const { error: evErr } = await this.db.rpc("log_memory_event", {
+      p_memory_id:  null,
+      p_event_type: "mark_useful",
+      p_source:     "mcp:mark_experience_useful",
+      p_context:    { experience_id: experienceId },
+      p_trace_id:   null,
+      p_created_by: null,
+    });
+    if (evErr) console.error(`emit mark_useful(experience) failed:`, fmtErr(evErr));
   }
 
   /** Find existing lessons whose embedding is close to the query text. */

--- a/mcp-server/src/services/supabase.ts
+++ b/mcp-server/src/services/supabase.ts
@@ -202,6 +202,31 @@ export class MemoryService {
   }
 
   /**
+   * Emit one `recalled` event per recall call with hit count and top score
+   * in the context payload. Consumed by the compute_affect() triggers
+   * (see docs/affect-observables.md): `hits=0` feeds empty_recalls, and
+   * `score<0.4` feeds low_conf_recalls.
+   *
+   * Non-fatal on error — this is telemetry, not a correctness dependency.
+   */
+  async emitRecalled(
+    hits: number,
+    topScore: number,
+    queryLength: number,
+    source: string
+  ): Promise<void> {
+    const { error } = await this.db.rpc("log_memory_event", {
+      p_memory_id:  null,
+      p_event_type: "recalled",
+      p_source:     source,
+      p_context:    { hits, score: topScore, query_length: queryLength },
+      p_trace_id:   null,
+      p_created_by: null,
+    });
+    if (error) console.error(`emitRecalled(${source}) failed:`, fmtErr(error));
+  }
+
+  /**
    * Emit one `used_in_response` event per id, all sharing a trace_id.
    * Consumed by the CoactivationAgent (Migration 047 event-bus). Non-fatal
    * on error — this is telemetry, not a correctness dependency.

--- a/mcp-server/src/services/supabase.ts
+++ b/mcp-server/src/services/supabase.ts
@@ -154,6 +154,25 @@ export class MemoryService {
   async markUseful(id: string): Promise<void> {
     const { error } = await this.db.rpc("mark_memory_useful", { memory_id: id });
     if (error) throw new Error(`mark_memory_useful failed: ${fmtErr(error)}`);
+    await this.emitMarkUseful(id, "mcp:mark_useful");
+  }
+
+  /**
+   * Emit one `mark_useful` event per explicit strong-learning signal.
+   * Consumed by the compute_affect() triggers (see docs/affect-observables.md):
+   * feeds the `useful_delta` term of `satisfaction`. Non-fatal — this is
+   * telemetry, not a correctness dependency.
+   */
+  async emitMarkUseful(memoryId: string | null, source: string): Promise<void> {
+    const { error } = await this.db.rpc("log_memory_event", {
+      p_memory_id:  memoryId,
+      p_event_type: "mark_useful",
+      p_source:     source,
+      p_context:    {},
+      p_trace_id:   null,
+      p_created_by: null,
+    });
+    if (error) console.error(`emitMarkUseful(${source}) failed:`, fmtErr(error));
   }
 
   async dedup(threshold = 0.93): Promise<number> {

--- a/mcp-server/src/tools/belief.ts
+++ b/mcp-server/src/tools/belief.ts
@@ -48,6 +48,9 @@ export async function inferAction(
     0.7
   );
   const topScore = hits[0]?.effective_score ?? 0;
+  // Observability: feed the `recalled` stream that compute_affect() will
+  // consume (docs/affect-observables.md).
+  void memory.emitRecalled(hits.length, topScore, input.task_description.length, "mcp:infer_action");
 
   // ---- Step 1b: fetch current serotonin (modulates ask_teacher_cost) ---
   let serotonin: number | undefined;

--- a/mcp-server/src/tools/recall.ts
+++ b/mcp-server/src/tools/recall.ts
@@ -78,11 +78,17 @@ export async function recall(
     input.vector_weight
   );
 
+  // ---- Observability: emit a `recalled` memory_event ----------------------
+  // Forward-compatible with the trigger-based compute_affect() described in
+  // docs/affect-observables.md — empty_recalls / low_conf_recalls read from
+  // memory_events, not from the affect.apply path below.
+  const topScore = results[0]?.effective_score ?? 0;
+  void service.emitRecalled(results.length, topScore, input.query.length, "mcp:recall");
+
   // ---- Auto-update affect from recall outcome -----------------------------
   // Empty recalls nudge curiosity up / confidence down; rich recalls confirm
   // confidence. Touches (single weak hit) don't move state.
   if (!input.ignore_affect) {
-    const topScore = results[0]?.effective_score ?? 0;
     if (results.length === 0) {
       void affect.apply("recall_empty", 0.5);
     } else if (results.length >= 5 && topScore >= 0.6) {


### PR DESCRIPTION
## Summary

Step 2 continuation of the `compute_affect()` decomposition in
[docs/affect-observables.md](../blob/main/docs/affect-observables.md).
Adds three more `memory_events` types that the future `compute_affect()`
triggers will consume.

| Event type | Emitted from | Feeds |
|---|---|---|
| `mark_useful` | `mark_useful` tool (memory) | `satisfaction.useful_delta` |
| `mark_useful` | `mark_experience_useful` tool | `satisfaction.useful_delta` |
| `agent_completed` | `record_experience` with outcome `success` / `partial` | `frustration.retry_rate` denominator |
| `agent_error` | `record_experience` with outcome `failure` | `frustration.retry_rate` numerator |

All emissions are **additive and non-fatal** — existing behaviour is
unchanged, `affect_apply` still runs, `mark_memory_useful` still returns
the same way, and a failing `log_memory_event` RPC only logs to stderr.

## Why this tick is small

Following the decomposition in `docs/affect-observables.md` (step 2
extended). No SQL migration, no trigger, no CI change. Deliberately
autonomy-loop-safe: just feeds signal into the existing event log so
later ticks (steps 3–5) have input data available from day one.

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)**: the agent's mood
surface moves from LLM-self-reported to locally observable events
logged at the database boundary. This strengthens the pillar — mood
becomes authoritatively derived on the user's own hardware rather than
dependent on cloud-LLM honesty.

No pillar is weakened. Consent gates, genome signing, federation trust,
and cryptographic identity are all untouched.

## Test plan

- [x] `npm run build` in `mcp-server` compiles clean
- [ ] Live smoke (manual): run `mark_useful` on a memory, query
      `SELECT event_type, source, created_at FROM memory_events
       WHERE event_type = 'mark_useful' ORDER BY created_at DESC LIMIT 5;`
- [ ] Live smoke (manual): call `record_experience` with
      `outcome='failure'` and confirm an `agent_error` row appears in
      `memory_events`
- [ ] Live smoke (manual): call `record_experience` with
      `outcome='success'` and confirm an `agent_completed` row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)