### PR TITLE
test(affect): pin experiences.reflected client-input invariant (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/affect-reflected-invariant.test.ts
+++ b/mcp-server/src/__tests__/affect-reflected-invariant.test.ts
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { recordExperienceSchema } from "../tools/experience.js";
+import { digestSchema } from "../tools/digest.js";
+
+// ---------------------------------------------------------------------------
+// experiences.reflected client-input invariant
+//
+// Why this guard exists: compute_affect() (docs/affect-observables.md
+// §curiosity) reads `experiences.reflected` to compute cluster_gaps:
+//
+//   cluster_gaps = count(experiences WHERE NOT reflected
+//                        AND created_at > now()-'48h')
+//                / greatest(1, count(experiences WHERE created_at > now()-'48h'))
+//
+// `reflected` must only flip from FALSE → TRUE inside the SQL `record_lesson`
+// RPC (migration 015), which is the canonical signal that an episode has
+// been distilled into a lesson. If a client could initialize a brand-new
+// experience with `reflected: true`, the §curiosity formula would treat it
+// as already-distilled and zero out the cluster_gaps numerator — silently
+// pinning curiosity at its baseline even when episodic backlog is real.
+//
+// The defense is layered:
+//   1. The TS schemas (record_experience + digest) MUST NOT define a
+//      `reflected` field.
+//   2. Zod's default object-parse strips unknown keys, so a malicious or
+//      buggy caller passing `reflected: true` through MCP gets it silently
+//      dropped before reaching the service.
+//
+// This test pins both layers. If a future refactor adds `reflected` to
+// either schema (e.g. "let's let clients mark old episodes reflected to
+// avoid re-clustering"), this test fails loudly and forces a design
+// conversation about the §curiosity term first.
+// ---------------------------------------------------------------------------
+
+test("recordExperienceSchema does not define a `reflected` field", () => {
+  // Same defensive pattern as affect-tools-used-contract.test.ts: pin the
+  // shape, not just the runtime parse, so that adding the field with any
+  // wrapper (optional/default/effects) is caught by the type-level shape
+  // inspection.
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      recordExperienceSchema.shape,
+      "reflected"
+    ),
+    false,
+    "recordExperienceSchema.shape must not contain `reflected` — see §curiosity"
+  );
+});
+
+test("digestSchema does not define a `reflected` field", () => {
+  // digest.ts builds the experienceService.record() argument object
+  // explicitly (digest.ts ~line 119), so it does not currently propagate
+  // any extra digest-input fields. Still, pin the schema directly: if a
+  // future refactor switches to `service.record({ ...input })`, an unknown
+  // `reflected` from the digest boundary would otherwise leak into the
+  // service call.
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(digestSchema.shape, "reflected"),
+    false,
+    "digestSchema.shape must not contain `reflected` — see §curiosity"
+  );
+});
+
+test("recordExperienceSchema strips a stray `reflected` key from caller input", () => {
+  // Defense-in-depth: even if a client sends an undeclared `reflected: true`
+  // (e.g. an older MCP client speaking a future-shape API by mistake), Zod's
+  // default strip behavior must drop it before the service layer sees it.
+  // If a future refactor switches to .passthrough() / .strict() this test
+  // catches the regression: passthrough would let `reflected` leak through;
+  // strict would throw, which is *also* a behavior change worth a review.
+  const parsed = recordExperienceSchema.parse({
+    summary: "test episode",
+    reflected: true,
+  } as unknown as { summary: string });
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(parsed, "reflected"),
+    false,
+    "parsed payload must not surface `reflected` — §curiosity relies on it being SQL-only"
+  );
+});
+
+test("digestSchema strips a stray `reflected` key from caller input", () => {
+  const parsed = digestSchema.parse({
+    summary: "test digest",
+    reflected: true,
+  } as unknown as { summary: string });
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(parsed, "reflected"),
+    false,
+    "parsed payload must not surface `reflected` — §curiosity relies on it being SQL-only"
+  );
+});


### PR DESCRIPTION
## Summary

Pins that `experiences.reflected` cannot be set from client input.
`compute_affect()` (`docs/affect-observables.md` §curiosity) computes
`cluster_gaps` as the share of recent unreflected experiences:

```
cluster_gaps = count(experiences WHERE NOT reflected
                     AND created_at > now()-'48h')
             / greatest(1, count(experiences WHERE created_at > now()-'48h'))
```

`reflected` must only flip FALSE→TRUE inside the SQL `record_lesson`
RPC. If a client could initialize a brand-new experience with
`reflected: true`, the §curiosity formula would treat it as
already-distilled and zero out the cluster_gaps numerator — silently
pinning curiosity at its baseline.

## What this PR adds

`mcp-server/src/__tests__/affect-reflected-invariant.test.ts` — 4 unit
tests pinning two layers of defense:

1. `recordExperienceSchema` and `digestSchema` do not define a
   `reflected` field (shape-level check).
2. Zod's default strip behavior drops a stray `reflected: true` from
   caller input before it reaches the service (parse-level check).

A future refactor that switches to `.passthrough()` (would leak
`reflected`) or `.strict()` (would throw on extras — also a behavior
change worth a review) fails these tests.

Same defensive pattern as the prior `affect-tools-used-contract` /
`affect-event-payloads` test pins. Additive — no production code
touched.

## Decomposition context

This is one more small tick on issue #11's pre-migration checklist
(see `docs/affect-observables.md` §"Decomposition across autonomy
ticks"). Locks in the contract for §curiosity's `cluster_gaps` term,
matching prior pins for §arousal (`tools_used`), §satisfaction
(outcome/sentiment, mark_useful), and §frustration
(agent_error/completed, contradiction_detected/resolved).

## Test plan

- [x] `npm test` in `mcp-server/` — 123/123 pass (4 new)
- [x] No production code touched
- [x] No SQL migration, dependency, or CI/CD change

## Constitution affirmation

Touches **Pillar 6 (Cyber security)** in spirit: client input cannot
poison an SQL-only invariant the cognitive layer relies on. No pillar
is weakened, removed, or bypassed by this PR.

Closes part of #11 (incremental — full close requires migration steps 5–8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)