### PR TITLE
feat(conscience): emit contradiction_detected for compute_affect() (issue #11)

### DIFF
--- a/docs/affect-observables.md
+++ b/docs/affect-observables.md
@@ -205,16 +205,23 @@ The issue is explicitly too big for one tick. Suggested order:
 2. **`recalled` event emission** — MCP tools emit `recalled` memory_events
    with `{hits, score, query_length}` so the future triggers have input
    data from day one. Additive; doesn't replace `affect_apply`. (done)
-3. Snapshot-migration: freeze the current `agent_affect` row into a
+3. **`mark_useful` / `agent_completed` / `agent_error` emission** — MCP
+   plumbing so satisfaction (`useful_delta`) and frustration (`retry_rate`)
+   have their input data. Additive. (done)
+4. **`contradiction_detected` emission** — ConscienceAgent emits this
+   alongside `conscience_warning` (shared `trace_id`) so frustration's
+   `open_conflicts` term has a data source and a future
+   `contradiction_resolved` event can correlate back. Additive. (done)
+5. Snapshot-migration: freeze the current `agent_affect` row into a
    historical anchor table before `compute_affect()` starts overwriting.
-4. Migration: `compute_affect()` as a pure SQL function returning JSONB
+6. Migration: `compute_affect()` as a pure SQL function returning JSONB
    (no side-effects yet, so it can be tested against live data first).
-5. Migration: triggers on `experiences` and `memory_events` that call
+7. Migration: triggers on `experiences` and `memory_events` that call
    `compute_affect()` and patch `agent_affect`.
-6. MCP-server refactor: stop calling `affect_apply` from `remember` /
+8. MCP-server refactor: stop calling `affect_apply` from `remember` /
    `recall` / `absorb` / `digest`; keep the `memory_events` log as the
    authoritative input.
-7. CLAUDE.md — link this doc under the Roadmap. (done, PR #15)
-8. Post-observation tuning pass (after ~2 weeks of live data).
+9. CLAUDE.md — link this doc under the Roadmap. (done, PR #15)
+10. Post-observation tuning pass (after ~2 weeks of live data).
 
 Each step should be a separate PR so the diff stays reviewable.

--- a/mcp-server/src/agents/conscience-agent.ts
+++ b/mcp-server/src/agents/conscience-agent.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { PostgrestClient } from "@supabase/postgrest-js";
 import type { Agent, AgentEventBus, BusEvent } from "./event-bus.js";
 
@@ -125,13 +126,20 @@ export class ConscienceAgent implements Agent {
       return;
     }
 
-    // 4) log warning event + chain relation
+    // 4) log warning event + chain relation.
+    //    Two events share one trace_id so a future "contradiction_resolved"
+    //    event can correlate back. `conscience_warning` is the human-readable
+    //    surface; `contradiction_detected` is the observable counted by the
+    //    frustration term of compute_affect() — see docs/affect-observables.md.
     const reason = (verdict.reason ?? "").slice(0, 500);
-    await bus.emit(mem.id, "conscience_warning", this.name, {
+    const traceId = randomUUID();
+    const payload = {
       contradicts_id: verdict.contradicts_id,
       confidence:     verdict.confidence,
       reason,
-    });
+    };
+    await bus.emit(mem.id, "conscience_warning",    this.name, payload, traceId);
+    await bus.emit(mem.id, "contradiction_detected", this.name, payload, traceId);
     const { error: chainErr } = await this.db.rpc("chain_memories", {
       p_a_id:   mem.id,
       p_b_id:   verdict.contradicts_id,


### PR DESCRIPTION
## Summary

- ConscienceAgent now emits `contradiction_detected` alongside the existing `conscience_warning` whenever it finds a real contradiction (confidence ≥ `minConfidence`, candidate id matches).
- Both events share a freshly-generated `trace_id`, so a future `contradiction_resolved` event can correlate back (the frustration formula uses a `NOT EXISTS (…resolution event with same trace_id…)` clause).
- Refreshes the decomposition list in `docs/affect-observables.md` so the \"done\" markers reflect steps that already landed on `main` (PR #15 + recalled/mark_useful/agent_completed emission).

## Why

Issue #11 plans a `compute_affect()` trigger whose **frustration** term reads `count(memory_events WHERE event_type='contradiction_detected' …)`. Until this PR the event type was declared in migration 047's enum but had no producer, leaving `open_conflicts` unfed.

This change is purely additive — no migrations, no dep changes, no CI files touched. Existing consumers of `conscience_warning` are unaffected.

## Test plan

- [x] `npm test` (47 pass) in `mcp-server/`
- [x] `npx tsc --noEmit` clean
- [ ] After the next `compute_affect()` trigger lands, verify `memory_events` has `contradiction_detected` rows with trace_ids matching their sibling `conscience_warning` rows

## Constitution affirmation

This PR touches **Pillar 3 — Swarm intelligence** (the conscience-agent is part of the specialized multi-agent mesh) and **Pillar 6 — Cyber security** (signed memory lineage via `memory_events`). No pillar is weakened: no trust gates bypassed, no central authority introduced, no breeding machinery altered, no cryptographic boundary crossed. The change is additive event emission only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)