### PR TITLE
test(affect): pin contradiction_detected JSONB contract from ConscienceAgent (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/conscience.test.ts
+++ b/mcp-server/src/__tests__/conscience.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildContradictionDetectedContext } from "../agents/conscience-agent.js";
+
+// ---------------------------------------------------------------------------
+// buildContradictionDetectedContext — JSONB payload contract for the
+// `contradiction_detected` (and sibling `conscience_warning`) memory_events
+// emitted by ConscienceAgent.
+//
+// Why these tests matter: the `contradicts_id` key is load-bearing for
+// `findResolutionMatch` in services/relations.ts, which pairs a
+// `contradiction_detected` row with its eventual `contradiction_resolved`
+// counterpart (same trace_id) when `supersede_memory` runs. That pairing
+// closes the open-conflict loop counted by compute_affect()'s frustration
+// term — see docs/affect-observables.md §frustration:
+//
+//   open_conflicts = count(memory_events WHERE event_type='contradiction_detected'
+//                          AND created_at > now()-'48h'
+//                          AND NOT EXISTS (…resolution event with same trace_id…))
+//
+// A silent rename of `contradicts_id` here would not break compilation
+// (the payload is JSONB) and would not break relations.test.ts (which
+// tests the matcher in isolation against synthetic rows). It would
+// silently zero out the resolution pairing — frustration would then
+// over-count open conflicts indefinitely until someone noticed the
+// dashboard drift. These tests pin the wire contract instead.
+// ---------------------------------------------------------------------------
+
+const CONTRADICTS_ID = "11111111-1111-1111-1111-111111111111";
+
+test("buildContradictionDetectedContext returns exactly the keys findResolutionMatch + downstream consumers read", () => {
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.82, "conflicts on policy");
+  assert.deepEqual(Object.keys(ctx).sort(), ["confidence", "contradicts_id", "reason"]);
+});
+
+test("buildContradictionDetectedContext maps contradictsId arg → 'contradicts_id' key (snake_case, load-bearing)", () => {
+  // The TS arg is camelCase; the JSONB key MUST be 'contradicts_id'
+  // because `findResolutionMatch` reads `e.context?.contradicts_id`.
+  // A rename to camelCase would silently break the resolution pairing.
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, "");
+  assert.equal(ctx.contradicts_id, CONTRADICTS_ID);
+  assert.equal((ctx as unknown as Record<string, unknown>).contradictsId, undefined);
+});
+
+test("buildContradictionDetectedContext passes confidence through unchanged", () => {
+  // Confidence is exposed for human-readable conscience_warning UIs and
+  // for any future weighting in the frustration formula. Pin the
+  // passthrough so a future helper that auto-buckets it (e.g. low/med/high)
+  // is a deliberate contract change.
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.6125, "x");
+  assert.equal(ctx.confidence, 0.6125);
+  assert.equal(typeof ctx.confidence, "number");
+});
+
+test("buildContradictionDetectedContext truncates reason at 500 chars", () => {
+  // The conscience-agent gateway can return long verdicts; the JSONB column
+  // should not balloon. Pin the 500-char cap so the bound moves only
+  // deliberately (it's also the cap used by the chain_memories p_reason
+  // call site, which now reuses payload.reason).
+  const long = "a".repeat(750);
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, long);
+  assert.equal(ctx.reason.length, 500);
+  assert.equal(ctx.reason, "a".repeat(500));
+});
+
+test("buildContradictionDetectedContext keeps reason at exactly 500 chars unchanged (boundary)", () => {
+  // The cap is non-strict at the boundary: 500 in → 500 out, no slicing
+  // surprises. Guards against an off-by-one rewrite (e.g. slice(0, 499)).
+  const exact = "b".repeat(500);
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, exact);
+  assert.equal(ctx.reason.length, 500);
+  assert.equal(ctx.reason, exact);
+});
+
+test("buildContradictionDetectedContext keeps an empty reason as empty string (not null/undefined)", () => {
+  // ConscienceAgent passes `verdict.reason ?? ""` into the helper, so the
+  // empty-string case is the realistic input when the gateway returns
+  // no rationale. Pin that the JSONB writes a string, not a missing key —
+  // downstream code can rely on `typeof ctx.reason === "string"`.
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.9, "");
+  assert.equal(ctx.reason, "");
+  assert.equal(typeof ctx.reason, "string");
+});
+
+test("buildContradictionDetectedContext is pure (no aliasing across calls)", () => {
+  // Mirrors the buildRecalledContext purity guard. The downstream RPC
+  // serializes the object so identity doesn't matter, but mutation across
+  // calls would be a footgun if the helper grows.
+  const a = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, "first");
+  const b = buildContradictionDetectedContext(CONTRADICTS_ID, 0.8, "second");
+  assert.notStrictEqual(a, b);
+  assert.equal(a.reason, "first");
+  assert.equal(b.reason, "second");
+  assert.equal(a.confidence, 0.7);
+  assert.equal(b.confidence, 0.8);
+});

--- a/mcp-server/src/agents/conscience-agent.ts
+++ b/mcp-server/src/agents/conscience-agent.ts
@@ -31,6 +31,53 @@ interface ConscienceVerdict {
   reason?:           string;
 }
 
+/**
+ * JSONB payload for `contradiction_detected` (and the sibling
+ * `conscience_warning`) memory_events emitted by ConscienceAgent.
+ *
+ * The `contradicts_id` key is load-bearing: `findResolutionMatch` in
+ * services/relations.ts reads `context.contradicts_id` to pair a
+ * `contradiction_detected` row with its eventual `contradiction_resolved`
+ * counterpart (same trace_id) when `supersede_memory` runs. That pairing
+ * closes the open-conflict loop counted by compute_affect()'s frustration
+ * term — see docs/affect-observables.md §frustration:
+ *
+ *   open_conflicts = count(memory_events WHERE event_type='contradiction_detected'
+ *                          AND created_at > now()-'48h'
+ *                          AND NOT EXISTS (…resolution event with same trace_id…))
+ *
+ * A silent rename of `contradicts_id` here would not break compilation
+ * (the payload is JSONB) and would not break relations.test.ts (which
+ * tests the matcher in isolation), but would zero out the resolution
+ * pairing — frustration would then over-count open conflicts indefinitely.
+ *
+ * The unit tests in `__tests__/conscience.test.ts` pin the key set, the
+ * value passthrough, and the 500-char reason truncation so a future
+ * refactor can't drift away from the wire shape relations.ts depends on.
+ */
+export interface ContradictionDetectedContext {
+  contradicts_id: string;
+  confidence:     number;
+  reason:         string;
+  // Index signature so the payload is assignable to AgentEventBus.emit's
+  // `Record<string, unknown>` parameter without an explicit cast at the
+  // emission site. The shape is still pinned by the explicit keys above
+  // and by the unit tests in __tests__/conscience.test.ts.
+  [key: string]: unknown;
+}
+
+export function buildContradictionDetectedContext(
+  contradictsId: string,
+  confidence:    number,
+  reason:        string,
+): ContradictionDetectedContext {
+  return {
+    contradicts_id: contradictsId,
+    confidence,
+    reason: reason.slice(0, 500),
+  };
+}
+
 export interface ConscienceOptions {
   agentId?:       string;          // openclaw agent id, default "main"
   topK?:          number;          // neighbours to compare against
@@ -131,20 +178,19 @@ export class ConscienceAgent implements Agent {
     //    event can correlate back. `conscience_warning` is the human-readable
     //    surface; `contradiction_detected` is the observable counted by the
     //    frustration term of compute_affect() — see docs/affect-observables.md.
-    const reason = (verdict.reason ?? "").slice(0, 500);
     const traceId = randomUUID();
-    const payload = {
-      contradicts_id: verdict.contradicts_id,
-      confidence:     verdict.confidence,
-      reason,
-    };
+    const payload = buildContradictionDetectedContext(
+      verdict.contradicts_id,
+      verdict.confidence ?? 0,
+      verdict.reason ?? "",
+    );
     await bus.emit(mem.id, "conscience_warning",    this.name, payload, traceId);
     await bus.emit(mem.id, "contradiction_detected", this.name, payload, traceId);
     const { error: chainErr } = await this.db.rpc("chain_memories", {
       p_a_id:   mem.id,
       p_b_id:   verdict.contradicts_id,
       p_type:   "contradicts",
-      p_reason: reason,
+      p_reason: payload.reason,
       p_weight: verdict.confidence ?? 0.7,
     });
     if (chainErr) {


### PR DESCRIPTION
Part of #11 — multi-tick decomposition.

## What

Extracts a pure helper `buildContradictionDetectedContext(contradictsId, confidence, reason)` out of `ConscienceAgent.checkOne` and adds 7 unit tests pinning the JSONB key contract.

## Why this tick

The `contradiction_detected` (and sibling `conscience_warning`) events both carry the same payload, currently inlined as `{ contradicts_id, confidence, reason }`. The `contradicts_id` key is **load-bearing**: `findResolutionMatch` in `services/relations.ts` reads `e.context?.contradicts_id` to pair a `contradiction_detected` row with its eventual `contradiction_resolved` counterpart (same `trace_id`) when `supersede_memory` runs. That pairing closes the open-conflict loop counted by `compute_affect()`'s frustration term (docs/affect-observables.md §frustration):

```
open_conflicts = count(memory_events WHERE event_type='contradiction_detected'
                       AND created_at > now()-'48h'
                       AND NOT EXISTS (…resolution event with same trace_id…))
```

A silent rename of `contradicts_id` here would not break compilation (the payload is JSONB) and would not break `relations.test.ts` (which exercises the matcher in isolation against synthetic rows). It would silently zero out the resolution pairing — frustration would over-count open conflicts indefinitely until someone noticed the dashboard drift. These tests pin the wire contract instead.

Mirrors the earlier `buildRecalledContext` / `buildMarkUsefulFromExperienceContext` pattern (PRs #28, #29) so every `memory_event` JSONB payload `compute_affect()` may read lands in a pure, unit-testable helper that the emitter then calls.

## What changed

- `mcp-server/src/agents/conscience-agent.ts`
  - new `ContradictionDetectedContext` interface + `buildContradictionDetectedContext` helper
  - reason truncation (`slice(0, 500)`) moved into the helper
  - emission site now constructs the payload via the helper; `chain_memories` p_reason call site now reuses `payload.reason` so the cap lives in one place
  - interface carries an `[key: string]: unknown` index signature so the payload stays assignable to `AgentEventBus.emit`'s `Record<string, unknown>` parameter without an explicit cast
- `mcp-server/src/__tests__/conscience.test.ts` — 7 new tests:
  - exact key set (`contradicts_id`, `confidence`, `reason`) — drift guard
  - `contradicts_id` snake_case passthrough — load-bearing for `findResolutionMatch`
  - `confidence` numeric passthrough
  - `reason` truncated at 500 chars
  - `reason` of exactly 500 chars unchanged (off-by-one boundary)
  - empty reason stays as empty string (typed string, not null/undefined)
  - purity (no aliasing across calls)

## Non-goals (explicitly deferred)

- No SQL migration, no trigger work (blocked by hard process rule).
- No change to the `contradiction_resolved` payload in `services/relations.ts` — its JSONB shape is downstream telemetry, not load-bearing for `compute_affect()` (the formula correlates by `trace_id`, not by JSONB content). A separate tick can pin it if introspection tools start reading it.
- Does not exercise the full `checkOne` flow against a fake DB / fake bus — matches the lightweight pattern of `buildRecalledContext` / `findResolutionMatch` / `buildMarkUsefulFromExperienceContext` / `outcomeToEventType`.

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)** — pure helper runs client-side in the MCP server, no new network dependencies, agents continue to own their observable streams.

Touches **Pillar 6 (Cyber security)** — pure, side-effect-free helper, no mutation of trust state, no bypass of any boundary; the existing trace_id correlation channel for contradiction events is preserved bit-for-bit.

**No pillar is weakened by this change.**

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] `npm test` passes — 91/91 (was 84, +7 new)
- [ ] Human review: confirm `contradicts_id` / `confidence` / `reason` is the full key set future introspection tools want from this context (no `category`, no `tags`, no `source_score`?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)