### PR TITLE
feat(affect): preview_affect MCP tool — TS reference for compute_affect() (issue #11)

### DIFF
--- a/docs/affect-observables.md
+++ b/docs/affect-observables.md
@@ -205,16 +205,23 @@ The issue is explicitly too big for one tick. Suggested order:
 2. **`recalled` event emission** — MCP tools emit `recalled` memory_events
    with `{hits, score, query_length}` so the future triggers have input
    data from day one. Additive; doesn't replace `affect_apply`. (done)
-3. Snapshot-migration: freeze the current `agent_affect` row into a
+3. **`mark_useful` / `agent_completed` / `agent_error` emission** — MCP
+   plumbing so satisfaction (`useful_delta`) and frustration (`retry_rate`)
+   have their input data. Additive. (done)
+4. **`contradiction_detected` emission** — ConscienceAgent emits this
+   alongside `conscience_warning` (shared `trace_id`) so frustration's
+   `open_conflicts` term has a data source and a future
+   `contradiction_resolved` event can correlate back. Additive. (done)
+5. Snapshot-migration: freeze the current `agent_affect` row into a
    historical anchor table before `compute_affect()` starts overwriting.
-4. Migration: `compute_affect()` as a pure SQL function returning JSONB
+6. Migration: `compute_affect()` as a pure SQL function returning JSONB
    (no side-effects yet, so it can be tested against live data first).
-5. Migration: triggers on `experiences` and `memory_events` that call
+7. Migration: triggers on `experiences` and `memory_events` that call
    `compute_affect()` and patch `agent_affect`.
-6. MCP-server refactor: stop calling `affect_apply` from `remember` /
+8. MCP-server refactor: stop calling `affect_apply` from `remember` /
    `recall` / `absorb` / `digest`; keep the `memory_events` log as the
    authoritative input.
-7. CLAUDE.md — link this doc under the Roadmap. (done, PR #15)
-8. Post-observation tuning pass (after ~2 weeks of live data).
+9. CLAUDE.md — link this doc under the Roadmap. (done, PR #15)
+10. Post-observation tuning pass (after ~2 weeks of live data).
 
 Each step should be a separate PR so the diff stays reviewable.

--- a/docs/affect-observables.md
+++ b/docs/affect-observables.md
@@ -216,6 +216,12 @@ The issue is explicitly too big for one tick. Suggested order:
    historical anchor table before `compute_affect()` starts overwriting.
 6. Migration: `compute_affect()` as a pure SQL function returning JSONB
    (no side-effects yet, so it can be tested against live data first).
+
+   As an interim: the MCP tool `preview_affect` (done) is a TypeScript
+   reference implementation of the formulas above against live data. No
+   writes — it lets the weights be tuned and the observable streams be
+   sanity-checked before the SQL migration lands. The future SQL function
+   must produce the same values for the same snapshot.
 7. Migration: triggers on `experiences` and `memory_events` that call
    `compute_affect()` and patch `agent_affect`.
 8. MCP-server refactor: stop calling `affect_apply` from `remember` /

--- a/mcp-server/src/agents/conscience-agent.ts
+++ b/mcp-server/src/agents/conscience-agent.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { PostgrestClient } from "@supabase/postgrest-js";
 import type { Agent, AgentEventBus, BusEvent } from "./event-bus.js";
 
@@ -125,13 +126,20 @@ export class ConscienceAgent implements Agent {
       return;
     }
 
-    // 4) log warning event + chain relation
+    // 4) log warning event + chain relation.
+    //    Two events share one trace_id so a future "contradiction_resolved"
+    //    event can correlate back. `conscience_warning` is the human-readable
+    //    surface; `contradiction_detected` is the observable counted by the
+    //    frustration term of compute_affect() — see docs/affect-observables.md.
     const reason = (verdict.reason ?? "").slice(0, 500);
-    await bus.emit(mem.id, "conscience_warning", this.name, {
+    const traceId = randomUUID();
+    const payload = {
       contradicts_id: verdict.contradicts_id,
       confidence:     verdict.confidence,
       reason,
-    });
+    };
+    await bus.emit(mem.id, "conscience_warning",    this.name, payload, traceId);
+    await bus.emit(mem.id, "contradiction_detected", this.name, payload, traceId);
     const { error: chainErr } = await this.db.rpc("chain_memories", {
       p_a_id:   mem.id,
       p_b_id:   verdict.contradicts_id,

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -90,6 +90,7 @@ import {
   getAffectSchema, getAffect,
   updateAffectSchema, updateAffect,
   resetAffectSchema, resetAffect,
+  previewAffectSchema, previewAffect,
 } from "./tools/affect.js";
 import { BeliefService } from "./services/belief.js";
 import { inferActionSchema, inferAction } from "./tools/belief.js";
@@ -585,6 +586,13 @@ server.tool(
   "Reset the persistent affective state to defaults (all 0.5 except frustration=0). Use sparingly — this wipes regulator history.",
   resetAffectSchema.shape,
   withErrorHandling((input) => resetAffect(affectService, resetAffectSchema.parse(input)))
+);
+
+server.tool(
+  "preview_affect",
+  "Read-only preview of compute_affect(): runs the observables→affect formulas (docs/affect-observables.md) against live data and returns the 6 dimensions + their inputs, WITHOUT writing agent_affect. Reference implementation for the future SQL migration; lets humans tune weights before the trigger-driven version lands.",
+  previewAffectSchema.shape,
+  withErrorHandling((input) => previewAffect(affectService, previewAffectSchema.parse(input)))
 );
 
 // --- causal annotation layer -----------------------------------------------

--- a/mcp-server/src/services/affect.ts
+++ b/mcp-server/src/services/affect.ts
@@ -41,6 +41,39 @@ export interface AffectState {
   last_event: string | null;
 }
 
+/** Preview of what a trigger-driven `compute_affect()` would write right now. */
+export interface AffectPreview {
+  computed: {
+    valence:      number;        // [-1, 1]
+    arousal:      number;        // [0, 1]
+    curiosity:    number;        // [0, 1]
+    satisfaction: number;        // [0, 1]
+    frustration:  number;        // [0, 1]
+    confidence:   number | null; // [0, 1], null if no skill activity in 48h
+  };
+  inputs: {
+    experiences_24h_total:      number;
+    experiences_72h_total:      number;
+    experiences_48h_unreflected:number;
+    successes_24h:              number;
+    failures_24h:               number;
+    events_last_15min:          number;
+    tool_diversity_60min:       number;
+    novel_stimuli_6h:           number;
+    recalled_24h:               number;
+    recalled_24h_hits_0:        number;
+    recalled_24h_low_conf:      number;
+    agent_error_24h:            number;
+    agent_completed_24h:        number;
+    mark_useful_6h:             number;
+    mark_useful_6_to_12h:       number;
+    contradiction_detected_48h: number;
+    skill_rows_48h:             number;
+  };
+  spec:  string;
+  notes: string[];
+}
+
 /** How affect biases a recall call — the practical output of "having feelings". */
 export interface RecallBias {
   /** Additive delta on `limit`; positive → widen search. */
@@ -54,6 +87,12 @@ export interface RecallBias {
   /** Short debug string showing which dimensions pushed the bias. */
   reason: string;
 }
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+function clamp01(v: number): number { return clamp(v, 0, 1); }
+function round2(v: number): number { return Math.round(v * 100) / 100; }
 
 function fmtErr(err: unknown): string {
   if (!err) return "unknown error";
@@ -105,6 +144,202 @@ export class AffectService {
     const { data, error } = await this.db.rpc("affect_reset");
     if (error) throw new Error(`affect_reset failed: ${fmtErr(error)}`);
     return data as AffectState;
+  }
+
+  /**
+   * Read-only preview of what a trigger-driven `compute_affect()` would
+   * write if the formulas in docs/affect-observables.md ran right now.
+   *
+   * Intentionally duplicates the spec in TypeScript so humans can see the
+   * values against live data before the SQL migration lands. No writes, no
+   * side effects — `agent_affect` is untouched. When the SQL function exists
+   * this method becomes the reference implementation to diff against.
+   */
+  async previewCompute(): Promise<AffectPreview> {
+    const now = Date.now();
+    const isoAgo = (hours: number) => new Date(now - hours * 3600 * 1000).toISOString();
+    const iso15m = new Date(now - 15 * 60 * 1000).toISOString();
+    const iso60m = new Date(now - 60 * 60 * 1000).toISOString();
+
+    const [expRes, evRes, skillRes, stimRes] = await Promise.all([
+      // experiences last 72h — valence/satisfaction/curiosity/arousal(tool_diversity)
+      this.db
+        .from("experiences")
+        .select("created_at,outcome,user_sentiment,tools_used,reflected")
+        .gte("created_at", isoAgo(72))
+        .limit(2000),
+      // memory_events last 48h, only the types we aggregate on
+      this.db
+        .from("memory_events")
+        .select("event_type,context,created_at")
+        .in("event_type", [
+          "recalled",
+          "agent_error",
+          "agent_completed",
+          "mark_useful",
+          "contradiction_detected",
+        ])
+        .gte("created_at", isoAgo(48))
+        .limit(10000),
+      // skill_outcomes last 48h — confidence
+      this.db
+        .from("skill_outcomes")
+        .select("outcome,n,last_at")
+        .gte("last_at", isoAgo(48))
+        .limit(500),
+      // stimuli last 6h with status='new' — arousal(novel_stimuli)
+      this.db
+        .from("stimuli")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "new")
+        .gte("collected_at", isoAgo(6)),
+    ]);
+
+    if (expRes.error)  throw new Error(`previewCompute.experiences failed: ${fmtErr(expRes.error)}`);
+    if (evRes.error)   throw new Error(`previewCompute.memory_events failed: ${fmtErr(evRes.error)}`);
+    if (skillRes.error) throw new Error(`previewCompute.skill_outcomes failed: ${fmtErr(skillRes.error)}`);
+    if (stimRes.error) throw new Error(`previewCompute.stimuli failed: ${fmtErr(stimRes.error)}`);
+
+    type ExpRow = { created_at: string; outcome: string; user_sentiment: string | null; tools_used: string[] | null; reflected: boolean };
+    type EvRow  = { event_type: string; context: Record<string, unknown> | null; created_at: string };
+    type SkRow  = { outcome: string; n: number; last_at: string };
+
+    const experiences = (expRes.data ?? []) as ExpRow[];
+    const events      = (evRes.data  ?? []) as EvRow[];
+    const skills      = (skillRes.data ?? []) as SkRow[];
+    const novelStimuliCount = stimRes.count ?? 0;
+
+    const hoursSince = (iso: string) => (now - new Date(iso).getTime()) / (3600 * 1000);
+
+    // --- valence (72h, recency-weighted outcome balance) ---------------------
+    const OUTCOME_SCORE: Record<string, number> = {
+      success: 1.0,
+      partial: 0.2,
+      failure: -1.0,
+      unknown: 0.0,
+    };
+    let valNum = 0, valDen = 0;
+    for (const e of experiences) {
+      const w = Math.exp(-hoursSince(e.created_at) / 24);
+      const s = OUTCOME_SCORE[e.outcome] ?? 0;
+      valNum += w * s;
+      valDen += w;
+    }
+    const valence = valDen > 0 ? clamp(valNum / valDen, -1, 1) : 0;
+
+    // --- arousal (15min event rate + 60min tool diversity + 6h novel stimuli)
+    const events15m = events.filter(e => hoursSince(e.created_at) <= 0.25).length;
+    const toolSet = new Set<string>();
+    for (const e of experiences) {
+      if (hoursSince(e.created_at) > 1) continue;
+      for (const t of e.tools_used ?? []) if (t) toolSet.add(t);
+    }
+    const eventRate     = events15m / 15;
+    const toolDiversity = toolSet.size / 10;
+    const novelStimuli  = novelStimuliCount / 20;
+    const arousal = clamp01(
+      0.5 * Math.min(eventRate, 1) +
+      0.3 * Math.min(toolDiversity, 1) +
+      0.2 * Math.min(novelStimuli, 1),
+    );
+
+    // --- curiosity (24h empty/low-conf recalls + 48h unreflected ratio) ------
+    const recalled24h = events.filter(e => e.event_type === "recalled" && hoursSince(e.created_at) <= 24);
+    const empty24h    = recalled24h.filter(e => Number((e.context ?? {}).hits ?? -1) === 0).length;
+    const lowConf24h  = recalled24h.filter(e => {
+      const s = Number((e.context ?? {}).score);
+      return Number.isFinite(s) && s < 0.4;
+    }).length;
+    const exp48h = experiences.filter(e => hoursSince(e.created_at) <= 48);
+    const unreflected48h = exp48h.filter(e => !e.reflected).length;
+    const clusterGaps = exp48h.length > 0 ? unreflected48h / exp48h.length : 0;
+    const curiosity = clamp01(
+      0.3 +
+      0.02 * empty24h +
+      0.01 * lowConf24h +
+      0.3 * clusterGaps,
+    );
+
+    // --- satisfaction (24h success rate + pleased ratio + useful_count delta)
+    const exp24h = experiences.filter(e => hoursSince(e.created_at) <= 24);
+    const successRate = exp24h.length > 0
+      ? exp24h.filter(e => e.outcome === "success").length / exp24h.length
+      : 0;
+    const withSentiment24h = exp24h.filter(e => e.user_sentiment != null);
+    const pleasedRatio = withSentiment24h.length > 0
+      ? withSentiment24h.filter(e => e.user_sentiment === "pleased" || e.user_sentiment === "delighted").length
+        / withSentiment24h.length
+      : 0;
+    const useful6h    = events.filter(e => e.event_type === "mark_useful" && hoursSince(e.created_at) <= 6).length;
+    const useful6to12 = events.filter(e => {
+      if (e.event_type !== "mark_useful") return false;
+      const h = hoursSince(e.created_at);
+      return h > 6 && h <= 12;
+    }).length;
+    const usefulDelta = useful6h - useful6to12;
+    const satisfaction = clamp01(
+      0.6 * successRate +
+      0.3 * pleasedRatio +
+      0.05 * Math.tanh(usefulDelta / 5) + 0.05,
+    );
+
+    // --- frustration (24h retry + zero-hit recalls + 48h open contradictions)
+    const err24h   = events.filter(e => e.event_type === "agent_error"     && hoursSince(e.created_at) <= 24).length;
+    const done24h  = events.filter(e => e.event_type === "agent_completed" && hoursSince(e.created_at) <= 24).length;
+    const retryRate = err24h / Math.max(1, done24h);
+    const zeroHitRatio = recalled24h.length > 0 ? empty24h / recalled24h.length : 0;
+    // TODO: discount by resolution events with same trace_id once contradiction_resolved is emitted.
+    const openConflicts = events.filter(e => e.event_type === "contradiction_detected" && hoursSince(e.created_at) <= 48).length;
+    const frustration = clamp01(
+      0.4 * retryRate +
+      0.4 * zeroHitRatio +
+      0.05 * Math.min(openConflicts, 4),
+    );
+
+    // --- confidence (48h skill success rate, recency-weighted) ---------------
+    let confNum = 0, confDen = 0;
+    for (const s of skills) {
+      const w = Math.exp(-hoursSince(s.last_at) / 48);
+      if (s.outcome === "success") confNum += s.n * w;
+      confDen += s.n * w;
+    }
+    const confidence = confDen > 0 ? clamp01(confNum / confDen) : null;
+
+    return {
+      computed: {
+        valence:      round2(valence),
+        arousal:      round2(arousal),
+        curiosity:    round2(curiosity),
+        satisfaction: round2(satisfaction),
+        frustration:  round2(frustration),
+        confidence:   confidence == null ? null : round2(confidence),
+      },
+      inputs: {
+        experiences_24h_total:    exp24h.length,
+        experiences_72h_total:    experiences.length,
+        experiences_48h_unreflected: unreflected48h,
+        successes_24h:            exp24h.filter(e => e.outcome === "success").length,
+        failures_24h:             exp24h.filter(e => e.outcome === "failure").length,
+        events_last_15min:        events15m,
+        tool_diversity_60min:     toolSet.size,
+        novel_stimuli_6h:         novelStimuliCount,
+        recalled_24h:             recalled24h.length,
+        recalled_24h_hits_0:      empty24h,
+        recalled_24h_low_conf:    lowConf24h,
+        agent_error_24h:          err24h,
+        agent_completed_24h:      done24h,
+        mark_useful_6h:           useful6h,
+        mark_useful_6_to_12h:     useful6to12,
+        contradiction_detected_48h: openConflicts,
+        skill_rows_48h:           skills.length,
+      },
+      spec: "docs/affect-observables.md",
+      notes: [
+        "Preview only — does not write agent_affect. Runs the reference formulas against live observables.",
+        "Weights and time windows are first-pass guesses per the spec; revisit after 1–2 weeks of real data.",
+        "open_conflicts counts contradiction_detected events without discounting resolutions (contradiction_resolved not yet emitted).",
+      ],
+    };
   }
 
   /**

--- a/mcp-server/src/tools/affect.ts
+++ b/mcp-server/src/tools/affect.ts
@@ -75,6 +75,48 @@ export async function updateAffect(
 }
 
 // ===========================================================================
+// preview_affect — read-only compute_affect() reference implementation
+// ===========================================================================
+export const previewAffectSchema = z.object({});
+
+export async function previewAffect(
+  service: AffectService,
+  _input: z.infer<typeof previewAffectSchema>,
+) {
+  const preview = await service.previewCompute();
+  const c = preview.computed;
+  const bar = (v: number) => "█".repeat(Math.round(v * 10)).padEnd(10, "·");
+  const signBar = (v: number) => {
+    const n = Math.round(v * 5);
+    return n >= 0 ? "·····".padStart(5, "·") + "█".repeat(n).padEnd(5, "·")
+                  : "·".repeat(5) + "█".repeat(-n).padStart(5, "·").padEnd(5, "·");
+  };
+  const lines = [
+    `compute_affect() preview — per ${preview.spec}`,
+    `  valence      [${signBar(c.valence)}]  ${c.valence.toFixed(2).padStart(5)}   (72h recency-weighted outcome)`,
+    `  arousal      [${bar(c.arousal)}]  ${c.arousal.toFixed(2)}   (event rate + tool diversity + novel stimuli)`,
+    `  curiosity    [${bar(c.curiosity)}]  ${c.curiosity.toFixed(2)}   (empty/low-conf recalls + unreflected ratio)`,
+    `  satisfaction [${bar(c.satisfaction)}]  ${c.satisfaction.toFixed(2)}   (success rate + pleased ratio + useful delta)`,
+    `  frustration  [${bar(c.frustration)}]  ${c.frustration.toFixed(2)}   (retry rate + zero-hit ratio + open conflicts)`,
+    c.confidence == null
+      ? `  confidence   [·····.....]   n/a    (no skill_outcomes activity in 48h)`
+      : `  confidence   [${bar(c.confidence)}]  ${c.confidence.toFixed(2)}   (weighted skill success rate)`,
+    "",
+    "inputs:",
+    `  experiences:  24h=${preview.inputs.experiences_24h_total} (✓${preview.inputs.successes_24h} ✗${preview.inputs.failures_24h})  72h=${preview.inputs.experiences_72h_total}  48h unreflected=${preview.inputs.experiences_48h_unreflected}`,
+    `  events:       15min=${preview.inputs.events_last_15min}  recalled24h=${preview.inputs.recalled_24h} (hits=0: ${preview.inputs.recalled_24h_hits_0}, low-conf: ${preview.inputs.recalled_24h_low_conf})`,
+    `                agent_error24h=${preview.inputs.agent_error_24h}  agent_completed24h=${preview.inputs.agent_completed_24h}  contradiction48h=${preview.inputs.contradiction_detected_48h}`,
+    `                mark_useful 0-6h=${preview.inputs.mark_useful_6h}  6-12h=${preview.inputs.mark_useful_6_to_12h}`,
+    `  tool_div 60m: ${preview.inputs.tool_diversity_60min}   novel stimuli 6h: ${preview.inputs.novel_stimuli_6h}   skill rows 48h: ${preview.inputs.skill_rows_48h}`,
+    "",
+    ...preview.notes.map(n => `• ${n}`),
+  ];
+  return {
+    content: [{ type: "text" as const, text: lines.join("\n") }],
+  };
+}
+
+// ===========================================================================
 // reset_affect (Notbremse — für Dev/Tests)
 // ===========================================================================
 export const resetAffectSchema = z.object({});


### PR DESCRIPTION
Part of #11 — multi-tick decomposition.

## What

Adds a read-only MCP tool `preview_affect` that runs the compute_affect()
formulas specified in `docs/affect-observables.md` against live
observables and returns the six dimensions (valence, arousal, curiosity,
satisfaction, frustration, confidence) plus their raw inputs.

**Does not write `agent_affect`.** The existing `affect_apply()` path is
untouched.

## Why this tick

Previous ticks wired up the observable streams the formulas depend on:
- PR #15 — spec doc
- PR #16 — `recalled` events
- PR #17 — `mark_useful` + `agent_completed` / `agent_error` events
- commit f7a68b8 — `contradiction_detected` events

Roadmap step 6 (in `docs/affect-observables.md`) is to ship
`compute_affect()` as a pure SQL function, "tested against live data
first". The autonomy guard blocks SQL migrations from running
autonomously, so this PR ships the **TypeScript reference** of that
function: same formulas, same windows, same weights, read-only. It makes
the spec executable today and gives humans a tuning surface before
committing to the trigger-driven SQL migration.

When the SQL function lands, it must produce the same values as this
preview for the same snapshot — that's the diff target.

## What changed

- `mcp-server/src/services/affect.ts` — new `AffectService.previewCompute()`
  method implementing the 6 formulas against `experiences`,
  `memory_events`, `skill_outcomes`, `stimuli`. Clamps to the spec's
  ranges. Exposes raw inputs alongside computed values.
- `mcp-server/src/tools/affect.ts` — new `preview_affect` tool handler
  that formats the result (bars + inputs + spec notes).
- `mcp-server/src/index.ts` — registers the tool alongside
  `get_affect` / `update_affect` / `reset_affect`.
- `docs/affect-observables.md` — notes the preview tool as the interim
  for step 6.

## Non-goals (explicitly deferred)

- No SQL migration (blocked by the hard process rule; follow-up needed).
- No demotion of existing `affect_apply()` calls in remember/recall/
  absorb/digest — that's step 8, after the SQL trigger exists.
- No `contradiction_resolved` emission — open_conflicts currently counts
  all detected contradictions in the 48h window; noted inline as a TODO.

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)** — the preview runs
entirely against the local Supabase, no new network dependencies, agents
keep owning their own observable streams.

Touches **Pillar 6 (Cyber security)** — the preview is read-only. No
mutation of `agent_affect`, no new trust-boundary crossings, no bypass of
existing write paths.

**No pillar is weakened by this change.**

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (47/47)
- [ ] Manual: call `preview_affect` via MCP client after a session of
      recall/remember activity and verify arousal/curiosity respond
- [ ] Human review: eyeball the formula constants in
      `services/affect.ts:previewCompute` against
      `docs/affect-observables.md` formulas section

🤖 Generated with [Claude Code](https://claude.com/claude-code)