### PR TITLE
test(affect): guard outcome → agent_completed/agent_error mapping (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/experiences.test.ts
+++ b/mcp-server/src/__tests__/experiences.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { outcomeToEventType } from "../services/experiences.js";
+
+// These tests pin the mapping used by ExperienceService.record() to emit
+// `agent_completed` / `agent_error` memory_events after each episode. The
+// mapping is a compute_affect() input — see docs/affect-observables.md
+// §frustration (retry_rate = agent_error / agent_completed).
+// Breaking the mapping silently would skew the frustration dimension; this
+// test is the guard.
+
+test("outcomeToEventType: 'failure' → agent_error", () => {
+  assert.equal(outcomeToEventType("failure"), "agent_error");
+});
+
+test("outcomeToEventType: 'success' → agent_completed", () => {
+  assert.equal(outcomeToEventType("success"), "agent_completed");
+});
+
+test("outcomeToEventType: 'partial' → agent_completed", () => {
+  assert.equal(outcomeToEventType("partial"), "agent_completed");
+});
+
+test("outcomeToEventType: 'unknown' → null (no event emitted)", () => {
+  assert.equal(outcomeToEventType("unknown"), null);
+});
+
+test("outcomeToEventType: null/undefined → null", () => {
+  assert.equal(outcomeToEventType(null), null);
+  assert.equal(outcomeToEventType(undefined), null);
+});
+
+test("outcomeToEventType: unrecognized string → null", () => {
+  assert.equal(outcomeToEventType("in_progress"), null);
+  assert.equal(outcomeToEventType(""), null);
+});

--- a/mcp-server/src/services/experiences.ts
+++ b/mcp-server/src/services/experiences.ts
@@ -163,6 +163,26 @@ function fmtErr(err: unknown): string {
   return e.message || e.details || e.hint || e.code || JSON.stringify(err);
 }
 
+/**
+ * Map an experience outcome to the `memory_events.event_type` emitted after a
+ * successful `record_experience`. Feeds `frustration.retry_rate` in
+ * `compute_affect()` — see docs/affect-observables.md §frustration.
+ *
+ * - 'failure'            → 'agent_error'
+ * - 'success' | 'partial' → 'agent_completed'
+ * - 'unknown' | anything → null (no event emitted)
+ *
+ * Exported as a pure function so the mapping is unit-testable without a DB.
+ */
+export type OutcomeEventType = "agent_error" | "agent_completed";
+export function outcomeToEventType(
+  outcome: string | null | undefined,
+): OutcomeEventType | null {
+  if (outcome === "failure") return "agent_error";
+  if (outcome === "success" || outcome === "partial") return "agent_completed";
+  return null;
+}
+
 export class ExperienceService {
   private db: PostgrestClient;
   private embeddings: EmbeddingProvider;
@@ -270,10 +290,7 @@ export class ExperienceService {
     // 'failure' → agent_error. Fed into frustration.retry_rate.
     // See docs/affect-observables.md. Non-fatal.
     const outcome = input.outcome ?? "unknown";
-    const outcomeEventType =
-      outcome === "failure"                     ? "agent_error"
-      : outcome === "success" || outcome === "partial" ? "agent_completed"
-      :                                            null;
+    const outcomeEventType = outcomeToEventType(outcome);
     if (outcomeEventType) {
       try {
         const { error: evErr } = await this.db.rpc("log_memory_event", {


### PR DESCRIPTION
Part of #11 — multi-tick decomposition.

## What

Extracts the experience-outcome → `memory_events.event_type` mapping in
`ExperienceService.record()` into a pure exported helper
`outcomeToEventType()` and pins it with six unit tests covering all
outcome values plus null/undefined/unrecognized fallbacks.

**No behavior change** — `record()` now calls the helper with the same
branches it had inline.

## Why this tick

`compute_affect()`'s frustration dimension is defined in
`docs/affect-observables.md` §frustration as:

```
retry_rate = count(memory_events WHERE event_type='agent_error'  …24h…)
           / count(memory_events WHERE event_type='agent_completed' …24h…)
```

So the mapping from experience outcome (`success`/`partial`/`failure`/
`unknown`) to those event types is load-bearing for the affect pipeline.
Silently breaking it (e.g. swapping `partial` into the error bucket)
would skew `frustration` without any compile-time failure.

The mapping lived inline inside `record()` next to a PostgrestClient
call, so it wasn't unit-testable. Extracting to a pure function makes it
stubbable in zero lines of infrastructure — same pattern as the
`recalled` emission test in PR #22 and the `mark_useful` emission test
in PR #23.

## What changed

- `mcp-server/src/services/experiences.ts` — new exported
  `outcomeToEventType(outcome)` pure function + `OutcomeEventType` type
  alias. `record()` now calls the helper with the same branch logic as
  before.
- `mcp-server/src/__tests__/experiences.test.ts` — new test file with
  six cases pinning each branch: `failure` → `agent_error`,
  `success`/`partial` → `agent_completed`, and
  `unknown`/`null`/`undefined`/`""`/unknown-string → `null` (no event).

## Non-goals (explicitly deferred)

- No extraction of the `log_memory_event` RPC call itself — that would
  require a fake `PostgrestClient` or dependency inversion of
  `ExperienceService`. The mapping guard is the high-leverage piece;
  the RPC-plumbing guard is a separate future tick if needed.
- No SQL migration, no refactor of existing `affect_apply()` calls, no
  CI/CD changes — out of scope for autonomous ticks per the process
  rules.

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)** — the helper is a
pure function, no new network dependency, observables stay local.

Touches **Pillar 6 (Cyber security)** — no bypass of any trust
boundary; no mutation of `agent_affect`; behavior is byte-identical to
the previous inline version.

**No pillar is weakened by this change.**

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (57/57, +6 new)
- [x] `record()` produces the same event-type per outcome as before
      (same branches, refactor-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)