### PR TITLE
test(affect): pin skill_record RPC payload contract for confidence (issue #11)

### DIFF
--- a/mcp-server/src/__tests__/affect-skill-record-payload.test.ts
+++ b/mcp-server/src/__tests__/affect-skill-record-payload.test.ts
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildSkillRecordPayload } from "../services/skills.js";
+
+// ---------------------------------------------------------------------------
+// skill_record RPC payload contract
+//
+// Why this guard exists: compute_affect() (docs/affect-observables.md
+// §confidence) reads `skill_outcomes.outcome` as a literal-string filter:
+//
+//   numerator   = sum( n(outcome='success') * exp(-hours_since(last_at)/48) )
+//   denominator = sum( n(*)                 * exp(-hours_since(last_at)/48) )
+//
+// The string `'success'` (and the other 3 outcome literals) is sourced from
+// `digestSchema.outcome` (already pinned in affect-enum-contracts.test.ts)
+// and flows verbatim through `digest.ts` line 142 into
+// `SkillsService.record(...)` and from there into the `skill_record` RPC
+// payload as `p_outcome`. The SQL function `skill_record()` then writes that
+// value into `skill_outcomes.outcome`, where the confidence formula reads it.
+//
+// A silent rename of the RPC parameter key (e.g. `p_outcome` → `outcome`)
+// or a normalising transform (`'success'` → `'ok'`) at the TS boundary
+// would not break compilation, would still satisfy the `skill_record()`
+// CHECK constraint (because the SQL falls back to `'unknown'` for any
+// unrecognised value), and would silently zero out the confidence formula
+// numerator — symptom: confidence stuck at baseline regardless of skill
+// success rate, exactly the failure mode issue #11 fixes for valence.
+//
+// These tests pin the wire contract: the exact key set, the exact key
+// names, the empty-string fallback to `'unknown'`, and value passthrough
+// for every valid outcome literal compute_affect() reads.
+// ---------------------------------------------------------------------------
+
+test("buildSkillRecordPayload returns exactly the keys skill_record() declares", () => {
+  // skill_record(p_skills TEXT[], p_task_type TEXT, p_outcome TEXT,
+  //              p_difficulty DOUBLE PRECISION) — migration 021. Any drift
+  // between the TS payload keys and the SQL parameter names produces a
+  // PostgREST 400 at runtime, but compiles and unit-tests fine without
+  // this assertion.
+  const payload = buildSkillRecordPayload(["recall"], "implement", "success", 0.5);
+  assert.deepEqual(
+    Object.keys(payload).sort(),
+    ["p_difficulty", "p_outcome", "p_skills", "p_task_type"],
+  );
+});
+
+test("buildSkillRecordPayload pins p_outcome to the literal compute_affect §confidence reads", () => {
+  // The confidence numerator filters on `outcome='success'`. If the TS
+  // boundary rewrites the string (e.g. .toLowerCase() drift, locale
+  // normalisation, alias map), the SQL filter silently misses every row.
+  // Pin verbatim passthrough for the four canonical outcomes.
+  for (const outcome of ["success", "partial", "failure", "unknown"]) {
+    const payload = buildSkillRecordPayload(["x"], "t", outcome, 0.5);
+    assert.equal(
+      payload.p_outcome,
+      outcome,
+      `outcome '${outcome}' must pass through to p_outcome verbatim`,
+    );
+  }
+});
+
+test("buildSkillRecordPayload falls back to 'unknown' for empty outcome (matches SQL CHECK normalisation)", () => {
+  // skill_record() in migration 021 normalises an empty/whitespace outcome
+  // to 'unknown' before the CHECK runs. The TS wrapper does the same with
+  // `outcome || 'unknown'` so a caller that passes "" doesn't hit a 500.
+  // Pin the fallback because dropping it would surface as a CHECK-violation
+  // 500 at runtime instead of the silent 'unknown' the SQL expects.
+  const payload = buildSkillRecordPayload(["x"], "t", "", 0.5);
+  assert.equal(payload.p_outcome, "unknown");
+});
+
+test("buildSkillRecordPayload falls back to 'unknown' for empty taskType (matches SQL default)", () => {
+  // skill_outcomes.task_type column has DEFAULT 'unknown' (migration 021).
+  // The TS wrapper mirrors that default for empty strings so the row's
+  // task_type is never literally "" — which would split skill_recommend()
+  // into a separate task-type bucket nobody queries.
+  const payload = buildSkillRecordPayload(["x"], "", "success", 0.5);
+  assert.equal(payload.p_task_type, "unknown");
+});
+
+test("buildSkillRecordPayload preserves explicit non-empty taskType verbatim", () => {
+  // The fallback above is a `||`, not a normalisation. A real task_type
+  // (e.g. 'implement') must reach the column unchanged so prime_context
+  // can match it back later via skill_recommend(p_task_type=...).
+  const payload = buildSkillRecordPayload(["x"], "implement", "success", 0.5);
+  assert.equal(payload.p_task_type, "implement");
+});
+
+test("buildSkillRecordPayload passes p_skills through as-is (preserves order, case, duplicates)", () => {
+  // skill_record() iterates p_skills with FOREACH and upserts one row per
+  // distinct (skill, task_type, outcome) — duplicates collapse via the
+  // ON CONFLICT clause, but case differences create separate rows. The TS
+  // wrapper must not normalise here, otherwise skill_outcomes ends up with
+  // a single 'recall' row when the caller wrote 'Recall' twice + 'recall'.
+  const payload = buildSkillRecordPayload(["Recall", "Recall", "recall"], "t", "success", 0.5);
+  assert.deepEqual(payload.p_skills, ["Recall", "Recall", "recall"]);
+});
+
+test("buildSkillRecordPayload passes p_difficulty through unclamped (SQL clamps to [0,1])", () => {
+  // skill_record() clamps with GREATEST(0.0, LEAST(1.0, COALESCE(p_difficulty, 0.5))).
+  // The TS wrapper deliberately does NOT pre-clamp: clamping in two places
+  // creates two sources of truth and risks divergence (e.g. one side moves
+  // to [-1,1] for a different formula and the other doesn't follow).
+  // Pin that the TS layer is a transparent pipe.
+  const payload = buildSkillRecordPayload(["x"], "t", "success", 1.5);
+  assert.equal(payload.p_difficulty, 1.5);
+  const negative = buildSkillRecordPayload(["x"], "t", "success", -0.2);
+  assert.equal(negative.p_difficulty, -0.2);
+});
+
+test("buildSkillRecordPayload is pure (no aliasing across calls)", () => {
+  // Future maintainers may be tempted to memoise the payload object. The
+  // RPC client serialises to JSON so identity doesn't matter, but mutation
+  // across calls would be a footgun if the helper grows.
+  const a = buildSkillRecordPayload(["x"], "t1", "success", 0.5);
+  const b = buildSkillRecordPayload(["y"], "t2", "failure", 0.6);
+  assert.notStrictEqual(a, b);
+  assert.notStrictEqual(a.p_skills, b.p_skills);
+  assert.equal(a.p_task_type, "t1");
+  assert.equal(b.p_task_type, "t2");
+});

--- a/mcp-server/src/services/skills.ts
+++ b/mcp-server/src/services/skills.ts
@@ -40,6 +40,42 @@ function fmtErr(err: unknown): string {
   return e.message || e.details || e.hint || e.code || JSON.stringify(err);
 }
 
+/**
+ * Pure helper that builds the `skill_record` RPC payload — the wire that
+ * eventually populates `skill_outcomes.outcome` for compute_affect()'s
+ * confidence formula (docs/affect-observables.md §confidence reads
+ * `n(outcome='success')` from this column).
+ *
+ * Extracted so the parameter contract — exact key names, empty-string
+ * fallback to `'unknown'`, value passthrough — is unit-testable without a
+ * Supabase client. A silent rename here (e.g. `p_outcome` → `outcome`) or a
+ * normalising transform (`'success'` → `'ok'`) would not break compilation,
+ * would still satisfy the SQL CHECK constraint via the `'unknown'` branch in
+ * `skill_record()`, and would silently zero out the confidence numerator.
+ *
+ * Pure: no side-effects, no aliasing — every call returns a fresh object.
+ * Mirrors the same defensive pattern as `buildRecalledContext` /
+ * `buildContradictionResolvedContext`.
+ */
+export function buildSkillRecordPayload(
+  skills: string[],
+  taskType: string,
+  outcome: string,
+  difficulty: number,
+): {
+  p_skills: string[];
+  p_task_type: string;
+  p_outcome: string;
+  p_difficulty: number;
+} {
+  return {
+    p_skills: skills,
+    p_task_type: taskType || "unknown",
+    p_outcome: outcome || "unknown",
+    p_difficulty: difficulty,
+  };
+}
+
 export class SkillsService {
   private db: PostgrestClient;
 
@@ -60,12 +96,10 @@ export class SkillsService {
   ): Promise<number> {
     if (!skills || skills.length === 0) return 0;
     try {
-      const { data, error } = await this.db.rpc("skill_record", {
-        p_skills: skills,
-        p_task_type: taskType || "unknown",
-        p_outcome: outcome || "unknown",
-        p_difficulty: difficulty,
-      });
+      const { data, error } = await this.db.rpc(
+        "skill_record",
+        buildSkillRecordPayload(skills, taskType, outcome, difficulty),
+      );
       if (error) {
         console.error("skill_record failed (non-fatal):", fmtErr(error));
         return 0;


### PR DESCRIPTION
## Why

`compute_affect()` (docs/affect-observables.md §confidence) reads
`skill_outcomes.outcome` as a literal-string filter:

```
numerator   = sum( n(outcome='success') * exp(-hours_since(last_at)/48) )
denominator = sum( n(*)                 * exp(-hours_since(last_at)/48) )
```

The literal `'success'` is sourced from `digestSchema.outcome` (already
pinned in `affect-enum-contracts.test.ts`) and flows verbatim through
`digest.ts:142` into `SkillsService.record(...)` and from there into the
`skill_record` RPC payload as `p_outcome`. The SQL function
`skill_record()` (migration 021) writes that value into
`skill_outcomes.outcome`, which the confidence formula reads.

## The drift this guards against

A silent rename of the RPC parameter key (e.g. `p_outcome` → `outcome`) or
a normalising transform (`'success'` → `'ok'`) at the TS boundary would:

- not break compilation,
- still satisfy the `skill_record()` SQL CHECK constraint — it falls back
  to `'unknown'` for any unrecognised value,
- silently zero out the confidence formula numerator.

Symptom: confidence stuck at baseline regardless of actual skill success
rate — exactly the failure mode issue #11 fixes for valence.

## What this PR does

- Extracts `buildSkillRecordPayload(skills, taskType, outcome, difficulty)`
  in `services/skills.ts` as a pure helper next to `SkillsService.record`.
- Refactors `SkillsService.record` to build the RPC payload via the helper
  (no behaviour change — the RPC body is byte-for-byte identical).
- Adds `affect-skill-record-payload.test.ts` with 8 unit tests pinning:
  - exact key set: `p_skills`, `p_task_type`, `p_outcome`, `p_difficulty`
  - `p_outcome` verbatim passthrough for the 4 canonical literals
    (`success` / `partial` / `failure` / `unknown`)
  - empty-string `outcome` falls back to `'unknown'` (mirrors the SQL
    CHECK normalisation in migration 021)
  - empty-string `taskType` falls back to `'unknown'` (mirrors the SQL
    column DEFAULT)
  - explicit non-empty `taskType` is preserved verbatim
  - `p_skills` array passes order, case, and duplicates through unchanged
  - `p_difficulty` is unclamped at the TS layer — the SQL clamps to
    `[0,1]`, so the TS layer must remain a transparent pipe (single
    source of truth for clamping)
  - helper is pure (no aliasing across calls)

Same defensive pattern as prior ticks for `buildRecalledContext` /
`outcomeToEventType` / `buildContradictionResolvedContext`.

## Decomposition step

Issue #11 step list (`docs/affect-observables.md` §Decomposition):

- [x] Step 1 — Doc (PR #15)
- [x] Step 2 — `recalled` event emission (PRs #16/#22/#27/#28)
- [x] Step 3 — `mark_useful` / `agent_completed` / `agent_error` emission
      (PRs #17/#23/#24/#29/#31/#36)
- [x] Step 4 — `contradiction_detected` emission (PRs #18/#26/#30)
- [x] Step 4b — `contradiction_resolved` emission (PRs #20/#32)
- (this PR) — pin the wire from digestSchema.outcome → skill_record RPC →
  skill_outcomes.outcome that compute_affect §confidence will read.

This is purely additive and does not touch any SQL migration or schema —
those are out of scope for autonomous ticks.

## Test plan

- [x] `npm test` from `mcp-server/` — 135 tests pass (8 new, 127 existing
      unchanged).

## Constitution affirmation

Touches **no pillar**. The change is a pure refactor (extracting an
inlined object literal into a named helper) plus additive unit tests.

- Pillar 1 (decentralized AI): unchanged — no networking surface touched.
- Pillar 6 (cyber security): unchanged — no trust-boundary code touched.

No pillar is weakened, removed, or bypassed by this PR.