### PR TITLE
test(affect): guard recalled memory_event payload from recall tool (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/handlers.test.ts
+++ b/mcp-server/src/__tests__/handlers.test.ts
@@ -65,6 +65,7 @@ class FakeService implements Partial<MemoryService> {
   updated: UpdateMemoryInput[] = [];
   deleted: string[] = [];
   searched: string[] = [];
+  recalledEvents: Array<{ hits: number; topScore: number; queryLength: number; source: string }> = [];
 
   constructor(
     private opts: {
@@ -87,7 +88,9 @@ class FakeService implements Partial<MemoryService> {
   async touch(_ids: string[]): Promise<void> {}
   async coactivate(_ids: string[]): Promise<void> {}
   async spread(_ids: string[]): Promise<never[]> { return []; }
-  async emitRecalled(_h: number, _s: number, _q: number, _src: string): Promise<void> {}
+  async emitRecalled(hits: number, topScore: number, queryLength: number, source: string): Promise<void> {
+    this.recalledEvents.push({ hits, topScore, queryLength, source });
+  }
 
   async get(id: string): Promise<Memory | null> {
     return this.opts.getResult === undefined ? makeMemory({ id }) : this.opts.getResult;
@@ -179,6 +182,79 @@ test("recall formats results with rank, score and id", async () => {
   assert.match(res.content[0].text, /1\. \[people\//);
   assert.match(res.content[0].text, /0\.873/);
   assert.match(res.content[0].text, /alice/);
+});
+
+test("recall emits recalled memory_event with hits=0 on empty result", async () => {
+  const svc = new FakeService({ searchResults: [] });
+  await recall(svc as unknown as MemoryService, fakeAffect, {
+    query: "no matches for this",
+    limit: 10,
+    vector_weight: 0.7,
+    spread: false, with_experiences: false,
+    ignore_affect: true,
+    cite: false,
+  });
+  assert.equal(svc.recalledEvents.length, 1);
+  const ev = svc.recalledEvents[0];
+  assert.equal(ev.hits, 0);
+  assert.equal(ev.topScore, 0);
+  assert.equal(ev.queryLength, "no matches for this".length);
+  assert.equal(ev.source, "mcp:recall");
+});
+
+test("recall emits recalled memory_event with hit count and top score", async () => {
+  const svc = new FakeService({
+    searchResults: [
+      {
+        id: UUID,
+        content: "hit one",
+        category: "topics",
+        tags: [],
+        metadata: {},
+        stage: "episodic",
+        strength: 1.0,
+        importance: 0.5,
+        access_count: 0,
+        pinned: false,
+        relevance: 0.9,
+        strength_now: 1.0,
+        salience: 1.0,
+        effective_score: 0.812,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "22222222-2222-3333-4444-555555555555",
+        content: "hit two",
+        category: "topics",
+        tags: [],
+        metadata: {},
+        stage: "episodic",
+        strength: 1.0,
+        importance: 0.5,
+        access_count: 0,
+        pinned: false,
+        relevance: 0.7,
+        strength_now: 1.0,
+        salience: 1.0,
+        effective_score: 0.533,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+  });
+  await recall(svc as unknown as MemoryService, fakeAffect, {
+    query: "two hits",
+    limit: 10,
+    vector_weight: 0.7,
+    spread: false, with_experiences: false,
+    ignore_affect: true,
+    cite: false,
+  });
+  assert.equal(svc.recalledEvents.length, 1);
+  const ev = svc.recalledEvents[0];
+  assert.equal(ev.hits, 2);
+  assert.equal(ev.topScore, 0.812);
+  assert.equal(ev.queryLength, "two hits".length);
+  assert.equal(ev.source, "mcp:recall");
 });
 
 test("forget reports not-found when missing", async () => {


### PR DESCRIPTION
## Summary

- Adds two unit tests in `mcp-server/src/__tests__/handlers.test.ts` that pin the payload shape of the `recalled` memory_event emitted by the recall tool: `{hits, topScore, queryLength, source}`.
- Extends `FakeService.emitRecalled` from a no-op stub into a recorder so future regressions in the observables pipeline show up in the test run.

This is the observables signal the upcoming `compute_affect()` trigger will read for the `empty_recalls` / `low_conf_recalls` terms of curiosity and the `zero_hit_ratio` term of frustration (see docs/affect-observables.md).

## Scope

- Additive only. No production code touched.
- `npm test` in `mcp-server/` stays green (49 tests pass, incl. the 2 new ones).

## Follow-up filed during this tick

- #21 — `contradiction_resolved` is missing from the `memory_events` CHECK constraint, so PR #20's emission is silently rejected. Fixing that needs a migration; the agent contract forbids writing migrations autonomously, so it's been filed for human review instead.

## Constitution affirmation

Touches pillar **3 (Swarm intelligence)** — the observables this test guards feed `compute_affect()`, which keeps a local agent's affective state grounded in its own lived activity rather than an LLM's self-report. Pillars **1**, **2**, **4**, **5**, **6** are unaffected. No pillar is weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)