### PR TITLE
feat: per-client MCP agents in registry (kind=server | client-session)

### DIFF
--- a/mcp-server/src/__tests__/client-identity.test.ts
+++ b/mcp-server/src/__tests__/client-identity.test.ts
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { deriveClientLabel } from "../services/client-identity.js";
+
+test("derives label from clientInfo.name + host segment + pid", () => {
+  const label = deriveClientLabel(
+    { name: "claude-code", version: "1.2.3" },
+    "Mac-mini-von-Reed.local",
+    51188,
+  );
+  assert.equal(label, "claude-code-mac-mini-von-reed-51188");
+});
+
+test("uses unknown-client when name missing", () => {
+  const label = deriveClientLabel(undefined, "host.local", 42);
+  assert.equal(label, "unknown-client-host-42");
+});
+
+test("treats empty/whitespace name as unknown-client", () => {
+  const label = deriveClientLabel({ name: "   " }, "host.local", 42);
+  assert.equal(label, "unknown-client-host-42");
+});
+
+test("sanitizes punctuation and uppercase", () => {
+  const label = deriveClientLabel(
+    { name: "Cursor IDE / v2" },
+    "MyHost",
+    7,
+  );
+  assert.equal(label, "cursor-ide-v2-myhost-7");
+});
+
+test("respects max length while preserving host+pid suffix", () => {
+  const longName = "a".repeat(200);
+  const label = deriveClientLabel({ name: longName }, "host", 999);
+  assert.ok(label.length <= 60, `expected ≤60 chars, got ${label.length}`);
+  assert.ok(label.endsWith("-host-999"), `expected suffix preserved, got '${label}'`);
+});
+
+test("produces label that satisfies agents.label charset (lowercase, dashes, digits)", () => {
+  const label = deriveClientLabel(
+    { name: "Claude.Code" },
+    "Mac-mini.local",
+    100,
+  );
+  assert.match(label, /^[a-z0-9-]+$/);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -222,32 +222,69 @@ const federationService = new FederationService(
 );
 
 // --- agent registry: diese MCP-Instanz registriert sich als 'agent' ---------
-// Label default = 'main' (der produktive Agent). Weitere Instanzen setzen
-// OPENCLAW_AGENT_LABEL bzw. OPENCLAW_GENOME_LABEL explizit in ihrer MCP-Config.
+// Two modes:
+//   (a) OPENCLAW_getAgentLabel() is set → backend/server kind. Registers
+//       eagerly with that label (LaunchAgents, cron workers, …).
+//   (b) OPENCLAW_getAgentLabel() is unset → client-session kind. Registers
+//       LAZILY in `server.oninitialized`, deriving the label from the MCP
+//       client's `clientInfo.name` (claude-code, openclaw, cursor, codex, …).
+//       Each connected client gets its own row instead of all sharing 'main'.
+import os from "node:os";
 import { homedir as _homedir } from "node:os";
 import { join as _join } from "node:path";
-const AGENT_LABEL     = process.env.OPENCLAW_AGENT_LABEL    ?? "main";
-const GENOME_LABEL    = process.env.OPENCLAW_GENOME_LABEL   ?? AGENT_LABEL;
-const WORKSPACE_PATH  = process.env.OPENCLAW_WORKSPACE_PATH ?? _join(_homedir(), ".openclaw", "workspace");
-const registryService = new RegistryService(SUPABASE_URL, SUPABASE_KEY, {
-  label:         AGENT_LABEL,
-  genomeLabel:   GENOME_LABEL,
-  workspacePath: WORKSPACE_PATH,
-  version:       "0.1.0",
-  gatewayUrl:    process.env.OPENCLAW_GATEWAY_URL ?? undefined,
-  ports: {
-    gateway:    parseInt(process.env.OPENCLAW_GATEWAY_PORT    ?? "18789", 10),
-    belief:     parseInt(process.env.OPENCLAW_BELIEF_PORT     ?? "18790", 10),
-    motivation: parseInt(process.env.OPENCLAW_MOTIVATION_PORT ?? "18792", 10),
-    dashboard:  parseInt(process.env.OPENCLAW_DASHBOARD_PORT  ?? "8787",  10),
-    cockpit:    parseInt(process.env.OPENCLAW_COCKPIT_PORT    ?? "8767",  10),
-  },
-  capabilities: (process.env.OPENCLAW_CAPABILITIES ?? "memory,soul,motivation,belief,sleep").split(","),
-  metadata: {
-    started_at: new Date().toISOString(),
-    registered_by: "mcp-server",
-  },
-});
+import { deriveClientLabel } from "./services/client-identity.js";
+const AGENT_LABEL_ENV = process.env.OPENCLAW_AGENT_LABEL;
+const AGENT_LABEL_EAGER = AGENT_LABEL_ENV ?? null;
+const GENOME_LABEL_ENV  = process.env.OPENCLAW_GENOME_LABEL ?? AGENT_LABEL_ENV ?? null;
+const WORKSPACE_PATH    = process.env.OPENCLAW_WORKSPACE_PATH ?? _join(_homedir(), ".openclaw", "workspace");
+
+function buildRegistryConfig(opts: {
+  label: string;
+  genomeLabel: string;
+  kind: "server" | "client-session";
+  extraMetadata?: Record<string, unknown>;
+}) {
+  return {
+    label:         opts.label,
+    genomeLabel:   opts.genomeLabel,
+    workspacePath: WORKSPACE_PATH,
+    version:       "0.1.0",
+    gatewayUrl:    process.env.OPENCLAW_GATEWAY_URL ?? undefined,
+    ports: {
+      gateway:    parseInt(process.env.OPENCLAW_GATEWAY_PORT    ?? "18789", 10),
+      belief:     parseInt(process.env.OPENCLAW_BELIEF_PORT     ?? "18790", 10),
+      motivation: parseInt(process.env.OPENCLAW_MOTIVATION_PORT ?? "18792", 10),
+      dashboard:  parseInt(process.env.OPENCLAW_DASHBOARD_PORT  ?? "8787",  10),
+      cockpit:    parseInt(process.env.OPENCLAW_COCKPIT_PORT    ?? "8767",  10),
+    },
+    capabilities: (process.env.OPENCLAW_CAPABILITIES ?? "memory,soul,motivation,belief,sleep").split(","),
+    metadata: {
+      started_at: new Date().toISOString(),
+      registered_by: "mcp-server",
+      ...(opts.extraMetadata ?? {}),
+    },
+    kind: opts.kind,
+  };
+}
+
+let registryService: RegistryService | null = AGENT_LABEL_EAGER
+  ? new RegistryService(
+      SUPABASE_URL,
+      SUPABASE_KEY,
+      buildRegistryConfig({
+        label:       AGENT_LABEL_EAGER,
+        genomeLabel: GENOME_LABEL_ENV ?? AGENT_LABEL_EAGER,
+        kind:        "server",
+      }),
+    )
+  : null;
+
+// Resolved at tool-call time. In eager mode (env override) the registry is
+// already constructed and these return env-derived values immediately. In
+// lazy mode (per-client) MCP guarantees `initialize` completes before any
+// tool call, so by the time any handler runs the registry is filled in.
+const getAgentLabel  = (): string => registryService?.cfg.label       ?? AGENT_LABEL_ENV  ?? "main";
+const getGenomeLabel = (): string => registryService?.cfg.genomeLabel ?? GENOME_LABEL_ENV ?? "main";
 
 const server = new McpServer({
   name: "vector-memory",
@@ -348,14 +385,14 @@ server.tool(
   "remember",
   "Store a new memory with automatic embedding generation. Use for important facts, decisions, people info, or project details.",
   rememberSchema.shape,
-  withErrorHandling((input) => remember(memoryService, affectService, projectService, AGENT_LABEL, rememberSchema.parse(input)))
+  withErrorHandling((input) => remember(memoryService, affectService, projectService, getAgentLabel(), rememberSchema.parse(input)))
 );
 
 server.tool(
   "absorb",
   "Low-friction learning: pass any text you picked up during conversation — a fact, preference, decision, person detail. The server auto-detects category, extracts tags, scores importance, checks for duplicates, and — when the text carries real emotion — ALSO auto-records a lightweight experience so the soul layer fills up organically without waiting for digest. USE THIS whenever you notice something worth remembering — don't wait to be asked.",
   absorbSchema.shape,
-  withErrorHandling((input) => absorb(memoryService, experienceService, affectService, projectService, AGENT_LABEL, absorbSchema.parse(input)))
+  withErrorHandling((input) => absorb(memoryService, experienceService, affectService, projectService, getAgentLabel(), absorbSchema.parse(input)))
 );
 
 server.tool(
@@ -433,7 +470,7 @@ server.tool(
   "record_experience",
   "Record an episodic experience: what happened, how hard it felt, what worked, what failed, and the emotional tone. Use after completing any non-trivial task — these episodes feed the agent's evolving 'soul'.",
   recordExperienceSchema.shape,
-  withErrorHandling((input) => recordExperience(experienceService, neurochemistryService, projectService, GENOME_LABEL, AGENT_LABEL, recordExperienceSchema.parse(input)))
+  withErrorHandling((input) => recordExperience(experienceService, neurochemistryService, projectService, getGenomeLabel(), getAgentLabel(), recordExperienceSchema.parse(input)))
 );
 
 server.tool(
@@ -454,7 +491,7 @@ server.tool(
   "record_lesson",
   "Store a synthesised lesson distilled from a cluster of episodes. Marks the source episodes as reflected.",
   recordLessonSchema.shape,
-  withErrorHandling((input) => recordLesson(experienceService, neurochemistryService, projectService, GENOME_LABEL, AGENT_LABEL, recordLessonSchema.parse(input)))
+  withErrorHandling((input) => recordLesson(experienceService, neurochemistryService, projectService, getGenomeLabel(), getAgentLabel(), recordLessonSchema.parse(input)))
 );
 
 server.tool(
@@ -511,7 +548,7 @@ server.tool(
   "set_intention",
   "Declare a forward-looking goal in first person. Subsequent experiences that semantically match will automatically advance its progress.",
   setIntentionSchema.shape,
-  withErrorHandling((input) => setIntention(experienceService, projectService, AGENT_LABEL, setIntentionSchema.parse(input)))
+  withErrorHandling((input) => setIntention(experienceService, projectService, getAgentLabel(), setIntentionSchema.parse(input)))
 );
 
 server.tool(
@@ -567,14 +604,14 @@ server.tool(
   "narrate_self",
   "Return a coherent first-person self-narration: who I am, what I want, what I have learned, who I am bonded with, what tensions I hold, and how fast I am evolving.",
   narrateSelfSchema.shape,
-  withErrorHandling((input) => narrateSelf(experienceService, GENOME_LABEL, narrateSelfSchema.parse(input)))
+  withErrorHandling((input) => narrateSelf(experienceService, getGenomeLabel(), narrateSelfSchema.parse(input)))
 );
 
 server.tool(
   "digest",
   "END-OF-CONVERSATION soul development. Call this ONCE at the end of every conversation. It automatically: (1) records the experience, (2) stores extracted facts, (3) runs REM-sleep reflection to find patterns, (4) creates or reinforces lessons, (5) promotes mature lessons to soul traits, (6) consolidates memories, (7) updates the agent's affective state from the outcome, (8) tracks skill performance per task_type from tools_used, (9) auto-ingests plausible causal edges to prior experiences. Pass a first-person summary, outcome, optional facts, and especially `tools_used` + `task_type` so the learning loop fills up.",
   digestSchema.shape,
-  withErrorHandling((input) => digest(experienceService, memoryService, affectService, causalService, skillsService, neurochemistryService, GENOME_LABEL, digestSchema.parse(input)))
+  withErrorHandling((input) => digest(experienceService, memoryService, affectService, causalService, skillsService, neurochemistryService, getGenomeLabel(), digestSchema.parse(input)))
 );
 
 // --- affective state layer --------------------------------------------------
@@ -641,7 +678,7 @@ server.tool(
   "infer_action",
   "Active-Inference decision: given a task description, probe the vector memory, then ask the PyMDP belief sidecar whether to recall (exploit known), research (explore), or ask_teacher (delegate). Minimises Expected Free Energy = pragmatic_value + epistemic_value + action_cost. Use BEFORE starting any non-trivial task to decide whether to lean on memory or escalate. Falls back to a simple rule-of-thumb if the sidecar is down.",
   inferActionSchema.shape,
-  withErrorHandling((input) => inferAction(memoryService, beliefService, affectService, neurochemistryService, GENOME_LABEL, inferActionSchema.parse(input)))
+  withErrorHandling((input) => inferAction(memoryService, beliefService, affectService, neurochemistryService, getGenomeLabel(), inferActionSchema.parse(input)))
 );
 
 server.tool(
@@ -1128,14 +1165,18 @@ async function main() {
   }
 
   // Register in the agents-Tabelle. Non-fatal if it fails — memory operations
-  // still work.
-  try {
-    await registryService.start();
-  } catch (err) {
-    console.error(
-      "agent registry unavailable (non-fatal):",
-      err instanceof Error ? err.message : String(err)
-    );
+  // still work. Eager path runs only when OPENCLAW_getAgentLabel() is set
+  // (backend/server processes). For MCP clients we wait for the initialize
+  // handshake — see server.server.oninitialized below.
+  if (registryService) {
+    try {
+      await registryService.start();
+    } catch (err) {
+      console.error(
+        "agent registry unavailable (non-fatal):",
+        err instanceof Error ? err.message : String(err)
+      );
+    }
   }
 
   // Agent event-bus (Migration 047) — ON by default. Set
@@ -1183,9 +1224,50 @@ async function main() {
     }
   }
 
+  // If no eager getAgentLabel() was provided, register a per-client row once the
+  // MCP `initialize` handshake completes. clientInfo.name is the source of
+  // truth ("claude-code", "openclaw", "cursor", "codex", …).
+  if (!registryService) {
+    server.server.oninitialized = () => {
+      const ci = server.server.getClientVersion();
+      const host = os.hostname();
+      const label = deriveClientLabel(ci, host, process.pid);
+      const genomeLabel = GENOME_LABEL_ENV ?? "visiting-client";
+      registryService = new RegistryService(
+        SUPABASE_URL,
+        SUPABASE_KEY,
+        buildRegistryConfig({
+          label,
+          genomeLabel,
+          kind: "client-session",
+          extraMetadata: {
+            client_name:    ci?.name    ?? null,
+            client_version: ci?.version ?? null,
+            pid:            process.pid,
+          },
+        }),
+      );
+      void registryService.start().catch((err) => {
+        console.error(
+          "agent registry (client-session) unavailable (non-fatal):",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+      console.error(
+        `vector-memory MCP server initialized for client=${ci?.name ?? "unknown"} → agent=${label}`,
+      );
+    };
+  }
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`vector-memory MCP server started (agent=${AGENT_LABEL} genome=${GENOME_LABEL})`);
+  if (registryService) {
+    console.error(
+      `vector-memory MCP server started (agent=${registryService.cfg.label} genome=${registryService.cfg.genomeLabel} kind=${registryService.cfg.kind ?? "server"})`,
+    );
+  } else {
+    console.error("vector-memory MCP server started (waiting for client initialize for agent registry)");
+  }
 }
 
 main().catch((err) => {

--- a/mcp-server/src/services/client-identity.ts
+++ b/mcp-server/src/services/client-identity.ts
@@ -1,0 +1,55 @@
+/**
+ * Per-client agent-label derivation.
+ *
+ * The MCP `initialize` handshake gives us `clientInfo.name` (e.g. "claude-code",
+ * "openclaw", "cursor", "codex"). We turn that into a deterministic
+ * agent-label that is stable per (client × host × process) so multiple parallel
+ * sessions of the same client get distinct registry rows without colliding.
+ *
+ * The label is also written to `agents.label`, which is UNIQUE — uniqueness is
+ * the load-bearing property here.
+ */
+
+export interface ClientInfo {
+  name?: string;
+  version?: string;
+}
+
+const MAX_LABEL_LEN = 60;
+
+function sanitize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function shortHost(host: string): string {
+  // hostname can be "Mac-mini-von-Reed.local" — shorten to first segment
+  return sanitize(host.split(".")[0] ?? host).slice(0, 20);
+}
+
+/**
+ * Build a per-session agent label.
+ *
+ * Examples:
+ *   { name: "claude-code", version: "1.2.3" }, "Mac-mini-von-Reed.local", 51188
+ *     → "claude-code-mac-mini-von-reed-51188"
+ *
+ * If clientInfo.name is missing/empty, uses "unknown-client".
+ */
+export function deriveClientLabel(
+  clientInfo: ClientInfo | undefined,
+  host: string,
+  pid: number,
+): string {
+  const rawName = clientInfo?.name?.trim() || "unknown-client";
+  const name = sanitize(rawName) || "unknown-client";
+  const hostPart = shortHost(host);
+  const candidate = `${name}-${hostPart}-${pid}`;
+  if (candidate.length <= MAX_LABEL_LEN) return candidate;
+  // truncate name first, keep host+pid suffix readable
+  const suffix = `-${hostPart}-${pid}`;
+  const room = Math.max(1, MAX_LABEL_LEN - suffix.length);
+  return name.slice(0, room) + suffix;
+}

--- a/mcp-server/src/services/registry.ts
+++ b/mcp-server/src/services/registry.ts
@@ -17,8 +17,10 @@ function fmtErr(err: unknown): string {
   return e.message || e.details || e.hint || e.code || JSON.stringify(err);
 }
 
+export type AgentKind = "server" | "client-session";
+
 export interface RegistryConfig {
-  /** Label of this running instance — e.g. "main", "dev-agent", "inherit_smoke". */
+  /** Label of this running instance — e.g. "main", "dev-agent", "claude-code-mac-12345". */
   label: string;
   /** Label of the genome this instance runs. Defaults to same as instance label. */
   genomeLabel: string;
@@ -38,6 +40,8 @@ export interface RegistryConfig {
   metadata?: Record<string, unknown>;
   /** Heartbeat interval in ms (default 30s). */
   heartbeatMs?: number;
+  /** Registry row kind — "server" for backend processes, "client-session" for MCP clients. */
+  kind?: AgentKind;
 }
 
 export class RegistryService {
@@ -69,6 +73,7 @@ export class RegistryService {
       p_ports:          this.cfg.ports ?? {},
       p_capabilities:   this.cfg.capabilities ?? [],
       p_metadata:       this.cfg.metadata ?? {},
+      p_kind:           this.cfg.kind ?? "server",
     });
     if (error) {
       console.error(`agent_register(${this.cfg.label}) failed:`, fmtErr(error));

--- a/scripts/nightly-sleep.mjs
+++ b/scripts/nightly-sleep.mjs
@@ -326,6 +326,23 @@ async function runWeeklyFitness() {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 5 — Registry GC (delete stale client-session rows)
+//   sweep_stale_client_sessions(p_max_age_hours)
+// ---------------------------------------------------------------------------
+async function runRegistryGc() {
+  const out = { ran: false, deleted: 0, errors: [] };
+  const hours = parseInt(process.env.SLEEP_CLIENT_SESSION_TTL_HOURS ?? "24", 10);
+  try {
+    const deleted = await restPost("/rpc/sweep_stale_client_sessions", { p_max_age_hours: hours });
+    out.deleted = typeof deleted === "number" ? deleted : (deleted?.[0] ?? 0);
+    out.ran = true;
+  } catch (e) {
+    out.errors.push({ step: "sweep_stale_client_sessions", msg: String(e?.message ?? e) });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 const startedEpoch = Date.now();
@@ -359,12 +376,18 @@ try {
   log("fitness", { ran: fit.ran });
   await patchCycle(cycleId, { fitness_result: fit });
 
+  log("phase Registry GC …");
+  const gc = await runRegistryGc();
+  log("registry gc done", { deleted: gc.deleted, errors: gc.errors.length });
+  await patchCycle(cycleId, { registry_gc_result: gc });
+
   const allErrors = [
     ...(sws.errors || []),
     ...(rem.errors || []),
     ...(emerg.errors || []),
     ...(meta.errors || []),
     ...(fit.errors || []),
+    ...(gc.errors || []),
   ];
   const status = allErrors.length === 0 ? "ok" : "partial";
   await finishCycle(cycleId, status, startedEpoch, {

--- a/supabase/migrations/061_agent_kind_and_visiting_clients.sql
+++ b/supabase/migrations/061_agent_kind_and_visiting_clients.sql
@@ -1,0 +1,159 @@
+-- 061_agent_kind_and_visiting_clients.sql
+--
+-- Per-client agents in the registry.
+--
+-- Until now the `agents` table held one row per *server process* (label='main').
+-- Every connected MCP client (Claude Code, openClaw, Cursor, Codex, …) was
+-- invisible — they all shared the same row because the label was hardcoded
+-- via OPENCLAW_AGENT_LABEL.
+--
+-- This migration:
+--   1. Adds `agents.kind` ('server' | 'client-session') so the dashboard can
+--      distinguish always-on backend processes from transient LLM sessions.
+--   2. Seeds a fallback genome `visiting-client` so unknown client labels can
+--      register without manual genome creation.
+--   3. Adds an optional p_kind parameter to `agent_register(...)`.
+--   4. Surfaces `kind` from `agents_live()`.
+--   5. Adds `sweep_stale_client_sessions(p_max_age_hours)` for nightly GC.
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'server'
+    CHECK (kind IN ('server','client-session'));
+
+CREATE INDEX IF NOT EXISTS agents_kind_idx ON agents (kind);
+
+-- Fallback genome for visiting MCP clients. Neutral defaults; provenance is
+-- documented in `notes`. Idempotent.
+INSERT INTO agent_genomes (
+  label, generation, values, interests,
+  curiosity_baseline, frustration_threshold, exploration_rate, risk_tolerance,
+  mutation_rate, notes
+) VALUES (
+  'visiting-client',
+  1,
+  ARRAY['ehrlich','konkret','ownership','neugierig','respektvoll','praktisch'],
+  ARRAY['mcp-client','llm-session'],
+  0.55, 0.70, 0.55, 0.45,
+  0.05,
+  'Auto-fallback genome for MCP clients (Claude Code / Cursor / Codex / openClaw / …) that connect without an explicit genome. Inherits Gen-1 main traits.'
+)
+ON CONFLICT (label) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- agent_register(...) — now accepts p_kind and (optionally) auto-creates the
+-- genome when a client connects with a fresh label and no genome exists.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION agent_register(
+  p_label           TEXT,
+  p_genome_label    TEXT,
+  p_workspace_path  TEXT,
+  p_host            TEXT,
+  p_version         TEXT DEFAULT NULL,
+  p_gateway_url     TEXT DEFAULT NULL,
+  p_ports           JSONB DEFAULT '{}'::jsonb,
+  p_capabilities    TEXT[] DEFAULT '{}',
+  p_metadata        JSONB DEFAULT '{}'::jsonb,
+  p_kind            TEXT DEFAULT 'server'
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_genome_id UUID;
+  v_row       agents%ROWTYPE;
+BEGIN
+  IF p_kind NOT IN ('server','client-session') THEN
+    RAISE EXCEPTION 'invalid kind %, expected server|client-session', p_kind;
+  END IF;
+
+  SELECT id INTO v_genome_id FROM agent_genomes WHERE label = p_genome_label;
+
+  -- Client sessions get a transparent fallback to `visiting-client` if the
+  -- requested genome doesn't exist. Server kind keeps the strict check —
+  -- backend processes must run a defined genome.
+  IF v_genome_id IS NULL AND p_kind = 'client-session' THEN
+    SELECT id INTO v_genome_id FROM agent_genomes WHERE label = 'visiting-client';
+  END IF;
+
+  IF v_genome_id IS NULL THEN
+    RAISE EXCEPTION 'genome % not found', p_genome_label;
+  END IF;
+
+  INSERT INTO agents (
+    genome_id, label, workspace_path, host, version,
+    gateway_url, ports, status, last_heartbeat, started_at,
+    capabilities, metadata, kind
+  ) VALUES (
+    v_genome_id, p_label, p_workspace_path, p_host, p_version,
+    p_gateway_url, p_ports, 'online', NOW(), NOW(),
+    COALESCE(p_capabilities, '{}'), COALESCE(p_metadata, '{}'::jsonb), p_kind
+  )
+  ON CONFLICT (label) DO UPDATE SET
+    genome_id      = EXCLUDED.genome_id,
+    workspace_path = EXCLUDED.workspace_path,
+    host           = EXCLUDED.host,
+    version        = COALESCE(EXCLUDED.version, agents.version),
+    gateway_url    = COALESCE(EXCLUDED.gateway_url, agents.gateway_url),
+    ports          = EXCLUDED.ports,
+    status         = 'online',
+    last_heartbeat = NOW(),
+    started_at     = NOW(),
+    stopped_at     = NULL,
+    capabilities   = EXCLUDED.capabilities,
+    metadata       = agents.metadata || EXCLUDED.metadata,
+    kind           = EXCLUDED.kind
+  RETURNING * INTO v_row;
+
+  RETURN to_jsonb(v_row);
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- agents_live() — now includes kind
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION agents_live()
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COALESCE(jsonb_agg(to_jsonb(x) ORDER BY x.live DESC, x.kind, x.label), '[]'::jsonb)
+  FROM (
+    SELECT
+      a.id, a.label, a.kind, a.workspace_path, a.host, a.version, a.gateway_url,
+      a.ports, a.status, a.last_heartbeat, a.started_at, a.stopped_at,
+      a.capabilities, a.metadata,
+      _agent_is_live(a.last_heartbeat) AS live,
+      g.id    AS genome_id,
+      g.label AS genome_label,
+      g.generation,
+      (SELECT f.fitness FROM agent_fitness_history f
+         WHERE f.genome_id = g.id
+         ORDER BY f.computed_at DESC LIMIT 1) AS latest_fitness
+    FROM agents a
+    JOIN agent_genomes g ON g.id = a.genome_id
+  ) x;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- sweep_stale_client_sessions(...) — hard-delete client-session rows that
+-- have been offline longer than p_max_age_hours. Server rows are never
+-- deleted by this sweep (they may be intentionally idle).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION sweep_stale_client_sessions(p_max_age_hours INT DEFAULT 24)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  n INT;
+BEGIN
+  DELETE FROM agents
+  WHERE kind = 'client-session'
+    AND (last_heartbeat IS NULL OR last_heartbeat < NOW() - (p_max_age_hours || ' hours')::INTERVAL);
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION agent_register(
+  TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, JSONB, TEXT[], JSONB, TEXT
+) TO anon, service_role;
+GRANT EXECUTE ON FUNCTION sweep_stale_client_sessions(INT) TO anon, service_role;


### PR DESCRIPTION
## Summary

Each connected MCP client (Claude Code, openClaw, Cursor, Codex, …) now appears as its own card in the dashboard's agents tab — not just the hardcoded `main` server row.

- **Migration 061** adds `agents.kind` ('server' | 'client-session'), seeds a `visiting-client` fallback genome, extends `agent_register(... p_kind)`, surfaces `kind` from `agents_live()`, and adds `sweep_stale_client_sessions(hours)` for GC.
- **MCP server**: when `OPENCLAW_AGENT_LABEL` is unset, registration is **deferred** until `server.oninitialized`. Label is derived from `clientInfo.name` + host segment + pid via the new pure helper `deriveClientLabel()`. Backend/server processes (LaunchAgents, cron workers) keep eager registration with kind=server — behavior unchanged.
- **Nightly sleep**: phase 5 calls `sweep_stale_client_sessions` (default 24h TTL) so per-session rows don't accumulate.

## Why this exists

Previously every spawned MCP-server child registered as `main`, so 5 zombie node processes from days-old sessions all overwrote one row. The dashboard could only ever show one card. Reed wanted the LLMs themselves visible — "Du zum Beispiel" → I (Claude Code) should appear as `claude-code-mac-mini-von-reed-<pid>`.

## Test plan

- [x] Migration applies cleanly: `psql < 061_…sql` (ALTER TABLE + INSERT + 3 × CREATE FUNCTION + 2 × GRANT)
- [x] PostgREST smoke test: `agent_register` with `p_kind='client-session'` inserts a client-session row referencing `visiting-client` genome (after `NOTIFY pgrst, 'reload schema'`)
- [x] `sweep_stale_client_sessions(0)` deletes the test row, leaves `kind='server'` rows alone
- [x] `npm test` → 161/161 green (incl. 6 new unit tests for `deriveClientLabel`: sanitization, unknown fallback, length bound, charset)
- [x] `tsc` → no errors
- [ ] **Manual after merge**: restart the eager `main` server (LaunchAgent), reconnect Claude Code → expect a second card `claude-code-…` appearing live alongside `main`

## Operator notes

- After deploying, run `NOTIFY pgrst, 'reload schema';` so PostgREST picks up the new `agent_register` signature.
- Existing callers of `agent_register` keep working: `p_kind` defaults to `'server'`.
- `OPENCLAW_AGENT_LABEL` still wins as an explicit override (cron jobs, openClaw gateway, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)