### PR TITLE
test(affect): pin mark_useful event_type wire literal (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/affect-event-types.test.ts
+++ b/mcp-server/src/__tests__/affect-event-types.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MARK_USEFUL_EVENT_TYPE } from "../services/supabase.js";
+
+// ---------------------------------------------------------------------------
+// memory_events.event_type wire-literal contract
+//
+// Why this guard exists: compute_affect() (docs/affect-observables.md
+// §satisfaction) reads memory_events filtered by `event_type='mark_useful'`
+// to compute `useful_delta`:
+//
+//   useful_delta = count(memory_events WHERE event_type='mark_useful'
+//                        AND created_at > now()-'6h')
+//                - count(memory_events WHERE event_type='mark_useful'
+//                        AND created_at BETWEEN now()-'12h' AND now()-'6h')
+//
+// The string `mark_useful` is emitted from TWO independent producer call
+// sites — one for memory subjects (MemoryService.emitMarkUseful in
+// services/supabase.ts) and one for experience subjects
+// (ExperienceService.markUseful in services/experiences.ts). A silent
+// rename at one site (or both) would not break compilation, would not
+// break any existing JSONB-payload guard (those test the context shape,
+// not the event_type literal), and would not surface in the FakeService
+// accumulator in handlers.test.ts. It would, however, zero out the
+// satisfaction `useful_delta` term — and the symptom would look like
+// "satisfaction stuck near baseline" instead of "events wrong type".
+//
+// Centralising the literal in `MARK_USEFUL_EVENT_TYPE` and pinning its
+// value here makes a rename a single deliberate edit that also fails this
+// test until the spec doc + SQL are updated to match. Same defensive
+// pattern as the prior ticks for buildRecalledContext / outcomeToEventType
+// / buildContradictionDetectedContext.
+// ---------------------------------------------------------------------------
+
+test("MARK_USEFUL_EVENT_TYPE pins to the literal compute_affect §satisfaction reads", () => {
+  // The SQL formula in docs/affect-observables.md §satisfaction filters
+  // memory_events by exact-string equality (`event_type='mark_useful'`).
+  // If this assertion fails, the formula and the producer have drifted —
+  // update both together (constant + spec doc + any SQL function) rather
+  // than weakening the test.
+  assert.equal(MARK_USEFUL_EVENT_TYPE, "mark_useful");
+});
+
+test("MARK_USEFUL_EVENT_TYPE is a string (not coerced to a non-string sentinel)", () => {
+  // Defensive: a future maintainer might be tempted to swap the string for
+  // a Symbol or numeric enum. log_memory_event takes p_event_type as TEXT,
+  // so anything but a string would either throw at the RPC boundary or get
+  // serialised in a surprising way. Pin the runtime type.
+  assert.equal(typeof MARK_USEFUL_EVENT_TYPE, "string");
+});
+
+test("MARK_USEFUL_EVENT_TYPE is non-empty (would otherwise match every row)", () => {
+  // A `""` event_type would silently break compute_affect()'s filter
+  // (`event_type=''` matches nothing in practice but inserts would still
+  // succeed against the TEXT column). Pin a length floor so an empty
+  // string can't slip in via a bad refactor.
+  assert.ok(MARK_USEFUL_EVENT_TYPE.length > 0);
+});
+
+test("MARK_USEFUL_EVENT_TYPE is snake_case (matches SQL convention used in the spec)", () => {
+  // The spec doc, SQL functions, and the Postgres column convention all
+  // use snake_case event_type strings. A camelCase or kebab-case rename
+  // (e.g. "markUseful" / "mark-useful") would silently miss the SQL
+  // filter. This regex is intentionally narrow — it only allows
+  // `[a-z0-9_]+` — to flag any drift toward another casing scheme.
+  assert.match(MARK_USEFUL_EVENT_TYPE, /^[a-z][a-z0-9_]*$/);
+});

--- a/mcp-server/src/services/experiences.ts
+++ b/mcp-server/src/services/experiences.ts
@@ -1,5 +1,6 @@
 import { PostgrestClient } from "@supabase/postgrest-js";
 import type { EmbeddingProvider } from "./embeddings.js";
+import { MARK_USEFUL_EVENT_TYPE } from "./supabase.js";
 
 /**
  * Experience / soul layer service.
@@ -507,7 +508,7 @@ export class ExperienceService {
     // context so downstream consumers can still correlate. Non-fatal.
     const { error: evErr } = await this.db.rpc("log_memory_event", {
       p_memory_id:  null,
-      p_event_type: "mark_useful",
+      p_event_type: MARK_USEFUL_EVENT_TYPE,
       p_source:     "mcp:mark_experience_useful",
       p_context:    buildMarkUsefulFromExperienceContext(experienceId),
       p_trace_id:   null,

--- a/mcp-server/src/services/supabase.ts
+++ b/mcp-server/src/services/supabase.ts
@@ -38,6 +38,23 @@ function fmtErr(err: unknown): string {
 }
 
 /**
+ * Wire literal for the `mark_useful` memory_event type.
+ *
+ * compute_affect() (docs/affect-observables.md §satisfaction) reads
+ * memory_events filtered by `event_type='mark_useful'` to compute
+ * `useful_delta`. The string is emitted from two independent call sites:
+ *
+ *   - `MemoryService.emitMarkUseful` (memory-subject path, this file)
+ *   - `ExperienceService.markUseful` (experience-subject path, services/experiences.ts)
+ *
+ * Both must agree, and both must agree with the SQL formula. Centralising
+ * the literal here means a rename forces a single edit (and the test in
+ * `affect-event-types.test.ts` then fails until the spec doc is updated
+ * too), instead of two emit sites silently drifting apart.
+ */
+export const MARK_USEFUL_EVENT_TYPE = "mark_useful" as const;
+
+/**
  * JSONB payload for `recalled` memory_events.
  *
  * The compute_affect() SQL formulas (docs/affect-observables.md §curiosity
@@ -192,7 +209,7 @@ export class MemoryService {
   async emitMarkUseful(memoryId: string | null, source: string): Promise<void> {
     const { error } = await this.db.rpc("log_memory_event", {
       p_memory_id:  memoryId,
-      p_event_type: "mark_useful",
+      p_event_type: MARK_USEFUL_EVENT_TYPE,
       p_source:     source,
       p_context:    {},
       p_trace_id:   null,


### PR DESCRIPTION
## Summary

Closes one more contract gap on the path to `compute_affect()` (issue #11):
the `mark_useful` `memory_events.event_type` wire literal.

`compute_affect()` (docs/affect-observables.md §satisfaction) reads
memory_events filtered by `event_type='mark_useful'` for `useful_delta`. The
producer emits this string from **two independent sites**:

- `MemoryService.emitMarkUseful` — memory-subject path (`services/supabase.ts:195`)
- `ExperienceService.markUseful` — experience-subject path (`services/experiences.ts:510`)

Both inlined the literal as a bare string. A silent rename at either site
would not break compilation, would not break any existing JSONB-payload
guard (those pin the context shape, not the event_type), and would not
surface in the `FakeService` accumulator in `handlers.test.ts`. It would
just zero out satisfaction's `useful_delta` term — exactly the silent
under-reporting failure mode that compute_affect() is supposed to replace.

## What changes

- `services/supabase.ts`: new export `MARK_USEFUL_EVENT_TYPE = "mark_useful"`,
  placed next to `buildRecalledContext` (the existing affect-event helper).
- `services/supabase.ts:195` and `services/experiences.ts:510`: import and
  use the constant instead of the inlined literal. No behaviour change.
- `__tests__/affect-event-types.test.ts` (new): 4 unit tests pinning value,
  runtime type, non-emptiness, and snake_case shape — same defensive pattern
  as `buildRecalledContext` / `outcomeToEventType` / `buildContradictionResolvedContext`.

Tests: `npm test` 123 → 127, all green. No SQL migration, no CI/CD change,
no dependency change.

## Constitution affirmation

This change touches no Constitution pillar. It is a purely additive
refactor + test that reduces silent-drift risk on a `compute_affect()`
input.

- Pillar 1 (Decentralized): unchanged
- Pillar 2 (Reproduction): unchanged
- Pillar 3 (Swarm): unchanged
- Pillar 4 (Microtransactions): unchanged
- Pillar 5 (Experts): unchanged
- Pillar 6 (Cyber security): unchanged

No pillar is weakened.

## Test plan

- [x] `npm test` in `mcp-server/` — 127 tests pass (4 new)
- [x] No new dependencies, no migration, no CI/CD edits
- [x] Both producer call sites still hit `log_memory_event` with
      `p_event_type === "mark_useful"` (now via the shared constant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)