### PR TITLE
test(affect): pin recalled memory_event JSONB key contract (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/affect-event-payloads.test.ts
+++ b/mcp-server/src/__tests__/affect-event-payloads.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildRecalledContext } from "../services/supabase.js";
+
+// ---------------------------------------------------------------------------
+// recalled memory_event JSONB payload contract
+//
+// Why this guard exists: compute_affect() (docs/affect-observables.md
+// §curiosity, §frustration) reads `recalled` events via JSON pointer:
+//
+//   empty_recalls    = … WHERE (context->>'hits')::int  = 0
+//   low_conf_recalls = … WHERE (context->>'score')::float < 0.4
+//   zero_hit_ratio   = … WHERE (context->>'hits')::int  = 0
+//
+// The TypeScript signature of MemoryService.emitRecalled (hits, topScore,
+// queryLength) does NOT match the JSONB key names the SQL reads — `topScore`
+// is renamed to `score` on the way into the payload. A silent refactor that
+// renames the JSONB key (e.g. to `topScore`) would not break compilation,
+// would not break the existing handlers.test.ts FakeService accumulator
+// (which records the function args, not the JSONB shape), but would
+// silently zero out the curiosity / frustration dimensions.
+//
+// These tests pin the wire contract: the exact key set, the exact key
+// names, and the value-passthrough.
+// ---------------------------------------------------------------------------
+
+test("buildRecalledContext returns exactly the keys compute_affect() reads", () => {
+  const ctx = buildRecalledContext(2, 0.812, 10);
+  assert.deepEqual(Object.keys(ctx).sort(), ["hits", "query_length", "score"]);
+});
+
+test("buildRecalledContext maps topScore arg → 'score' key (not 'topScore')", () => {
+  // The function arg is named topScore but the JSONB key MUST be 'score'
+  // because the SQL formula is `(context->>'score')::float`.
+  const ctx = buildRecalledContext(0, 0.31, 5);
+  assert.equal(ctx.score, 0.31);
+  assert.equal((ctx as unknown as Record<string, unknown>).topScore, undefined);
+});
+
+test("buildRecalledContext maps queryLength arg → 'query_length' key (snake_case)", () => {
+  // The SQL convention is snake_case; the TS arg is camelCase. Pin the
+  // boundary so a future "consistency" rename doesn't break the trigger.
+  const ctx = buildRecalledContext(0, 0, 42);
+  assert.equal(ctx.query_length, 42);
+  assert.equal((ctx as unknown as Record<string, unknown>).queryLength, undefined);
+});
+
+test("buildRecalledContext passes hits through unchanged (used by empty_recalls)", () => {
+  // empty_recalls counts rows WHERE (context->>'hits')::int = 0, so a 0
+  // hit count must round-trip as the integer 0 — not null, not undefined.
+  const ctx = buildRecalledContext(0, 0, 0);
+  assert.equal(ctx.hits, 0);
+  assert.equal(typeof ctx.hits, "number");
+});
+
+test("buildRecalledContext preserves score=0 as a real number for low_conf_recalls", () => {
+  // The empty-result branch in MemoryService.search emits topScore=0; the
+  // JSON pointer cast `(context->>'score')::float` would coerce '0' → 0.
+  // Pin that the wire shape is still a number, not null.
+  const ctx = buildRecalledContext(0, 0, 4);
+  assert.equal(ctx.score, 0);
+  assert.equal(typeof ctx.score, "number");
+});
+
+test("buildRecalledContext is pure (no aliasing across calls)", () => {
+  // Future maintainers may be tempted to memoize. The downstream RPC call
+  // serializes the object to JSONB so identity doesn't matter, but
+  // mutation across calls would be a footgun if the helper grows.
+  const a = buildRecalledContext(1, 0.5, 3);
+  const b = buildRecalledContext(2, 0.6, 4);
+  assert.notStrictEqual(a, b);
+  assert.equal(a.hits, 1);
+  assert.equal(b.hits, 2);
+});

--- a/mcp-server/src/services/supabase.ts
+++ b/mcp-server/src/services/supabase.ts
@@ -37,6 +37,32 @@ function fmtErr(err: unknown): string {
   return e.message || e.details || e.hint || e.code || JSON.stringify(err);
 }
 
+/**
+ * JSONB payload for `recalled` memory_events.
+ *
+ * The compute_affect() SQL formulas (docs/affect-observables.md §curiosity
+ * and §frustration) read these keys directly via JSON pointer:
+ *   (context->>'hits')::int   — empty_recalls / zero_hit_ratio
+ *   (context->>'score')::float — low_conf_recalls
+ *
+ * Renaming or dropping a key here silently breaks the SQL trigger without
+ * any TypeScript signal. The unit test in `affect-event-payloads.test.ts`
+ * pins the key set + types so the contract stays in lockstep with the spec.
+ */
+export interface RecalledContext {
+  hits: number;
+  score: number;
+  query_length: number;
+}
+
+export function buildRecalledContext(
+  hits: number,
+  topScore: number,
+  queryLength: number,
+): RecalledContext {
+  return { hits, score: topScore, query_length: queryLength };
+}
+
 export class MemoryService {
   private db: PostgrestClient;
   private embeddings: EmbeddingProvider;
@@ -238,7 +264,7 @@ export class MemoryService {
       p_memory_id:  null,
       p_event_type: "recalled",
       p_source:     source,
-      p_context:    { hits, score: topScore, query_length: queryLength },
+      p_context:    buildRecalledContext(hits, topScore, queryLength),
       p_trace_id:   null,
       p_created_by: null,
     });


### PR DESCRIPTION
Part of #11 — multi-tick decomposition.

## What

Extracts a pure `buildRecalledContext(hits, topScore, queryLength)` helper
out of `MemoryService.emitRecalled` and adds a unit test that pins the
exact JSONB key set the future `compute_affect()` SQL trigger will read.

## Why this tick

`docs/affect-observables.md` specifies these SQL formulas for the
curiosity and frustration dimensions:

```sql
empty_recalls    = … WHERE (context->>'hits')::int  = 0
low_conf_recalls = … WHERE (context->>'score')::float < 0.4
zero_hit_ratio   = … WHERE (context->>'hits')::int  = 0
```

So the JSONB keys `hits` and `score` are load-bearing. Today the wire
shape lives inline inside `MemoryService.emitRecalled`:

```ts
p_context: { hits, score: topScore, query_length: queryLength }
```

The TypeScript arg `topScore` is renamed on the way into the payload
key `score`. `query_length` is snake_cased. Neither boundary is pinned
by an existing test:

- `handlers.test.ts`'s `FakeService.emitRecalled` records the function
  args (`hits, topScore, queryLength`), not the JSONB shape sent to
  PostgREST. A silent rename like `score` → `topScore` (made for
  "consistency" with the arg name) would typecheck, pass
  `handlers.test.ts`, and silently zero out the `curiosity` and
  `frustration` dimensions once the SQL trigger lands.

This guard pins the wire contract.

## What changed

- `mcp-server/src/services/supabase.ts` — new exported pure helper
  `buildRecalledContext()` returning the typed `RecalledContext` shape.
  `emitRecalled` now calls the helper instead of building the object
  inline. Behavior unchanged.
- `mcp-server/src/__tests__/affect-event-payloads.test.ts` — 6 new
  tests pinning: exact key set, `topScore` arg → `score` JSONB key,
  `queryLength` arg → `query_length` snake_case key, integer 0
  passthrough for `hits` (used by `(context->>'hits')::int = 0`),
  numeric 0 passthrough for `score`, and purity (no aliasing across
  calls).

No SQL written, no migration touched, no behavior change. 80/80 tests
green (was 74/74).

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)** — preserves the
local observable stream contract that powers each agent's own affect
loop, no new network dependency.

Touches **Pillar 6 (Cyber security)** — pure refactor + additive test,
no trust-boundary changes, no new write paths, no bypass.

**No pillar is weakened by this change.**

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (80/80)
- [ ] Human review: confirm the JSONB key set in
      `buildRecalledContext` still matches the JSON pointers in
      `docs/affect-observables.md` §curiosity / §frustration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)