### PR TITLE
feat(dashboard): i18n DE/EN scaffold + chrome extraction (#42, phase 1)

### DIFF
--- a/dashboard/i18n/README.md
+++ b/dashboard/i18n/README.md
@@ -1,0 +1,50 @@
+# Dashboard i18n
+
+Vanilla, framework-free i18n for the mycelium dashboard.
+
+## Files
+
+- `i18n.js` — runtime helper (`t`, `setLocale`, `applyToDom`, `initI18n`)
+- `de.json` — German strings
+- `en.json` — English strings (used as fallback for missing keys)
+
+## How it works
+
+The helper walks the DOM and applies translations based on two attributes:
+
+```html
+<button data-i18n="nav.memory">gedächtnis</button>
+<input data-i18n-attr="placeholder:search.placeholder">
+<button data-i18n-attr="aria-label:header.burger.aria;title:header.burger.title"></button>
+```
+
+For DOM built dynamically by JavaScript, use `window.myceliumI18n.t('key')`.
+
+Variables are written as `{name}` in the JSON value:
+
+```json
+{ "hello.user": "Hello {name}" }
+```
+
+```js
+t('hello.user', { name: 'Reed' }) // "Hello Reed"
+```
+
+## Locale precedence
+
+1. `localStorage['mycelium.locale']` — user override (set by clicking the
+   language toggle in the header)
+2. `navigator.language` — browser preference
+3. `'en'` — default
+
+## Adding a language
+
+1. Drop a new `<code>.json` next to `de.json` / `en.json`. Key set must
+   match `en.json` (the fallback dictionary).
+2. Add the code to `AVAILABLE` in `i18n.js`.
+3. Done. The header toggle cycles through `AVAILABLE_LOCALES`.
+
+## Status
+
+Phase 1 covers the dashboard chrome (sidebar tabs, header, brand subtitle).
+Per-tab string extraction is tracked as a follow-up.

--- a/dashboard/i18n/de.json
+++ b/dashboard/i18n/de.json
@@ -1,0 +1,29 @@
+{
+  "brand.subtitle": "real open AI",
+
+  "nav.memory": "gedächtnis",
+  "nav.projects": "projekte",
+  "nav.soul": "seele",
+  "nav.regulator": "regulator",
+  "nav.learning": "lernen",
+  "nav.motivation": "motivation",
+  "nav.identity": "identität",
+  "nav.sleep": "schlaf",
+  "nav.population": "population",
+  "nav.tinder": "tinder",
+  "nav.guard": "guard",
+  "nav.emergence": "emergenz",
+  "nav.federation": "föderation",
+  "nav.neurochemistry": "neurochemie",
+  "nav.synapses": "synapsen",
+  "nav.teacher": "teacher",
+
+  "header.burger.aria": "menü",
+  "header.status.connecting": "verbinde…",
+  "header.refresh": "aktualisieren",
+  "header.theme": "light / dark",
+
+  "lang.toggle.aria": "Sprache wechseln",
+  "lang.de": "DE",
+  "lang.en": "EN"
+}

--- a/dashboard/i18n/de.json
+++ b/dashboard/i18n/de.json
@@ -1,5 +1,5 @@
 {
-  "brand.subtitle": "real open AI",
+  "brand.subtitle": "your AI",
 
   "nav.memory": "gedächtnis",
   "nav.projects": "projekte",

--- a/dashboard/i18n/en.json
+++ b/dashboard/i18n/en.json
@@ -1,0 +1,29 @@
+{
+  "brand.subtitle": "real open AI",
+
+  "nav.memory": "memory",
+  "nav.projects": "projects",
+  "nav.soul": "soul",
+  "nav.regulator": "regulator",
+  "nav.learning": "learning",
+  "nav.motivation": "motivation",
+  "nav.identity": "identity",
+  "nav.sleep": "sleep",
+  "nav.population": "population",
+  "nav.tinder": "tinder",
+  "nav.guard": "guard",
+  "nav.emergence": "emergence",
+  "nav.federation": "federation",
+  "nav.neurochemistry": "neurochemistry",
+  "nav.synapses": "synapses",
+  "nav.teacher": "teacher",
+
+  "header.burger.aria": "menu",
+  "header.status.connecting": "connecting…",
+  "header.refresh": "refresh",
+  "header.theme": "light / dark",
+
+  "lang.toggle.aria": "Switch language",
+  "lang.de": "DE",
+  "lang.en": "EN"
+}

--- a/dashboard/i18n/en.json
+++ b/dashboard/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "brand.subtitle": "real open AI",
+  "brand.subtitle": "your AI",
 
   "nav.memory": "memory",
   "nav.projects": "projects",

--- a/dashboard/i18n/i18n.js
+++ b/dashboard/i18n/i18n.js
@@ -1,0 +1,102 @@
+// Vanilla i18n helper for the mycelium dashboard.
+// No framework, no build step. Two responsibilities:
+//   1) provide t(key) for JS-built DOM
+//   2) walk the DOM and apply data-i18n / data-i18n-attr attributes
+//
+// Markup conventions:
+//   <button data-i18n="nav.memory">gedächtnis</button>
+//   <input data-i18n-attr="placeholder:search.placeholder">
+//   <button data-i18n-attr="aria-label:header.burger.aria"></button>
+//   (multiple attrs: "placeholder:foo;title:bar")
+//
+// Variables: t('hello.name', { name: 'Reed' }) → "Hello Reed"
+//   placeholders are written as {name} in the JSON value.
+//
+// Locale precedence: localStorage('mycelium.locale') > navigator.language > 'en'
+// Adding a language: drop a new <code>.json into this folder, add to AVAILABLE.
+
+const AVAILABLE = ['de', 'en'];
+const STORAGE_KEY = 'mycelium.locale';
+const DEFAULT_LOCALE = 'en';
+
+let currentLocale = DEFAULT_LOCALE;
+const dictionaries = {};
+const listeners = new Set();
+
+function detectInitialLocale() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && AVAILABLE.includes(stored)) return stored;
+  } catch (_) { /* localStorage may be unavailable */ }
+  const nav = (navigator.language || '').toLowerCase().split('-')[0];
+  if (AVAILABLE.includes(nav)) return nav;
+  return DEFAULT_LOCALE;
+}
+
+async function loadDictionary(locale) {
+  if (dictionaries[locale]) return dictionaries[locale];
+  const res = await fetch(`/i18n/${locale}.json`, { cache: 'no-cache' });
+  if (!res.ok) throw new Error(`i18n: failed to load ${locale}.json (${res.status})`);
+  dictionaries[locale] = await res.json();
+  return dictionaries[locale];
+}
+
+function interpolate(template, vars) {
+  if (!vars) return template;
+  return template.replace(/\{(\w+)\}/g, (m, k) => (k in vars ? String(vars[k]) : m));
+}
+
+export function t(key, vars) {
+  const dict = dictionaries[currentLocale] || {};
+  const fallback = dictionaries[DEFAULT_LOCALE] || {};
+  const raw = key in dict ? dict[key] : (key in fallback ? fallback[key] : key);
+  return interpolate(raw, vars);
+}
+
+export function getLocale() {
+  return currentLocale;
+}
+
+export function onLocaleChange(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export async function setLocale(locale) {
+  if (!AVAILABLE.includes(locale)) throw new Error(`i18n: unknown locale ${locale}`);
+  await loadDictionary(locale);
+  currentLocale = locale;
+  try { localStorage.setItem(STORAGE_KEY, locale); } catch (_) {}
+  document.documentElement.setAttribute('lang', locale);
+  applyToDom(document);
+  listeners.forEach(fn => { try { fn(locale); } catch (_) {} });
+}
+
+export function applyToDom(root = document) {
+  root.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    el.textContent = t(key);
+  });
+  root.querySelectorAll('[data-i18n-attr]').forEach(el => {
+    const spec = el.getAttribute('data-i18n-attr');
+    spec.split(';').forEach(pair => {
+      const [attr, key] = pair.split(':').map(s => s && s.trim());
+      if (attr && key) el.setAttribute(attr, t(key));
+    });
+  });
+}
+
+export async function initI18n() {
+  const initial = detectInitialLocale();
+  // Always preload the default locale too so t() can fall back on missing keys.
+  await Promise.all([
+    loadDictionary(DEFAULT_LOCALE),
+    initial === DEFAULT_LOCALE ? Promise.resolve() : loadDictionary(initial),
+  ]);
+  currentLocale = initial;
+  document.documentElement.setAttribute('lang', initial);
+  applyToDom(document);
+  return initial;
+}
+
+export const AVAILABLE_LOCALES = AVAILABLE;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -499,36 +499,37 @@
   <aside class="sidebar" id="sidebar">
     <div class="brand">
       <h1>mycelium</h1>
-      <div class="sub">your AI</div>
+      <div class="sub" data-i18n="brand.subtitle">your AI</div>
     </div>
     <nav class="tabs">
-      <button class="tab active" data-tab="memory">gedächtnis</button>
-      <button class="tab" data-tab="projects">projekte</button>
-      <button class="tab" data-tab="soul">seele</button>
-      <button class="tab" data-tab="regulator">regulator</button>
-      <button class="tab" data-tab="learning">lernen</button>
-      <button class="tab" data-tab="motivation">motivation</button>
-      <button class="tab" data-tab="identity">identität</button>
-      <button class="tab" data-tab="sleep">schlaf</button>
-      <button class="tab" data-tab="population">population</button>
-      <button class="tab" data-tab="tinder">tinder</button>
-      <button class="tab" data-tab="guard">guard</button>
-      <button class="tab" data-tab="emergence">emergenz</button>
-      <button class="tab" data-tab="federation">föderation</button>
-      <button class="tab" data-tab="neurochemistry">neurochemie</button>
-      <button class="tab" data-tab="synapses">synapsen</button>
-      <button class="tab" data-tab="teacher">teacher</button>
+      <button class="tab active" data-tab="memory" data-i18n="nav.memory">gedächtnis</button>
+      <button class="tab" data-tab="projects" data-i18n="nav.projects">projekte</button>
+      <button class="tab" data-tab="soul" data-i18n="nav.soul">seele</button>
+      <button class="tab" data-tab="regulator" data-i18n="nav.regulator">regulator</button>
+      <button class="tab" data-tab="learning" data-i18n="nav.learning">lernen</button>
+      <button class="tab" data-tab="motivation" data-i18n="nav.motivation">motivation</button>
+      <button class="tab" data-tab="identity" data-i18n="nav.identity">identität</button>
+      <button class="tab" data-tab="sleep" data-i18n="nav.sleep">schlaf</button>
+      <button class="tab" data-tab="population" data-i18n="nav.population">population</button>
+      <button class="tab" data-tab="tinder" data-i18n="nav.tinder">tinder</button>
+      <button class="tab" data-tab="guard" data-i18n="nav.guard">guard</button>
+      <button class="tab" data-tab="emergence" data-i18n="nav.emergence">emergenz</button>
+      <button class="tab" data-tab="federation" data-i18n="nav.federation">föderation</button>
+      <button class="tab" data-tab="neurochemistry" data-i18n="nav.neurochemistry">neurochemie</button>
+      <button class="tab" data-tab="synapses" data-i18n="nav.synapses">synapsen</button>
+      <button class="tab" data-tab="teacher" data-i18n="nav.teacher">teacher</button>
     </nav>
   </aside>
   <div class="backdrop" id="sidebar-backdrop"></div>
 
   <main class="main">
   <header class="top">
-    <button class="burger" id="burger" aria-label="menü">☰</button>
-    <div class="status-line"><span class="status-dot" id="status"></span> <span id="status-text">verbinde…</span> &middot; <span id="generated">—</span></div>
+    <button class="burger" id="burger" data-i18n-attr="aria-label:header.burger.aria" aria-label="menü">☰</button>
+    <div class="status-line"><span class="status-dot" id="status"></span> <span id="status-text" data-i18n="header.status.connecting">verbinde…</span> &middot; <span id="generated">—</span></div>
     <div class="controls">
-      <button class="btn" id="refresh">aktualisieren</button>
-      <button class="btn" id="theme">light / dark</button>
+      <button class="btn" id="lang-toggle" data-i18n-attr="aria-label:lang.toggle.aria" aria-label="Sprache wechseln" title="DE / EN">DE | EN</button>
+      <button class="btn" id="refresh" data-i18n="header.refresh">aktualisieren</button>
+      <button class="btn" id="theme" data-i18n="header.theme">light / dark</button>
     </div>
   </header>
 
@@ -1222,6 +1223,33 @@
     quelle: <code>POST /api/rpc/dashboard_stats</code> &middot; proxy: <code>scripts/dashboard-server.mjs</code>
   </footer>
   </main>
+
+<script type="module">
+  // Bootstrap i18n before the main dashboard script runs.
+  // Exposes window.myceliumI18n for the legacy non-module script to consume
+  // when it builds DOM dynamically (planned in follow-up phases).
+  import { initI18n, setLocale, getLocale, t, applyToDom, AVAILABLE_LOCALES } from "/i18n/i18n.js";
+
+  await initI18n();
+
+  window.myceliumI18n = { t, setLocale, getLocale, applyToDom, AVAILABLE_LOCALES };
+
+  const updateToggle = () => {
+    const btn = document.getElementById("lang-toggle");
+    if (btn) btn.textContent = getLocale().toUpperCase();
+  };
+  updateToggle();
+
+  const toggle = document.getElementById("lang-toggle");
+  if (toggle) {
+    toggle.addEventListener("click", async () => {
+      const idx = AVAILABLE_LOCALES.indexOf(getLocale());
+      const next = AVAILABLE_LOCALES[(idx + 1) % AVAILABLE_LOCALES.length];
+      await setLocale(next);
+      updateToggle();
+    });
+  }
+</script>
 
 <script>
 const ENDPOINT = "/api";


### PR DESCRIPTION
## Summary
Adds a vanilla, framework-free i18n layer to the dashboard and translates the **chrome** — sidebar tabs, brand subtitle, header — as the first reviewable slice of #42. Per-tab string extraction (16 panels in a single 5500-line `index.html`) is intentionally deferred to a follow-up to keep this diff small enough to review.

## What's in
- `dashboard/i18n/i18n.js` — `t` / `setLocale` / `applyToDom` / `initI18n` (~110 lines, no deps)
- `dashboard/i18n/de.json` + `en.json` — chrome strings (24 keys each)
- `dashboard/i18n/README.md` — usage, locale precedence, how to add a language
- `dashboard/index.html`
  - `data-i18n` on 16 sidebar tabs + brand subtitle + 3 header buttons
  - `data-i18n-attr` on burger aria-label and toggle aria-label
  - `DE | EN` toggle button in header (cycles `AVAILABLE_LOCALES`)
  - bootstrap `<script type=\"module\">` before the legacy script — exposes `window.myceliumI18n` so the existing non-module dashboard code can consume `t()` for dynamic DOM in later phases

Locale precedence: `localStorage['mycelium.locale']` → `navigator.language` → `'en'` (also the fallback dictionary).

## What's out (follow-up)
- Per-tab string extraction across the 16 panels — large, mechanical, deserves its own PR(s)
- Plural rules / advanced ICU — not needed for our chrome; can add when a use case shows up

## Test plan
- [ ] Open `http://127.0.0.1:8787/` → sidebar in browser language (DE first time, EN if `navigator.language` starts with `en`)
- [ ] Click `DE | EN` toggle in the header → all chrome strings flip; reload → choice sticks
- [ ] `localStorage.removeItem('mycelium.locale')` + reload → falls back to browser language
- [ ] DevTools → no 404s for `/i18n/*.json`
- [ ] `<html lang>` flips between `de` / `en` on toggle

Closes part of #42 (chrome only — see PR body for what's deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)