### PR TITLE
test(affect): pin mark_useful JSONB contract from experience.markUseful (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/affect-event-payloads.test.ts
+++ b/mcp-server/src/__tests__/affect-event-payloads.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildRecalledContext } from "../services/supabase.js";
+
+// ---------------------------------------------------------------------------
+// recalled memory_event JSONB payload contract
+//
+// Why this guard exists: compute_affect() (docs/affect-observables.md
+// §curiosity, §frustration) reads `recalled` events via JSON pointer:
+//
+//   empty_recalls    = … WHERE (context->>'hits')::int  = 0
+//   low_conf_recalls = … WHERE (context->>'score')::float < 0.4
+//   zero_hit_ratio   = … WHERE (context->>'hits')::int  = 0
+//
+// The TypeScript signature of MemoryService.emitRecalled (hits, topScore,
+// queryLength) does NOT match the JSONB key names the SQL reads — `topScore`
+// is renamed to `score` on the way into the payload. A silent refactor that
+// renames the JSONB key (e.g. to `topScore`) would not break compilation,
+// would not break the existing handlers.test.ts FakeService accumulator
+// (which records the function args, not the JSONB shape), but would
+// silently zero out the curiosity / frustration dimensions.
+//
+// These tests pin the wire contract: the exact key set, the exact key
+// names, and the value-passthrough.
+// ---------------------------------------------------------------------------
+
+test("buildRecalledContext returns exactly the keys compute_affect() reads", () => {
+  const ctx = buildRecalledContext(2, 0.812, 10);
+  assert.deepEqual(Object.keys(ctx).sort(), ["hits", "query_length", "score"]);
+});
+
+test("buildRecalledContext maps topScore arg → 'score' key (not 'topScore')", () => {
+  // The function arg is named topScore but the JSONB key MUST be 'score'
+  // because the SQL formula is `(context->>'score')::float`.
+  const ctx = buildRecalledContext(0, 0.31, 5);
+  assert.equal(ctx.score, 0.31);
+  assert.equal((ctx as unknown as Record<string, unknown>).topScore, undefined);
+});
+
+test("buildRecalledContext maps queryLength arg → 'query_length' key (snake_case)", () => {
+  // The SQL convention is snake_case; the TS arg is camelCase. Pin the
+  // boundary so a future "consistency" rename doesn't break the trigger.
+  const ctx = buildRecalledContext(0, 0, 42);
+  assert.equal(ctx.query_length, 42);
+  assert.equal((ctx as unknown as Record<string, unknown>).queryLength, undefined);
+});
+
+test("buildRecalledContext passes hits through unchanged (used by empty_recalls)", () => {
+  // empty_recalls counts rows WHERE (context->>'hits')::int = 0, so a 0
+  // hit count must round-trip as the integer 0 — not null, not undefined.
+  const ctx = buildRecalledContext(0, 0, 0);
+  assert.equal(ctx.hits, 0);
+  assert.equal(typeof ctx.hits, "number");
+});
+
+test("buildRecalledContext preserves score=0 as a real number for low_conf_recalls", () => {
+  // The empty-result branch in MemoryService.search emits topScore=0; the
+  // JSON pointer cast `(context->>'score')::float` would coerce '0' → 0.
+  // Pin that the wire shape is still a number, not null.
+  const ctx = buildRecalledContext(0, 0, 4);
+  assert.equal(ctx.score, 0);
+  assert.equal(typeof ctx.score, "number");
+});
+
+test("buildRecalledContext is pure (no aliasing across calls)", () => {
+  // Future maintainers may be tempted to memoize. The downstream RPC call
+  // serializes the object to JSONB so identity doesn't matter, but
+  // mutation across calls would be a footgun if the helper grows.
+  const a = buildRecalledContext(1, 0.5, 3);
+  const b = buildRecalledContext(2, 0.6, 4);
+  assert.notStrictEqual(a, b);
+  assert.equal(a.hits, 1);
+  assert.equal(b.hits, 2);
+});

--- a/mcp-server/src/__tests__/experiences.test.ts
+++ b/mcp-server/src/__tests__/experiences.test.ts
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { outcomeToEventType } from "../services/experiences.js";
+import {
+  outcomeToEventType,
+  buildMarkUsefulFromExperienceContext,
+} from "../services/experiences.js";
 
 // These tests pin the mapping used by ExperienceService.record() to emit
 // `agent_completed` / `agent_error` memory_events after each episode. The
@@ -33,4 +36,50 @@ test("outcomeToEventType: null/undefined → null", () => {
 test("outcomeToEventType: unrecognized string → null", () => {
   assert.equal(outcomeToEventType("in_progress"), null);
   assert.equal(outcomeToEventType(""), null);
+});
+
+// ---------------------------------------------------------------------------
+// buildMarkUsefulFromExperienceContext — JSONB payload for `mark_useful`
+// memory_events emitted from ExperienceService.markUseful (experience-subject
+// path; the memory-subject path lives in MemoryService.emitMarkUseful).
+//
+// Why these tests matter: compute_affect() §satisfaction
+// (docs/affect-observables.md) computes useful_delta as a count of
+// `mark_useful` events regardless of source, so the experience emission has
+// to reach memory_events too — otherwise satisfaction undercounts whenever
+// the user marks an episode useful instead of a memory. The JSONB context
+// itself isn't read by the satisfaction formula, but downstream introspection
+// tools (memory_history, memory_patterns) join events back to their
+// experience via context.experience_id; renaming or dropping the key would
+// silently break that link.
+// ---------------------------------------------------------------------------
+
+test("buildMarkUsefulFromExperienceContext: emits experience_id key", () => {
+  const ctx = buildMarkUsefulFromExperienceContext(
+    "11111111-2222-3333-4444-555555555555",
+  );
+  assert.equal(ctx.experience_id, "11111111-2222-3333-4444-555555555555");
+});
+
+test("buildMarkUsefulFromExperienceContext: payload has exactly one key", () => {
+  // Pin the key set so adding fields is a deliberate contract change rather
+  // than an accidental drift that downstream JSONB consumers wouldn't catch.
+  const ctx = buildMarkUsefulFromExperienceContext(
+    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  );
+  assert.deepEqual(Object.keys(ctx).sort(), ["experience_id"]);
+});
+
+test("buildMarkUsefulFromExperienceContext: experience_id is typed as string", () => {
+  // The SQL trigger does no JSON-pointer read of this key today, but the
+  // emission still must round-trip a string through Postgres's JSONB without
+  // accidental coercion to a different type.
+  const ctx = buildMarkUsefulFromExperienceContext("not-strictly-a-uuid");
+  assert.equal(typeof ctx.experience_id, "string");
+});
+
+test("buildMarkUsefulFromExperienceContext: passes empty-string id through unchanged", () => {
+  // Defensive: caller must not pre-validate; the helper is a pure shaper.
+  const ctx = buildMarkUsefulFromExperienceContext("");
+  assert.equal(ctx.experience_id, "");
 });

--- a/mcp-server/src/services/experiences.ts
+++ b/mcp-server/src/services/experiences.ts
@@ -183,6 +183,34 @@ export function outcomeToEventType(
   return null;
 }
 
+/**
+ * JSONB payload for `mark_useful` memory_events emitted from
+ * `ExperienceService.markUseful` (subject is an experience, not a memory).
+ *
+ * Mirrors `MemoryService.emitMarkUseful` but carries `experience_id` in the
+ * context so downstream consumers can correlate the event back to the
+ * episode (the row's `p_memory_id` is null on this path).
+ *
+ * Consumed by `compute_affect()` triggers (docs/affect-observables.md
+ * §satisfaction): `useful_delta` counts `mark_useful` events regardless of
+ * source, so this emission must reach `memory_events` from the experience
+ * path too — otherwise satisfaction undercounts whenever the user marks an
+ * episode useful instead of a memory.
+ *
+ * Renaming or dropping `experience_id` here silently breaks introspection
+ * tools (e.g. `memory_history`) that join the event back to its experience.
+ * The unit tests in `experiences.test.ts` pin the key set + types.
+ */
+export interface MarkUsefulFromExperienceContext {
+  experience_id: string;
+}
+
+export function buildMarkUsefulFromExperienceContext(
+  experienceId: string,
+): MarkUsefulFromExperienceContext {
+  return { experience_id: experienceId };
+}
+
 export class ExperienceService {
   private db: PostgrestClient;
   private embeddings: EmbeddingProvider;
@@ -445,7 +473,7 @@ export class ExperienceService {
       p_memory_id:  null,
       p_event_type: "mark_useful",
       p_source:     "mcp:mark_experience_useful",
-      p_context:    { experience_id: experienceId },
+      p_context:    buildMarkUsefulFromExperienceContext(experienceId),
       p_trace_id:   null,
       p_created_by: null,
     });

--- a/mcp-server/src/services/supabase.ts
+++ b/mcp-server/src/services/supabase.ts
@@ -37,6 +37,32 @@ function fmtErr(err: unknown): string {
   return e.message || e.details || e.hint || e.code || JSON.stringify(err);
 }
 
+/**
+ * JSONB payload for `recalled` memory_events.
+ *
+ * The compute_affect() SQL formulas (docs/affect-observables.md §curiosity
+ * and §frustration) read these keys directly via JSON pointer:
+ *   (context->>'hits')::int   — empty_recalls / zero_hit_ratio
+ *   (context->>'score')::float — low_conf_recalls
+ *
+ * Renaming or dropping a key here silently breaks the SQL trigger without
+ * any TypeScript signal. The unit test in `affect-event-payloads.test.ts`
+ * pins the key set + types so the contract stays in lockstep with the spec.
+ */
+export interface RecalledContext {
+  hits: number;
+  score: number;
+  query_length: number;
+}
+
+export function buildRecalledContext(
+  hits: number,
+  topScore: number,
+  queryLength: number,
+): RecalledContext {
+  return { hits, score: topScore, query_length: queryLength };
+}
+
 export class MemoryService {
   private db: PostgrestClient;
   private embeddings: EmbeddingProvider;
@@ -238,7 +264,7 @@ export class MemoryService {
       p_memory_id:  null,
       p_event_type: "recalled",
       p_source:     source,
-      p_context:    { hits, score: topScore, query_length: queryLength },
+      p_context:    buildRecalledContext(hits, topScore, queryLength),
       p_trace_id:   null,
       p_created_by: null,
     });


### PR DESCRIPTION
Part of #11 — multi-tick decomposition.

## What

Extracts a pure helper `buildMarkUsefulFromExperienceContext(experienceId)`
out of `ExperienceService.markUseful` and adds 4 unit tests pinning the
JSONB key contract.

## Why this tick

`ExperienceService.markUseful` emits a `mark_useful` memory_event with a
`{experience_id}` context — a second emission path beyond
`MemoryService.emitMarkUseful` that feeds the **same** compute_affect()
`satisfaction.useful_delta` term (docs/affect-observables.md §satisfaction):

```
useful_delta = count(memory_events WHERE event_type='mark_useful'
                     AND created_at > now()-'6h')
             - count(... BETWEEN now()-'12h' AND now()-'6h')
```

The formula counts events regardless of source, so if the experience-side
emission silently breaks (rename, drop, source-tag drift) satisfaction
undercounts whenever the user marks an episode useful instead of a memory.
This was uncovered by tests until now.

The shape of the JSONB context isn't read by the satisfaction formula
itself, but introspection tools (`memory_history`, `memory_patterns`) join
the event back to its experience via `context.experience_id` — pinning
the key set keeps that link stable.

Mirrors the earlier `buildRecalledContext` extraction (issue #11 commit
81791ab / PR #19's spec section) so every memory_event JSONB payload
compute_affect() may read lands in a pure, unit-testable helper.

## What changed

- `mcp-server/src/services/experiences.ts` — new pure
  `buildMarkUsefulFromExperienceContext` + `MarkUsefulFromExperienceContext`
  type. `markUseful` now calls the helper instead of inlining `{experience_id}`.
- `mcp-server/src/__tests__/experiences.test.ts` — 4 new tests:
  - emits `experience_id` key
  - payload has exactly one key (drift guard)
  - `experience_id` typed as string
  - empty-string id passes through (helper is a pure shaper, no validation)

## Non-goals (explicitly deferred)

- No SQL migration, no trigger work (blocked by hard process rule).
- No change to `MemoryService.emitMarkUseful` — that path emits
  `{}` context (memory_id is the subject, no extra correlation needed).
- Does not yet exercise the full `markUseful` flow against a fake DB —
  this matches the lightweight pattern of `buildRecalledContext` /
  `findResolutionMatch` / `outcomeToEventType`.

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)** — the helper runs
client-side in the MCP server, no new network dependencies, agents keep
owning their observable streams.

Touches **Pillar 6 (Cyber security)** — pure, side-effect-free helper,
no mutation of trust state, no bypass of any boundary.

**No pillar is weakened by this change.**

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] `npm test` passes — 84/84 (was 80, +4 new)
- [ ] Human review: confirm `experience_id` is the only key future
      introspection tools want from this context

🤖 Generated with [Claude Code](https://claude.com/claude-code)