### PR TITLE
feat(affect): tuning-telemetry surface for compute_affect (issue #11 phase 10)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1086,6 +1086,37 @@
     </section>
 
     <section class="card" style="margin-top:16px">
+      <h2 data-i18n="card.regulator.trend">verlauf der gefühlslage</h2>
+      <div class="sub" data-i18n="card.regulator.trend.sub" style="margin-bottom:10px">Wie sich die vier Dimensionen plus Valenz/Arousal über die letzten Stunden bewegt haben. Quelle: <code>agent_affect_history</code> (compute_affect-Trigger). Tuning-Surface für Issue #11 Phase 10.</div>
+      <div class="syn-toolbar" style="margin-bottom:10px">
+        <div class="syn-group">
+          <span class="syn-group-label" data-i18n="card.regulator.trend.window">zeitraum</span>
+          <select id="affect-trend-hours" style="background:var(--bg-elev-2);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px">
+            <option value="24">24 h</option>
+            <option value="72" selected>72 h</option>
+            <option value="168">7 Tage</option>
+            <option value="336">14 Tage</option>
+          </select>
+        </div>
+        <div class="syn-divider"></div>
+        <div class="syn-group">
+          <span class="syn-group-label" data-i18n="card.regulator.trend.bucket">auflösung</span>
+          <select id="affect-trend-bucket" style="background:var(--bg-elev-2);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px">
+            <option value="15">15 min</option>
+            <option value="60" selected>1 h</option>
+            <option value="240">4 h</option>
+          </select>
+        </div>
+        <div id="affect-trend-meta" class="sub" style="margin-left:auto;font-size:11px"></div>
+      </div>
+      <div style="position:relative;height:220px"><canvas id="chart-affect-dims"></canvas></div>
+      <div style="position:relative;height:160px;margin-top:12px"><canvas id="chart-affect-valaro"></canvas></div>
+      <h3 style="font-size:11px;text-transform:uppercase;letter-spacing:0.10em;color:var(--text-dim);margin:18px 0 6px" data-i18n="card.regulator.trend.triggers">trigger-aufschlüsselung</h3>
+      <div class="sub" data-i18n="card.regulator.trend.triggers.sub" style="margin-bottom:10px">Welche Event-Typen das compute_affect-Update auslösen und wie der Affekt im Mittel pro Trigger aussieht. Wenn ein Trigger dominiert, kippt das Tuning.</div>
+      <table class="mem" id="affect-trend-triggers"></table>
+    </section>
+
+    <section class="card" style="margin-top:16px">
       <h2 data-i18n="card.regulator.belief">entscheidungs-finder</h2>
       <div class="sub" data-i18n="card.regulator.belief.sub" style="margin-bottom:10px">Eine separate Entscheidungs-Engine, die dem Agenten vorschlägt, ob er bei einer offenen Frage besser im Gedächtnis suchen, recherchieren oder um Hilfe fragen sollte. Wählt jeweils den Weg mit der geringsten erwarteten Unsicherheit.</div>
       <div class="health-grid" id="belief-health"></div>
@@ -1881,6 +1912,8 @@ async function fetchJson(path) {
   return r.json();
 }
 const fetchAffect       = () => fetchJson("/affect");
+const fetchAffectHistory = (hours, bucket) =>
+  fetchJson(`/affect/history?hours=${hours|0}&bucket=${bucket|0}`);
 const fetchBeliefHealth = () => fetchJson("/belief/health");
 const fetchBeliefModel  = () => fetchJson("/belief/model");
 const fetchSkillStats   = () => fetchJson("/skills");
@@ -1964,6 +1997,117 @@ function renderAffect(state) {
     ["Verwandte Tags",      bias.include_adjacent_tags ? "ja — bezieht ähnliche Themen ein" : "nein"],
     ["Begründung",          `<span class="sub">${escapeHtml(bias.reason)}</span>`],
   ].map(([k,v]) => `<div class="health-item"><div class="k">${k}</div><div class="v">${v}</div></div>`).join("");
+}
+
+// Trend surface for issue #11 phase 10. Charts the four regulator dims +
+// valence/arousal over the last N hours, plus a per-trigger breakdown.
+// Empty windows render the canvas with a "noch keine Daten" annotation
+// instead of crashing — compute_affect started writing on 2026-04-26.
+function renderAffectTrend(payload) {
+  const sBox = payload?.series ?? null;
+  const tBox = payload?.triggers ?? null;
+  const meta = $("affect-trend-meta");
+  const series = sBox?.series ?? [];
+  const totalSamples = sBox?.total_samples ?? 0;
+  if (meta) {
+    meta.textContent = totalSamples > 0
+      ? `${totalSamples} Samples · ${series.length} Buckets · ${sBox?.bucket_minutes ?? "?"} min`
+      : "noch keine compute_affect-Daten in diesem Zeitraum";
+  }
+  const p = palette();
+  const labels = series.map(s => s.at);
+  const fmtTime = (iso) => {
+    try {
+      const d = new Date(iso);
+      return d.toLocaleString("de-DE", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+    } catch { return iso; }
+  };
+  charts.affectDims?.destroy?.(); delete charts.affectDims;
+  charts.affectValAro?.destroy?.(); delete charts.affectValAro;
+
+  charts.affectDims = new Chart($("chart-affect-dims"), {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        { label: "Neugier",       data: series.map(s => s.curiosity),    borderColor: p.accent,  backgroundColor: p.accent  + "11", borderWidth: 1.5, pointRadius: 0, tension: 0.3, fill: false },
+        { label: "Zufriedenheit", data: series.map(s => s.satisfaction), borderColor: p.good,    backgroundColor: p.good    + "11", borderWidth: 1.5, pointRadius: 0, tension: 0.3, fill: false },
+        { label: "Vertrauen",     data: series.map(s => s.confidence),   borderColor: p.accent2, backgroundColor: p.accent2 + "11", borderWidth: 1.5, pointRadius: 0, tension: 0.3, fill: false },
+        { label: "Frust",         data: series.map(s => s.frustration),  borderColor: p.bad,     backgroundColor: p.bad     + "11", borderWidth: 1.5, pointRadius: 0, tension: 0.3, fill: false },
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { labels: { color: p.dim, font: { size: 11 }, usePointStyle: true, boxWidth: 8 } },
+        tooltip: { callbacks: { title: (items) => fmtTime(items[0]?.label) } },
+      },
+      scales: {
+        x: { ticks: { color: p.faint, font: { size: 10 }, maxRotation: 0, autoSkipPadding: 20, callback: (_v, i) => fmtTime(labels[i]) }, grid: { color: p.border + "44" } },
+        y: { min: 0, max: 1, ticks: { color: p.faint, font: { size: 10 } }, grid: { color: p.border + "44" } },
+      },
+    },
+  });
+
+  charts.affectValAro = new Chart($("chart-affect-valaro"), {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        { label: "Valenz",  data: series.map(s => s.valence), borderColor: p.accent3 || p.accent, backgroundColor: (p.accent3 || p.accent) + "11", borderWidth: 1.5, pointRadius: 0, tension: 0.3, yAxisID: "yV", fill: false },
+        { label: "Arousal", data: series.map(s => s.arousal), borderColor: p.warn,                backgroundColor: p.warn + "11",                borderWidth: 1.5, pointRadius: 0, tension: 0.3, yAxisID: "yA", fill: false },
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { labels: { color: p.dim, font: { size: 11 }, usePointStyle: true, boxWidth: 8 } },
+        tooltip: { callbacks: { title: (items) => fmtTime(items[0]?.label) } },
+      },
+      scales: {
+        x: { ticks: { color: p.faint, font: { size: 10 }, maxRotation: 0, autoSkipPadding: 20, callback: (_v, i) => fmtTime(labels[i]) }, grid: { color: p.border + "44" } },
+        yV: { position: "left",  min: -1, max: 1, ticks: { color: p.faint, font: { size: 10 } }, grid: { color: p.border + "44" }, title: { display: true, text: "Valenz",  color: p.faint, font: { size: 10 } } },
+        yA: { position: "right", min: 0,  max: 1, ticks: { color: p.faint, font: { size: 10 } }, grid: { display: false },         title: { display: true, text: "Arousal", color: p.faint, font: { size: 10 } } },
+      },
+    },
+  });
+
+  const triggers = tBox?.triggers ?? [];
+  const tbl = $("affect-trend-triggers");
+  if (!triggers.length) {
+    tbl.innerHTML = `<tr><td class="empty" colspan="6">noch keine Trigger-Events im Fenster</td></tr>`;
+  } else {
+    const total = tBox.total_fires || 1;
+    const fmt = (v) => (v == null ? "—" : Number(v).toFixed(2));
+    const head = `<thead><tr><th>Trigger</th><th>Anteil</th><th>Fires</th><th>Ø Valenz</th><th>Ø Frust</th><th>Ø Zufriedenheit</th></tr></thead>`;
+    const rows = triggers.map(r => {
+      const pct = ((r.fires / total) * 100).toFixed(1);
+      return `<tr>
+        <td><code>${escapeHtml(r.trigger_event)}</code></td>
+        <td>${pct}%</td>
+        <td>${r.fires}</td>
+        <td>${fmt(r.avg_valence)}</td>
+        <td>${fmt(r.avg_frustration)}</td>
+        <td>${fmt(r.avg_satisfaction)}</td>
+      </tr>`;
+    }).join("");
+    tbl.innerHTML = head + `<tbody>${rows}</tbody>`;
+  }
+}
+
+async function loadAffectTrend() {
+  const hours = Number($("affect-trend-hours")?.value) || 72;
+  const bucket = Number($("affect-trend-bucket")?.value) || 60;
+  try {
+    const payload = await fetchAffectHistory(hours, bucket);
+    renderAffectTrend(payload);
+  } catch (e) {
+    renderAffectTrend({ series: { series: [], total_samples: 0 }, triggers: { triggers: [] } });
+    const meta = $("affect-trend-meta");
+    if (meta) meta.textContent = `Fehler: ${e.message}`;
+  }
 }
 
 // Compact affect render for the soul tab — same data as renderAffect() but
@@ -3816,6 +3960,7 @@ async function load() {
     renderAffect(aff);
     renderSoulAffect(aff);   // Same data, compact render under the mood disc
     renderBelief(beliefHealth, beliefModel);
+    loadAffectTrend();       // mig 064 — trend over time + per-trigger breakdown
 
     // learning tab (migrations 020 + 021)
     renderSkills(skillsData);
@@ -4399,6 +4544,14 @@ async function resolveTeacherEsc(action){
   TCH_OPEN_ESC = null;
   refreshTeacher();
 }
+
+// affect-trend select wiring
+document.addEventListener("DOMContentLoaded", () => {
+  const hSel = document.getElementById("affect-trend-hours");
+  const bSel = document.getElementById("affect-trend-bucket");
+  if (hSel) hSel.addEventListener("change", () => { loadAffectTrend(); });
+  if (bSel) bSel.addEventListener("change", () => { loadAffectTrend(); });
+});
 
 function applyTheme(t) {
   document.documentElement.dataset.theme = t;

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -380,6 +380,34 @@ async function handleAffect(_req, res) {
   }
 }
 
+// /affect/history?hours=72&bucket=60 → time-series + per-trigger breakdown
+// for the issue #11 phase-10 tuning surface (mig 064).
+async function handleAffectHistory(req, res) {
+  try {
+    const u = new URL(req.url, "http://x");
+    const hours = clampInt(u.searchParams.get("hours"), 1, 720, 72);
+    const bucket = clampInt(u.searchParams.get("bucket"), 1, 1440, 60);
+    const [series, triggers] = await Promise.all([
+      callRpc("affect_history_series",   { p_hours: hours, p_bucket_minutes: bucket }),
+      callRpc("affect_history_triggers", { p_hours: hours }),
+    ]);
+    res.writeHead(200, {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify({ series, triggers }));
+  } catch (e) {
+    res.writeHead(502, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "affect_history failed", detail: String(e?.message || e) }));
+  }
+}
+
+function clampInt(raw, lo, hi, fallback) {
+  const n = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(lo, Math.min(hi, n));
+}
+
 async function proxyBelief(req, res) {
   // /belief/health and /belief/model → sidecar on 127.0.0.1:18790
   const sub = req.url.replace(/^\/belief/, "") || "/health";
@@ -1433,6 +1461,8 @@ const server = http.createServer((req, res) => {
     if (req.url.startsWith("/tinder/matches"))  return handleTinderMatches(req, res);
   }
   if (req.url === "/affect")                  return handleAffect(req, res);
+  if (req.url === "/affect/history" || req.url.startsWith("/affect/history?"))
+                                              return handleAffectHistory(req, res);
   if (req.url === "/skills")                  return handleSkills(req, res);
   if (req.url === "/causal")                  return handleCausal(req, res);
   if (req.url === "/motivation/stats")        return handleMotivationStats(req, res);

--- a/supabase/migrations/064_affect_history_rpc.sql
+++ b/supabase/migrations/064_affect_history_rpc.sql
@@ -1,0 +1,121 @@
+-- Migration 064 — affect_history RPCs for the tuning-telemetry surface.
+--
+-- Issue #11 phase 10 (post-observation tuning pass) needs a data-backed
+-- view of how compute_affect() actually behaves over time before we touch
+-- the constants in compute_affect(). agent_affect_history (mig 062 + 063
+-- grants) has the rows; this migration exposes two read-only RPCs:
+--
+--   1. affect_history_series(p_hours, p_bucket_minutes)
+--      Aggregated time-series for charting — average each dimension per
+--      bucket. Returns the last p_hours of compute_affect rows.
+--
+--   2. affect_history_triggers(p_hours)
+--      Per-trigger_event breakdown — which event types are firing
+--      compute_affect(), how often, and what affect they produce on
+--      average. This is the actual tuning input: weights that look right
+--      in isolation can still misfire when one trigger dominates.
+--
+-- Both RPCs are STABLE, return JSONB, and are GRANTed to anon so the
+-- dashboard server (which uses the service-role JWT but goes through the
+-- same PostgREST surface) can hit them. snapshot rows are excluded — they
+-- represent the pre-pivot anchor, not live compute_affect output.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION affect_history_series(
+  p_hours          INT DEFAULT 168,
+  p_bucket_minutes INT DEFAULT 60
+)
+RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+  WITH params AS (
+    SELECT GREATEST(1, p_hours)              AS hours,
+           GREATEST(1, p_bucket_minutes)     AS bucket_min
+  ),
+  windowed AS (
+    SELECT h.*
+    FROM agent_affect_history h, params p
+    WHERE h.source = 'compute_affect'
+      AND h.computed_at >= NOW() - (p.hours || ' hours')::interval
+  ),
+  bucketed AS (
+    SELECT
+      to_timestamp(
+        floor(extract(epoch FROM w.computed_at) / (p.bucket_min * 60))
+        * (p.bucket_min * 60)
+      ) AS bucket_at,
+      avg(w.curiosity)    AS curiosity,
+      avg(w.frustration)  AS frustration,
+      avg(w.satisfaction) AS satisfaction,
+      avg(w.confidence)   AS confidence,
+      avg(w.valence)      AS valence,
+      avg(w.arousal)      AS arousal,
+      count(*)            AS samples
+    FROM windowed w, params p
+    GROUP BY 1
+  )
+  SELECT jsonb_build_object(
+    'hours',          (SELECT hours FROM params),
+    'bucket_minutes', (SELECT bucket_min FROM params),
+    'series',         COALESCE(jsonb_agg(jsonb_build_object(
+                        'at',           bucket_at,
+                        'curiosity',    curiosity,
+                        'frustration',  frustration,
+                        'satisfaction', satisfaction,
+                        'confidence',   confidence,
+                        'valence',      valence,
+                        'arousal',      arousal,
+                        'samples',      samples
+                      ) ORDER BY bucket_at), '[]'::jsonb),
+    'total_samples',  COALESCE(sum(samples), 0)
+  )
+  FROM bucketed;
+$$;
+
+CREATE OR REPLACE FUNCTION affect_history_triggers(p_hours INT DEFAULT 168)
+RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+  WITH windowed AS (
+    SELECT *
+    FROM agent_affect_history
+    WHERE source = 'compute_affect'
+      AND computed_at >= NOW() - (GREATEST(1, p_hours) || ' hours')::interval
+  ),
+  by_trigger AS (
+    SELECT
+      COALESCE(trigger_event, '(none)') AS trigger_event,
+      count(*)                          AS fires,
+      avg(curiosity)                    AS avg_curiosity,
+      avg(frustration)                  AS avg_frustration,
+      avg(satisfaction)                 AS avg_satisfaction,
+      avg(confidence)                   AS avg_confidence,
+      avg(valence)                      AS avg_valence,
+      avg(arousal)                      AS avg_arousal,
+      max(computed_at)                  AS last_at
+    FROM windowed
+    GROUP BY 1
+  )
+  SELECT jsonb_build_object(
+    'hours',    GREATEST(1, p_hours),
+    'triggers', COALESCE(jsonb_agg(jsonb_build_object(
+                  'trigger_event',    trigger_event,
+                  'fires',            fires,
+                  'avg_curiosity',    avg_curiosity,
+                  'avg_frustration',  avg_frustration,
+                  'avg_satisfaction', avg_satisfaction,
+                  'avg_confidence',   avg_confidence,
+                  'avg_valence',      avg_valence,
+                  'avg_arousal',      avg_arousal,
+                  'last_at',          last_at
+                ) ORDER BY fires DESC), '[]'::jsonb),
+    'total_fires', COALESCE(sum(fires), 0)
+  )
+  FROM by_trigger;
+$$;
+
+GRANT EXECUTE ON FUNCTION affect_history_series(INT, INT) TO anon, service_role;
+GRANT EXECUTE ON FUNCTION affect_history_triggers(INT)    TO anon, service_role;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase 10 of the issue #11 decomposition is the **post-observation tuning pass** — the formulas in `compute_affect()` (mig 062) are explicit first-pass guesses, meant to be revisited after live data accumulates. Until now, there was no surface to look at that data; this PR adds it.

- **Migration 064** — two STABLE SQL RPCs reading `agent_affect_history` (snapshots excluded):
  - `affect_history_series(hours, bucket_minutes)` — bucketed time series of the 4 dimensions + valence/arousal.
  - `affect_history_triggers(hours)` — per-`trigger_event` breakdown so we can see if one event type dominates the signal.
- **`/affect/history`** route in `dashboard-server.mjs` — proxies both RPCs. Hours clamped to 1..720, bucket to 1..1440 min.
- **Regulator tab — \"verlauf der gefühlslage\" card** — two line charts (4 dims on 0..1; valence -1..1 left axis + arousal 0..1 right axis) plus a per-trigger table. Window and bucket are dropdowns; defaults 72h × 60min.

## Already useful

First production-data view already surfaces an actionable tuning signal:

| trigger_event | fires | share | avg valence | avg satisfaction |
|---|---|---|---|---|
| memory_events:recalled | 9 | 53% | +0.82 | 0.73 |
| experiences:success | 3 | 18% | +0.82 | 0.74 |
| memory_events:agent_completed | 3 | 18% | +0.82 | 0.74 |
| experiences:unknown | 1 | 6% | +0.79 | 0.68 |
| smoke | 1 | 6% | +0.80 | 0.73 |

Recall-side observables fire compute_affect roughly 3× more often than experience-side ones — so weight choices in §arousal and §curiosity have outsize influence over the running average. Exactly the kind of finding the tuning pass should drive.

## Test plan

- [x] `node --check scripts/dashboard-server.mjs` clean
- [x] mig 064 applied to both `vectormemory` and `vectormemory_bundle` DBs
- [x] PostgREST schema cache reloaded; `/affect/history?hours=72&bucket=60` returns valid JSON with non-empty series + triggers
- [x] Regulator tab loads without errors; window/bucket dropdowns trigger reload
- [ ] Visual verification across themes (light/dark) — done via Tailnet by reviewer

## Related

- Issue #11 — compute_affect() from observables
- `docs/affect-observables.md` §Tuning notes
- Migration 062 (compute_affect) and 063 (history grants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)