### PR TITLE
test(affect): guard contradiction_detected → _resolved pair matching (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/relations.test.ts
+++ b/mcp-server/src/__tests__/relations.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  findResolutionMatch,
+  type ContradictionDetectedRow,
+} from "../services/relations.js";
+
+// ---------------------------------------------------------------------------
+// findResolutionMatch — bidirectional pair matching for
+// contradiction_detected → contradiction_resolved correlation.
+//
+// Why these tests matter: the frustration term of compute_affect()
+// (docs/affect-observables.md §frustration) counts *open* conflicts by
+// joining contradiction_detected events against their matching
+// contradiction_resolved event via shared trace_id. If the lookup picks
+// the wrong row (or misses the pair) supersede_memory would emit the
+// wrong trace_id and the frustration term would drift. These tests pin
+// the matching contract — both directions of the pair must find the row,
+// unrelated rows must be skipped, and an empty input must return null.
+// ---------------------------------------------------------------------------
+
+const OLD_ID = "11111111-1111-1111-1111-111111111111";
+const NEW_ID = "22222222-2222-2222-2222-222222222222";
+const OTHER_ID = "33333333-3333-3333-3333-333333333333";
+
+function row(
+  memory_id: string,
+  contradicts_id: string | undefined,
+  trace_id: string | null = "trace-abc",
+): ContradictionDetectedRow {
+  return { trace_id, memory_id, context: { contradicts_id } };
+}
+
+test("findResolutionMatch picks row where memory_id=newId and contradicts_id=oldId", () => {
+  // ConscienceAgent stamps event on the new memory pointing back at the old.
+  // supersede_memory(old, new) must find it.
+  const rows = [row(NEW_ID, OLD_ID, "trace-1")];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.ok(match);
+  assert.equal(match!.trace_id, "trace-1");
+  assert.equal(match!.memory_id, NEW_ID);
+});
+
+test("findResolutionMatch picks row where memory_id=oldId and contradicts_id=newId (reverse direction)", () => {
+  // The stamping direction is an implementation detail of conscience-agent;
+  // the matcher must stay symmetric so future re-wirings don't break the
+  // contradiction-resolved emission.
+  const rows = [row(OLD_ID, NEW_ID, "trace-2")];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.ok(match);
+  assert.equal(match!.trace_id, "trace-2");
+  assert.equal(match!.memory_id, OLD_ID);
+});
+
+test("findResolutionMatch returns null when rows are empty", () => {
+  const match = findResolutionMatch([], OLD_ID, NEW_ID);
+  assert.equal(match, null);
+});
+
+test("findResolutionMatch returns null when candidate points at an unrelated id", () => {
+  // A contradiction was detected between NEW_ID and OTHER_ID, not NEW_ID and OLD_ID.
+  // Must not falsely close the (OLD_ID, NEW_ID) loop.
+  const rows = [row(NEW_ID, OTHER_ID, "trace-wrong")];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.equal(match, null);
+});
+
+test("findResolutionMatch returns null when context.contradicts_id is missing", () => {
+  // Defensive: malformed/legacy payloads must not match arbitrary rows by
+  // memory_id alone.
+  const rows: ContradictionDetectedRow[] = [
+    { trace_id: "trace-x", memory_id: NEW_ID, context: null },
+    { trace_id: "trace-y", memory_id: NEW_ID, context: {} },
+  ];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.equal(match, null);
+});
+
+test("findResolutionMatch returns the first matching row (caller pre-orders by created_at DESC)", () => {
+  // The service query orders by created_at DESC and limits to 20. The
+  // matcher preserves that ordering so the most recent open-conflict event
+  // wins, which is what compute_affect() expects.
+  const rows = [
+    row(NEW_ID, OLD_ID, "trace-newest"),
+    row(NEW_ID, OLD_ID, "trace-older"),
+  ];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.ok(match);
+  assert.equal(match!.trace_id, "trace-newest");
+});
+
+test("findResolutionMatch ignores rows pointing at (OTHER_ID, NEW_ID) even in mixed batch", () => {
+  // Real batches will contain events for sibling conflicts. The matcher
+  // must pick the (OLD_ID, NEW_ID) row specifically.
+  const rows = [
+    row(NEW_ID, OTHER_ID, "trace-noise"),
+    row(NEW_ID, OLD_ID, "trace-right"),
+    row(OTHER_ID, OLD_ID, "trace-unrelated"),
+  ];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.ok(match);
+  assert.equal(match!.trace_id, "trace-right");
+});
+
+test("findResolutionMatch tolerates null trace_id on a matching row", () => {
+  // Early events may lack a trace_id. The matcher must still find them;
+  // supersede's RPC call then passes null through as p_trace_id. Downstream
+  // log_memory_event is responsible for allocating a new one if needed.
+  const rows = [row(NEW_ID, OLD_ID, null)];
+  const match = findResolutionMatch(rows, OLD_ID, NEW_ID);
+  assert.ok(match);
+  assert.equal(match!.trace_id, null);
+});

--- a/mcp-server/src/services/relations.ts
+++ b/mcp-server/src/services/relations.ts
@@ -137,16 +137,8 @@ export class RelationsService {
       console.error(`[supersede] contradiction lookup failed: ${fmtErr(error)}`);
       return;
     }
-    const rows = (data ?? []) as Array<{
-      trace_id: string | null;
-      memory_id: string;
-      context: { contradicts_id?: string } | null;
-    }>;
-    const match = rows.find((e) => {
-      const other = e.context?.contradicts_id;
-      return (e.memory_id === oldId && other === newId) ||
-             (e.memory_id === newId && other === oldId);
-    });
+    const rows = (data ?? []) as ContradictionDetectedRow[];
+    const match = findResolutionMatch(rows, oldId, newId);
     if (!match) return;
     const { error: logErr } = await this.db.rpc("log_memory_event", {
       p_memory_id:  oldId,
@@ -160,4 +152,32 @@ export class RelationsService {
       console.error(`[supersede] emit contradiction_resolved failed: ${fmtErr(logErr)}`);
     }
   }
+}
+
+export interface ContradictionDetectedRow {
+  trace_id: string | null;
+  memory_id: string;
+  context: { contradicts_id?: string } | null;
+}
+
+/**
+ * Bidirectional lookup for a `contradiction_detected` row that pairs
+ * (oldId, newId). ConscienceAgent stamps the event on one side only —
+ * `memory_id = newMemory.id` with `context.contradicts_id = oldMemory.id`
+ * — so the matcher must tolerate either direction of the pair.
+ *
+ * Exported so __tests__/relations.test.ts can pin the payload shape
+ * compute_affect()'s frustration term depends on without needing a live
+ * PostgrestClient. See docs/affect-observables.md §frustration.
+ */
+export function findResolutionMatch(
+  rows: ContradictionDetectedRow[],
+  oldId: string,
+  newId: string,
+): ContradictionDetectedRow | null {
+  return rows.find((e) => {
+    const other = e.context?.contradicts_id;
+    return (e.memory_id === oldId && other === newId) ||
+           (e.memory_id === newId && other === oldId);
+  }) ?? null;
 }


### PR DESCRIPTION
## Summary

Smallest safe next tick for issue #11 — extract the bidirectional
contradiction-pair lookup from `RelationsService.maybeEmitContradictionResolved`
into a pure helper `findResolutionMatch()` and pin it with regression
tests.

## Why

The frustration term of `compute_affect()` counts *open* conflicts by
joining `contradiction_detected` events against their matching
`contradiction_resolved` event via shared `trace_id`
(docs/affect-observables.md §frustration). ConscienceAgent stamps the
detected event on the *new* memory only (`memory_id = new`,
`context.contradicts_id = old`), so `supersede_memory(old, new)` must
tolerate either direction when looking up the pair.

Previously the matching logic sat inline inside a PostgrestClient-bound
private method — untestable in isolation. This extracts the pure part
and pins it.

## What's guarded

Eight regression tests in `mcp-server/src/__tests__/relations.test.ts`:

- picks row where `memory_id=newId` and `contradicts_id=oldId` (the
  direction ConscienceAgent actually emits)
- picks row where `memory_id=oldId` and `contradicts_id=newId`
  (reverse direction — symmetry invariant)
- returns `null` on empty rows
- returns `null` when the candidate points at an unrelated id
- returns `null` when `context.contradicts_id` is missing (null/empty)
- returns the first match, preserving the caller's `created_at DESC`
  ordering
- ignores sibling-conflict rows in a mixed batch
- tolerates `null` `trace_id` on a matching row

## Additive only

No runtime behavior change. The inline `rows.find(…)` now lives in
`findResolutionMatch`; the method still calls it at the same point with
the same semantics. `npm test` passes 69/69 (was 61/61).

## Position in the decomposition

Follows the same pattern as PRs #22, #23, #24, #25 — pin the
observables that `compute_affect()` depends on with cheap unit tests
before the SQL migrations arrive. This covers step 4b of
`docs/affect-observables.md §Decomposition across autonomy ticks` from
the test side. Steps 5–7 (snapshot migration, `compute_affect()`,
triggers) remain blocked on SQL-migration authorization and are left
for human-driven work.

## Constitution affirmation

Touches pillar **3 (Swarm intelligence)** — the affect pipeline is the
shared signal that lets specialized agents coordinate without a central
authority; pinning its observables keeps that signal trustworthy.

No pillar weakened. No changes to Constitution, CI/CD, dependencies,
or SQL migrations. Tests only + one testability-refactor inside
`relations.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)