### PR TITLE
fix(affect): grant anon INSERT/SELECT on agent_affect_history (migration 063)

### DIFF
--- a/supabase/migrations/063_grant_agent_affect_history.sql
+++ b/supabase/migrations/063_grant_agent_affect_history.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- Migration 063 — grant runtime roles INSERT/SELECT on agent_affect_history
+-- ============================================================================
+--
+-- Phase-2 drift fix on top of migration 062. The history table was created
+-- but its grants were forgotten. apply_compute_affect() runs from AFTER-INSERT
+-- triggers on experiences and memory_events without SECURITY DEFINER, so it
+-- executes as the calling role. With anon (the role the MCP server uses for
+-- record_experience / remember / recall) it tried to INSERT into
+-- agent_affect_history without permission and bubbled up
+--
+--   ERROR: permission denied for table agent_affect_history
+--
+-- which fails the originating INSERT (record_experience etc.). Until this
+-- migration runs, every record_experience call from a non-superuser role
+-- aborts.
+--
+-- Mirrors the grants migration 019 set on agent_affect (SELECT, UPDATE for
+-- anon + service_role). For history we need INSERT (the apply_compute_affect
+-- writer) and SELECT (any future dashboard reader). USAGE on the BIGSERIAL
+-- sequence is required so anon can advance the id column.
+-- ============================================================================
+
+GRANT INSERT, SELECT ON agent_affect_history TO anon, service_role;
+GRANT USAGE, SELECT ON SEQUENCE agent_affect_history_id_seq TO anon, service_role;
+
+-- Sanity: confirm anon can now insert. We can't easily SET ROLE inside a
+-- migration (psql connects as superuser), but we can at least assert the
+-- privilege bit is present in the catalog.
+DO $$
+BEGIN
+  IF NOT has_table_privilege('anon', 'agent_affect_history', 'INSERT') THEN
+    RAISE EXCEPTION '063 sanity: anon still lacks INSERT on agent_affect_history';
+  END IF;
+  IF NOT has_sequence_privilege('anon', 'agent_affect_history_id_seq', 'USAGE') THEN
+    RAISE EXCEPTION '063 sanity: anon still lacks USAGE on agent_affect_history_id_seq';
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary

Phase-2 drift on top of migration 062. The history table was created but the grants were forgotten, and `apply_compute_affect()` runs from the AFTER-INSERT triggers without `SECURITY DEFINER`. With `anon` — the role the MCP server uses — every trigger fire raised:

```
ERROR: permission denied for table agent_affect_history
```

…which propagated up and aborted the originating INSERT (`record_experience`, `remember`, etc.). On any non-superuser role this effectively broke the regulator. Migration 062 itself applied cleanly because `psql` connects as `postgres`.

Found while smoke-testing PR #51 (Phase 3) — the very first `record_experience` after Phase 2 went live failed with the above.

## Fix

Mirrors the grants migration 019 set on `agent_affect`:

```sql
GRANT INSERT, SELECT ON agent_affect_history TO anon, service_role;
GRANT USAGE,  SELECT ON SEQUENCE agent_affect_history_id_seq
                                              TO anon, service_role;
```

`USAGE` on the BIGSERIAL sequence is required because `anon` advances the `id` column on every insert.

A DO-block sanity check refuses to commit the migration if either bit is still missing in `pg_class` — a future schema reset that strips grants will fail loudly instead of silently.

## Test plan

- [x] Applied to local Supabase (\`GRANT / GRANT / DO\`).
- [x] Smoke-tested live: \`record_experience\` that returned \"permission denied\" before now succeeds and emits expected memory_link side-effects.
- [ ] Apply on any other deployments using the anon role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)