### PR TITLE
feat(mcp): emit contradiction_resolved from supersede_memory (issue #11)

### DIFF
--- a/docs/affect-observables.md
+++ b/docs/affect-observables.md
@@ -34,8 +34,12 @@ exists. No new observable tables.
 
 `memory_events.event_type` is the key signal: `recalled`, `used_in_response`,
 `agent_error`, `agent_completed`, `mark_useful`, `contradiction_detected`,
-`positive_feedback`, `negative_feedback`. `context` carries per-event
-payload (e.g. recall hit count, similarity score).
+`contradiction_resolved`, `positive_feedback`, `negative_feedback`. `context`
+carries per-event payload (e.g. recall hit count, similarity score).
+
+A `contradiction_resolved` event shares the `trace_id` of the originating
+`contradiction_detected`, so the frustration term can close the loop with a
+cheap trace-id join instead of walking the memory-relations graph.
 
 ## Formulas
 
@@ -212,6 +216,11 @@ The issue is explicitly too big for one tick. Suggested order:
    alongside `conscience_warning` (shared `trace_id`) so frustration's
    `open_conflicts` term has a data source and a future
    `contradiction_resolved` event can correlate back. Additive. (done)
+4b. **`contradiction_resolved` emission** — `supersede_memory` checks for a
+   prior `contradiction_detected` event between (old, new) and emits the
+   matching resolution with the same `trace_id`. Lets the frustration term
+   count *open* conflicts only, without walking the relations graph.
+   Additive. (done)
 5. Snapshot-migration: freeze the current `agent_affect` row into a
    historical anchor table before `compute_affect()` starts overwriting.
 6. Migration: `compute_affect()` as a pure SQL function returning JSONB

--- a/mcp-server/src/services/relations.ts
+++ b/mcp-server/src/services/relations.ts
@@ -106,6 +106,58 @@ export class RelationsService {
       p_reason: reason,
     });
     if (error) throw new Error(`supersede_memory failed: ${fmtErr(error)}`);
-    return (data as Record<string, unknown>) ?? { ok: false };
+    const result = (data as Record<string, unknown>) ?? { ok: false };
+    if (result.ok !== false) {
+      await this.maybeEmitContradictionResolved(oldId, newId);
+    }
+    return result;
+  }
+
+  /**
+   * If conscience-agent previously flagged (oldId, newId) as a contradiction,
+   * emit a matching `contradiction_resolved` event with the same trace_id.
+   * This closes the open-conflict loop read by compute_affect()'s frustration
+   * term — see docs/affect-observables.md §frustration.
+   *
+   * Non-fatal on error: supersede itself has already succeeded; the event is
+   * telemetry for the affect pipeline, not a correctness dependency.
+   */
+  private async maybeEmitContradictionResolved(
+    oldId: string,
+    newId: string,
+  ): Promise<void> {
+    const { data, error } = await this.db
+      .from("memory_events")
+      .select("trace_id, memory_id, context")
+      .eq("event_type", "contradiction_detected")
+      .in("memory_id", [oldId, newId])
+      .order("created_at", { ascending: false })
+      .limit(20);
+    if (error) {
+      console.error(`[supersede] contradiction lookup failed: ${fmtErr(error)}`);
+      return;
+    }
+    const rows = (data ?? []) as Array<{
+      trace_id: string | null;
+      memory_id: string;
+      context: { contradicts_id?: string } | null;
+    }>;
+    const match = rows.find((e) => {
+      const other = e.context?.contradicts_id;
+      return (e.memory_id === oldId && other === newId) ||
+             (e.memory_id === newId && other === oldId);
+    });
+    if (!match) return;
+    const { error: logErr } = await this.db.rpc("log_memory_event", {
+      p_memory_id:  oldId,
+      p_event_type: "contradiction_resolved",
+      p_source:     "mcp:supersede_memory",
+      p_context:    { resolution: "superseded", superseder_id: newId },
+      p_trace_id:   match.trace_id,
+      p_created_by: null,
+    });
+    if (logErr) {
+      console.error(`[supersede] emit contradiction_resolved failed: ${fmtErr(logErr)}`);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes the open-conflict loop for the upcoming `compute_affect()` frustration term (issue #11).

When `supersede_memory` runs and the conscience-agent has previously flagged the (old, new) pair as a contradiction, the service now looks up the matching `contradiction_detected` event and emits a `contradiction_resolved` event with the same `trace_id`. The future SQL `compute_affect()` trigger can then count only *unresolved* contradictions via a cheap trace-id join, instead of walking the memory-relations graph.

This is step **4b** of the decomposition in `docs/affect-observables.md` — additive, observable-only, no SQL migration, no behavior change for existing callers.

### Changes

- `mcp-server/src/services/relations.ts` — after a successful `supersede_memory` RPC, query recent `contradiction_detected` events for either memory id, match on payload `contradicts_id`, and emit `contradiction_resolved` with the original `trace_id`. Non-fatal on error (telemetry, not correctness).
- `docs/affect-observables.md` — add `contradiction_resolved` to the event-type list with a note about `trace_id` correlation; insert a "step 4b (done)" entry in the decomposition.

### Why this is the right shape for this tick

- Explicitly called out as a future need in the spec (`docs/affect-observables.md` §frustration line 141) and in the conscience-agent comment (`mcp-server/src/agents/conscience-agent.ts:130`).
- Purely additive: no existing event payloads change, no existing tool behavior changes.
- Keeps the "observables-first, triggers-later" ordering of the decomposition intact — the SQL migration can be written independently once the event surface is complete.

## Constitution affirmation

Pillar(s) touched: **#1 (Decentralized, networked AI)** — the affect signal stays local to the agent and sourced from its own observable history; this change does nothing to weaken that property, and no cross-agent or central-authority path is introduced.

No other pillar is weakened. The change does not touch reproduction consent (#2), swarm routing (#3), microtransactions (#4), expert-weighting (#5), or the cryptographic trust boundary (#6).

## Test plan

- [ ] `cd mcp-server && npm run build` — clean (verified locally)
- [ ] Manual: call `supersede_memory` on a pair that conscience-agent previously flagged; verify one `contradiction_resolved` row appears in `memory_events` with the same `trace_id` as the originating `contradiction_detected`
- [ ] Manual: call `supersede_memory` on an un-flagged pair; verify **no** `contradiction_resolved` event is emitted (avoids noise-polluting the frustration signal)
- [ ] Post-merge: once `compute_affect()` trigger lands, verify `open_conflicts` drops to zero on the resolved pair

Refs: #11