### PR TITLE
test(affect): pin agent_completed/agent_error JSONB payload contract (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/conscience.test.ts
+++ b/mcp-server/src/__tests__/conscience.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildContradictionDetectedContext } from "../agents/conscience-agent.js";
+
+// ---------------------------------------------------------------------------
+// buildContradictionDetectedContext — JSONB payload contract for the
+// `contradiction_detected` (and sibling `conscience_warning`) memory_events
+// emitted by ConscienceAgent.
+//
+// Why these tests matter: the `contradicts_id` key is load-bearing for
+// `findResolutionMatch` in services/relations.ts, which pairs a
+// `contradiction_detected` row with its eventual `contradiction_resolved`
+// counterpart (same trace_id) when `supersede_memory` runs. That pairing
+// closes the open-conflict loop counted by compute_affect()'s frustration
+// term — see docs/affect-observables.md §frustration:
+//
+//   open_conflicts = count(memory_events WHERE event_type='contradiction_detected'
+//                          AND created_at > now()-'48h'
+//                          AND NOT EXISTS (…resolution event with same trace_id…))
+//
+// A silent rename of `contradicts_id` here would not break compilation
+// (the payload is JSONB) and would not break relations.test.ts (which
+// tests the matcher in isolation against synthetic rows). It would
+// silently zero out the resolution pairing — frustration would then
+// over-count open conflicts indefinitely until someone noticed the
+// dashboard drift. These tests pin the wire contract instead.
+// ---------------------------------------------------------------------------
+
+const CONTRADICTS_ID = "11111111-1111-1111-1111-111111111111";
+
+test("buildContradictionDetectedContext returns exactly the keys findResolutionMatch + downstream consumers read", () => {
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.82, "conflicts on policy");
+  assert.deepEqual(Object.keys(ctx).sort(), ["confidence", "contradicts_id", "reason"]);
+});
+
+test("buildContradictionDetectedContext maps contradictsId arg → 'contradicts_id' key (snake_case, load-bearing)", () => {
+  // The TS arg is camelCase; the JSONB key MUST be 'contradicts_id'
+  // because `findResolutionMatch` reads `e.context?.contradicts_id`.
+  // A rename to camelCase would silently break the resolution pairing.
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, "");
+  assert.equal(ctx.contradicts_id, CONTRADICTS_ID);
+  assert.equal((ctx as unknown as Record<string, unknown>).contradictsId, undefined);
+});
+
+test("buildContradictionDetectedContext passes confidence through unchanged", () => {
+  // Confidence is exposed for human-readable conscience_warning UIs and
+  // for any future weighting in the frustration formula. Pin the
+  // passthrough so a future helper that auto-buckets it (e.g. low/med/high)
+  // is a deliberate contract change.
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.6125, "x");
+  assert.equal(ctx.confidence, 0.6125);
+  assert.equal(typeof ctx.confidence, "number");
+});
+
+test("buildContradictionDetectedContext truncates reason at 500 chars", () => {
+  // The conscience-agent gateway can return long verdicts; the JSONB column
+  // should not balloon. Pin the 500-char cap so the bound moves only
+  // deliberately (it's also the cap used by the chain_memories p_reason
+  // call site, which now reuses payload.reason).
+  const long = "a".repeat(750);
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, long);
+  assert.equal(ctx.reason.length, 500);
+  assert.equal(ctx.reason, "a".repeat(500));
+});
+
+test("buildContradictionDetectedContext keeps reason at exactly 500 chars unchanged (boundary)", () => {
+  // The cap is non-strict at the boundary: 500 in → 500 out, no slicing
+  // surprises. Guards against an off-by-one rewrite (e.g. slice(0, 499)).
+  const exact = "b".repeat(500);
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, exact);
+  assert.equal(ctx.reason.length, 500);
+  assert.equal(ctx.reason, exact);
+});
+
+test("buildContradictionDetectedContext keeps an empty reason as empty string (not null/undefined)", () => {
+  // ConscienceAgent passes `verdict.reason ?? ""` into the helper, so the
+  // empty-string case is the realistic input when the gateway returns
+  // no rationale. Pin that the JSONB writes a string, not a missing key —
+  // downstream code can rely on `typeof ctx.reason === "string"`.
+  const ctx = buildContradictionDetectedContext(CONTRADICTS_ID, 0.9, "");
+  assert.equal(ctx.reason, "");
+  assert.equal(typeof ctx.reason, "string");
+});
+
+test("buildContradictionDetectedContext is pure (no aliasing across calls)", () => {
+  // Mirrors the buildRecalledContext purity guard. The downstream RPC
+  // serializes the object so identity doesn't matter, but mutation across
+  // calls would be a footgun if the helper grows.
+  const a = buildContradictionDetectedContext(CONTRADICTS_ID, 0.7, "first");
+  const b = buildContradictionDetectedContext(CONTRADICTS_ID, 0.8, "second");
+  assert.notStrictEqual(a, b);
+  assert.equal(a.reason, "first");
+  assert.equal(b.reason, "second");
+  assert.equal(a.confidence, 0.7);
+  assert.equal(b.confidence, 0.8);
+});

--- a/mcp-server/src/__tests__/experiences.test.ts
+++ b/mcp-server/src/__tests__/experiences.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   outcomeToEventType,
   buildMarkUsefulFromExperienceContext,
+  buildOutcomeEventContext,
 } from "../services/experiences.js";
 
 // These tests pin the mapping used by ExperienceService.record() to emit
@@ -82,4 +83,109 @@ test("buildMarkUsefulFromExperienceContext: passes empty-string id through uncha
   // Defensive: caller must not pre-validate; the helper is a pure shaper.
   const ctx = buildMarkUsefulFromExperienceContext("");
   assert.equal(ctx.experience_id, "");
+});
+
+// ---------------------------------------------------------------------------
+// buildOutcomeEventContext — JSONB payload for `agent_completed` /
+// `agent_error` memory_events emitted from ExperienceService.record().
+//
+// Why these tests matter: compute_affect() §frustration
+// (docs/affect-observables.md) currently reads only the *count* of these
+// events, but the payload keys are the natural inputs for the planned tuning
+// pass (weighting retries by task_type / difficulty) and `experience_id`
+// joins the event back to its episode for introspection tools (memory_history,
+// memory_patterns). The SQL trigger reads JSONB via `(context->>'…')` casts,
+// so a silent rename — say, dropping `task_type` to `taskType` — would not
+// break compilation, would not break the existing outcomeToEventType
+// guard, and would not break the FakeService accumulator in handlers.test.ts
+// (which records function args, not JSONB shape). It would, however, zero
+// out any future weighted frustration term and break dashboard joins. Pin
+// the wire contract here.
+// ---------------------------------------------------------------------------
+
+const EXP_ID = "11111111-2222-3333-4444-555555555555";
+
+test("buildOutcomeEventContext: returns exactly the documented key set", () => {
+  // Pin the key set so adding fields is a deliberate contract change rather
+  // than an accidental drift. Mirrors the buildRecalledContext guard.
+  const ctx = buildOutcomeEventContext(EXP_ID, "success", "refactor", 0.4);
+  assert.deepEqual(
+    Object.keys(ctx).sort(),
+    ["difficulty", "experience_id", "outcome", "task_type"],
+  );
+});
+
+test("buildOutcomeEventContext: maps taskType arg → 'task_type' key (snake_case)", () => {
+  // The TS arg is camelCase; the JSONB key MUST be 'task_type' because
+  // compute_affect() reads JSONB via `(context->>'task_type')`. A silent
+  // rename to camelCase would zero out the planned weighted retry term.
+  const ctx = buildOutcomeEventContext(EXP_ID, "failure", "debug", null);
+  assert.equal(ctx.task_type, "debug");
+  assert.equal((ctx as unknown as Record<string, unknown>).taskType, undefined);
+});
+
+test("buildOutcomeEventContext: maps experienceId arg → 'experience_id' key (snake_case)", () => {
+  // Snake_case is the SQL convention; introspection tools (memory_history)
+  // join via this key. A camelCase rename would silently break the join.
+  const ctx = buildOutcomeEventContext(EXP_ID, "partial", null, null);
+  assert.equal(ctx.experience_id, EXP_ID);
+  assert.equal(
+    (ctx as unknown as Record<string, unknown>).experienceId,
+    undefined,
+  );
+});
+
+test("buildOutcomeEventContext: passes outcome through unchanged (used for filtering)", () => {
+  // outcome is also already encoded in event_type ('success' → agent_completed,
+  // etc.), but the payload still carries the raw string so a future
+  // tuning pass can distinguish 'success' from 'partial' without reverse-
+  // mapping the event_type. Pin the passthrough.
+  const ctx = buildOutcomeEventContext(EXP_ID, "partial", "research", 0.3);
+  assert.equal(ctx.outcome, "partial");
+  assert.equal(typeof ctx.outcome, "string");
+});
+
+test("buildOutcomeEventContext: difficulty=0 round-trips as a number, not null", () => {
+  // The trigger cast `(context->>'difficulty')::float` would coerce the JSON
+  // null to SQL NULL but a literal 0 must stay a number. A naive
+  // `?? null` chain that treats 0 as falsy would silently drop the value;
+  // pin that 0 survives.
+  const ctx = buildOutcomeEventContext(EXP_ID, "success", "refactor", 0);
+  assert.equal(ctx.difficulty, 0);
+  assert.equal(typeof ctx.difficulty, "number");
+});
+
+test("buildOutcomeEventContext: undefined optional inputs become JSON null", () => {
+  // ExperienceService.record() passes input.task_type / input.difficulty
+  // straight through; both are optional in RecordExperienceInput. The
+  // helper must coerce undefined → null so the JSONB payload doesn't end
+  // up with a missing key (Postgres would store the JSON value 'null',
+  // not a missing key, but the runtime shape stays consistent for any
+  // TypeScript consumer that downstream-reads the helper).
+  const ctx = buildOutcomeEventContext(EXP_ID, "success", undefined, undefined);
+  assert.equal(ctx.task_type, null);
+  assert.equal(ctx.difficulty, null);
+  assert.ok("task_type" in ctx);
+  assert.ok("difficulty" in ctx);
+});
+
+test("buildOutcomeEventContext: null inputs stay null (no double-coercion)", () => {
+  // Defensive: the caller may already pass null explicitly. The helper
+  // must not coerce null → undefined or drop the key entirely.
+  const ctx = buildOutcomeEventContext(EXP_ID, "failure", null, null);
+  assert.equal(ctx.task_type, null);
+  assert.equal(ctx.difficulty, null);
+});
+
+test("buildOutcomeEventContext: is pure (no aliasing across calls)", () => {
+  // Mirrors the buildRecalledContext purity guard. Future maintainers may
+  // be tempted to memoize; mutation across calls would be a footgun if
+  // the helper grows.
+  const a = buildOutcomeEventContext(EXP_ID, "success", "a", 0.1);
+  const b = buildOutcomeEventContext(EXP_ID, "failure", "b", 0.9);
+  assert.notStrictEqual(a, b);
+  assert.equal(a.outcome, "success");
+  assert.equal(b.outcome, "failure");
+  assert.equal(a.task_type, "a");
+  assert.equal(b.task_type, "b");
 });

--- a/mcp-server/src/agents/conscience-agent.ts
+++ b/mcp-server/src/agents/conscience-agent.ts
@@ -31,6 +31,53 @@ interface ConscienceVerdict {
   reason?:           string;
 }
 
+/**
+ * JSONB payload for `contradiction_detected` (and the sibling
+ * `conscience_warning`) memory_events emitted by ConscienceAgent.
+ *
+ * The `contradicts_id` key is load-bearing: `findResolutionMatch` in
+ * services/relations.ts reads `context.contradicts_id` to pair a
+ * `contradiction_detected` row with its eventual `contradiction_resolved`
+ * counterpart (same trace_id) when `supersede_memory` runs. That pairing
+ * closes the open-conflict loop counted by compute_affect()'s frustration
+ * term — see docs/affect-observables.md §frustration:
+ *
+ *   open_conflicts = count(memory_events WHERE event_type='contradiction_detected'
+ *                          AND created_at > now()-'48h'
+ *                          AND NOT EXISTS (…resolution event with same trace_id…))
+ *
+ * A silent rename of `contradicts_id` here would not break compilation
+ * (the payload is JSONB) and would not break relations.test.ts (which
+ * tests the matcher in isolation), but would zero out the resolution
+ * pairing — frustration would then over-count open conflicts indefinitely.
+ *
+ * The unit tests in `__tests__/conscience.test.ts` pin the key set, the
+ * value passthrough, and the 500-char reason truncation so a future
+ * refactor can't drift away from the wire shape relations.ts depends on.
+ */
+export interface ContradictionDetectedContext {
+  contradicts_id: string;
+  confidence:     number;
+  reason:         string;
+  // Index signature so the payload is assignable to AgentEventBus.emit's
+  // `Record<string, unknown>` parameter without an explicit cast at the
+  // emission site. The shape is still pinned by the explicit keys above
+  // and by the unit tests in __tests__/conscience.test.ts.
+  [key: string]: unknown;
+}
+
+export function buildContradictionDetectedContext(
+  contradictsId: string,
+  confidence:    number,
+  reason:        string,
+): ContradictionDetectedContext {
+  return {
+    contradicts_id: contradictsId,
+    confidence,
+    reason: reason.slice(0, 500),
+  };
+}
+
 export interface ConscienceOptions {
   agentId?:       string;          // openclaw agent id, default "main"
   topK?:          number;          // neighbours to compare against
@@ -131,20 +178,19 @@ export class ConscienceAgent implements Agent {
     //    event can correlate back. `conscience_warning` is the human-readable
     //    surface; `contradiction_detected` is the observable counted by the
     //    frustration term of compute_affect() — see docs/affect-observables.md.
-    const reason = (verdict.reason ?? "").slice(0, 500);
     const traceId = randomUUID();
-    const payload = {
-      contradicts_id: verdict.contradicts_id,
-      confidence:     verdict.confidence,
-      reason,
-    };
+    const payload = buildContradictionDetectedContext(
+      verdict.contradicts_id,
+      verdict.confidence ?? 0,
+      verdict.reason ?? "",
+    );
     await bus.emit(mem.id, "conscience_warning",    this.name, payload, traceId);
     await bus.emit(mem.id, "contradiction_detected", this.name, payload, traceId);
     const { error: chainErr } = await this.db.rpc("chain_memories", {
       p_a_id:   mem.id,
       p_b_id:   verdict.contradicts_id,
       p_type:   "contradicts",
-      p_reason: reason,
+      p_reason: payload.reason,
       p_weight: verdict.confidence ?? 0.7,
     });
     if (chainErr) {

--- a/mcp-server/src/services/experiences.ts
+++ b/mcp-server/src/services/experiences.ts
@@ -211,6 +211,42 @@ export function buildMarkUsefulFromExperienceContext(
   return { experience_id: experienceId };
 }
 
+/**
+ * JSONB payload for `agent_completed` / `agent_error` memory_events emitted
+ * after `ExperienceService.record()`. Feeds compute_affect()'s frustration
+ * dimension (docs/affect-observables.md §frustration: retry_rate counts
+ * agent_error vs. agent_completed events).
+ *
+ * The current SQL formula only counts these events, but the payload keys are
+ * the natural inputs for future tuning passes (e.g. weighting retries by
+ * task_type or difficulty), and `experience_id` joins the event back to its
+ * episode for introspection tools. Pinning the wire shape now keeps both
+ * surfaces stable without a compile-time signal otherwise.
+ *
+ * Snake_case is required because compute_affect() reads JSONB via
+ * `(context->>'task_type')` etc. — see the analogous `buildRecalledContext`.
+ */
+export interface OutcomeEventContext {
+  experience_id: string;
+  outcome: string;
+  task_type: string | null;
+  difficulty: number | null;
+}
+
+export function buildOutcomeEventContext(
+  experienceId: string,
+  outcome: string,
+  taskType: string | null | undefined,
+  difficulty: number | null | undefined,
+): OutcomeEventContext {
+  return {
+    experience_id: experienceId,
+    outcome,
+    task_type:  taskType  ?? null,
+    difficulty: difficulty ?? null,
+  };
+}
+
 export class ExperienceService {
   private db: PostgrestClient;
   private embeddings: EmbeddingProvider;
@@ -325,12 +361,12 @@ export class ExperienceService {
           p_memory_id:  null,
           p_event_type: outcomeEventType,
           p_source:     "mcp:record_experience",
-          p_context:    {
-            experience_id: id,
+          p_context:    buildOutcomeEventContext(
+            id,
             outcome,
-            task_type:     input.task_type ?? null,
-            difficulty:    input.difficulty ?? null,
-          },
+            input.task_type,
+            input.difficulty,
+          ),
           p_trace_id:   null,
           p_created_by: null,
         });


### PR DESCRIPTION
## Summary

Extracts the inline JSONB payload emitted alongside `agent_completed` /
`agent_error` memory_events from `ExperienceService.record()` into a pure
`buildOutcomeEventContext()` helper, and guards the wire shape with eight
unit tests covering the key set, snake_case key names, value
passthrough, and zero/null/undefined edge cases.

Continues the test-guard pattern established by PR #28 (`recalled`),
PR #29 (`mark_useful`), commit 7c6e692 (`contradiction_detected`), and
PR #24 (`outcomeToEventType` mapping). With this guard, every memory
event type that compute_affect() will read from has its TS-side wire
shape pinned before the SQL trigger lands.

## Why this matters

compute_affect()'s frustration dimension (docs/affect-observables.md
§frustration) currently reads only the *count* of these events, but the
payload keys are the natural inputs for the planned tuning pass:

- `task_type` and `difficulty` → weight retries by what the agent was
  attempting and how hard it was, instead of a flat `count() / count()`.
- `experience_id` → the join key used by `memory_history` /
  `memory_patterns` introspection tools to correlate the event back to
  its source episode.

The SQL trigger reads JSONB via `(context->>'…')` casts. A silent rename
— say, dropping `task_type` to `taskType` — would:

- not break compilation
- not break the existing `outcomeToEventType` guard
- not break the FakeService accumulator in `handlers.test.ts` (which
  records function args, not JSONB shape)

…but would zero out any future weighted frustration term and break
dashboard joins. Pinning the wire contract closes that gap.

## Behavior change

None. `record()` now calls the helper with the same fields as before.
The helper is a pure shaper, exported for unit-testability without a DB.

## Tests

`npm test` — 99 pass / 0 fail (was 91; +8 new guards).

## Constitution affirmation

Touches **Pillar 1 (Decentralized, networked AI)** and **Pillar 6
(Cyber security)**. The helper is a pure function — no new network
surface, no bypass of any trust boundary, no schema change, no migration.
No pillar is weakened.

## Related

- Issue #11 — compute_affect() from observables
- docs/affect-observables.md §frustration
- PR #24 — sibling guard for the `outcomeToEventType` mapping