### PR TITLE
feat(n3): prime_context_compact — flat bracketed format for small models (#3)

### DIFF
--- a/mcp-server/src/__tests__/context-formatter.test.ts
+++ b/mcp-server/src/__tests__/context-formatter.test.ts
@@ -1,0 +1,153 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatCompactContext,
+  estimateTokens,
+  type CompactContextInput,
+} from "../util/context-formatter.js";
+
+test("formatter — empty input renders empty string", () => {
+  const out = formatCompactContext({});
+  assert.equal(out, "");
+});
+
+test("formatter — affect-only renders [state] section", () => {
+  const out = formatCompactContext({
+    affect: { curiosity: 0.72, frustration: 0.12, confidence: 0.54 },
+  });
+  assert.match(out, /^\[state\]/);
+  assert.match(out, /curiosity 0\.72/);
+  assert.match(out, /frustration 0\.12/);
+  assert.match(out, /confidence 0\.54/);
+  assert.doesNotMatch(out, /satisfaction/);  // not provided → not rendered
+});
+
+test("formatter — section order is fixed regardless of input key order", () => {
+  const inputA: CompactContextInput = {
+    soul_hint: "memory belongs to the user",
+    affect: { curiosity: 0.5 },
+    intentions: [{ intention: "ship N3" }],
+    traits: [{ trait: "patient", polarity: 0.8 }],
+  };
+  const out = formatCompactContext(inputA);
+  const stateIdx  = out.indexOf("[state]");
+  const idIdx     = out.indexOf("[identity]");
+  const aspIdx    = out.indexOf("[aspirations]");
+  const soulIdx   = out.indexOf("[soul-hint]");
+  assert.ok(stateIdx >= 0 && idIdx > stateIdx && aspIdx > idIdx && soulIdx > aspIdx,
+    `section order broken: state=${stateIdx} id=${idIdx} asp=${aspIdx} soul=${soulIdx}`);
+});
+
+test("formatter — same input → same output (determinism)", () => {
+  const input: CompactContextInput = {
+    affect: { curiosity: 0.7, frustration: 0.2 },
+    mood: { label: "pleased", valence: 0.5, arousal: 0.3, n: 12, window_hours: 24 },
+    traits: [
+      { trait: "Wenn ein wire-literal unpinned ist, dann konstant extrahieren", polarity: 0.9, evidence_count: 3 },
+    ],
+    intentions: [{ intention: "Montag 9:00 E-Mails checken", priority: 0.6, progress: 0.4 }],
+    task_description: "ship the formatter",
+    task_experiences: [{ content: "Last refactor went smoothly because tests came first.", outcome: "success" }],
+  };
+  const a = formatCompactContext(input);
+  const b = formatCompactContext(input);
+  assert.equal(a, b);
+});
+
+test("formatter — no markdown syntax in output", () => {
+  const input: CompactContextInput = {
+    affect: { curiosity: 0.5 },
+    traits: [{ trait: "**bold trait** with markdown", polarity: 0.5 }],
+    task_memories: [{ content: "# heading-like memory" }],
+  };
+  const out = formatCompactContext(input);
+  // Section labels are bracketed, not markdown
+  assert.doesNotMatch(out, /^#\s/m);          // no heading lines
+  assert.doesNotMatch(out, /^\*\*[^*]+\*\*/m); // no bold lines (content with ** is fine)
+  // Bracketed sections present
+  assert.match(out, /^\[state\]$/m);
+  assert.match(out, /^\[identity\]$/m);
+});
+
+test("formatter — recall truncation respects per-hit char limit", () => {
+  const long = "x".repeat(500);
+  const out = formatCompactContext({
+    task_memories: [{ content: long }],
+  }, { recall_truncate: 100 });
+  // truncate keeps max-1 chars + "…"
+  const facts = out.split("\n").filter(l => l.startsWith("  1. "));
+  assert.equal(facts.length, 1);
+  assert.ok(facts[0].length <= 5 + 100, `fact line too long: ${facts[0].length}`);
+  assert.ok(facts[0].endsWith("…"));
+});
+
+test("formatter — recall_per_section caps the list length", () => {
+  const items = Array.from({ length: 20 }, (_, i) => ({ content: `memory ${i}` }));
+  const out = formatCompactContext({ task_memories: items }, { recall_per_section: 3 });
+  const factLines = out.split("\n").filter(l => /^  \d+\. /.test(l));
+  assert.equal(factLines.length, 3);
+});
+
+test("formatter — empty sections are omitted entirely", () => {
+  const out = formatCompactContext({
+    affect: { curiosity: 0.5 },
+    traits: [],            // empty
+    intentions: [],        // empty
+    task_memories: [],     // empty
+  });
+  assert.match(out, /\[state\]/);
+  assert.doesNotMatch(out, /\[identity\]/);
+  assert.doesNotMatch(out, /\[aspirations\]/);
+  assert.doesNotMatch(out, /\[facts\]/);
+});
+
+test("formatter — token budget respected even on adversarial input", () => {
+  const huge = "a".repeat(50_000);
+  const items = Array.from({ length: 50 }, () => ({ content: huge }));
+  const out = formatCompactContext({
+    affect: { curiosity: 0.5 },
+    traits: items.slice(0, 50).map(c => ({ trait: c.content, polarity: 0.5 })),
+    task_memories: items,
+    task_experiences: items,
+  });
+  // hard ceiling 6000
+  assert.ok(out.length <= 6000, `output ${out.length} chars exceeds 6000 ceiling`);
+  // token budget 1500
+  assert.ok(estimateTokens(out) <= 1500, `${estimateTokens(out)} tokens > 1500`);
+});
+
+test("formatter — issue #3 example shape", () => {
+  // Mirror the example from the issue body. We're not asserting exact text,
+  // but every documented landmark should be present.
+  const out = formatCompactContext({
+    affect: { curiosity: 0.72, frustration: 0.12, confidence: 0.54 },
+    task_memories: [
+      { content: "first memory hit" },
+      { content: "second memory hit" },
+    ],
+    intentions: [
+      { intention: "ich checke nächste Woche Montag um 9:00 Uhr meine E-Mails" },
+    ],
+    soul_hint: "ein Satz aus SOUL.md",
+  });
+  // landmarks
+  assert.match(out, /\[state\]/);
+  assert.match(out, /curiosity 0\.72/);
+  assert.match(out, /\[facts\]/);          // "erinnerungen zum Topic" → [facts]
+  assert.match(out, /\[aspirations\]/);    // "aktive Intentionen"     → [aspirations]
+  assert.match(out, /\[soul-hint\]/);
+  assert.match(out, /Montag um 9:00/);
+});
+
+test("formatter — polarity sign mapping", () => {
+  const out = formatCompactContext({
+    traits: [
+      { trait: "patient",    polarity:  0.8 },
+      { trait: "uncertain",  polarity:  0.05 },
+      { trait: "frustrated", polarity: -0.7 },
+    ],
+  });
+  assert.match(out, /  \+ patient/);
+  assert.match(out, /  · uncertain/);
+  assert.match(out, /  - frustrated/);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -57,6 +57,7 @@ import {
   resolveConflictSchema, resolveConflict,
   synthesizeConflictSchema, synthesizeConflict,
   primeContextSchema, primeContext,
+  primeContextCompactSchema, primeContextCompact,
   narrateSelfSchema, narrateSelf,
 } from "./tools/soul.js";
 import { absorbSchema, absorb } from "./tools/absorb.js";
@@ -309,6 +310,7 @@ const TOOL_PROFILE = (process.env.MYCELIUM_TOOL_PROFILE ?? "full").toLowerCase()
 
 const CORE_TOOLS = [
   "prime_context",
+  "prime_context_compact",   // N3 — flat bracketed format for small local models
   "recall",
   "remember",
   "absorb",
@@ -589,6 +591,13 @@ server.tool(
   "THE auto-prime entry point. Returns a complete first-person system-prompt prefix: current mood, identity traits, active intentions, inner tensions, (if task_description is provided) semantically relevant past experiences and memories, AND (if task_type is provided) the skills that have historically worked best for that kind of task. Use this BEFORE starting any non-trivial task.",
   primeContextSchema.shape,
   withErrorHandling((input) => primeContext(experienceService, memoryService, skillsService, primeContextSchema.parse(input)))
+);
+
+server.tool(
+  "prime_context_compact",
+  "Same data as prime_context but rendered in a flat bracketed format (no markdown) for small local models that parse **bold** and # headings as content. Hard ceiling ~1500 tokens. Sections: [state] [mood] [recent pattern] [identity] [aspirations] [tensions] [skills] [task experiences] [facts] [soul-hint]. Empty sections are omitted entirely.",
+  primeContextCompactSchema.shape,
+  withErrorHandling((input) => primeContextCompact(experienceService, memoryService, skillsService, affectService, primeContextCompactSchema.parse(input)))
 );
 
 server.tool(

--- a/mcp-server/src/tools/soul.ts
+++ b/mcp-server/src/tools/soul.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import type { ExperienceService } from "../services/experiences.js";
 import type { MemoryService } from "../services/supabase.js";
 import type { ProjectService } from "../services/projects.js";
+import type { AffectService } from "../services/affect.js";
+import { formatCompactContext, type CompactContextInput } from "../util/context-formatter.js";
 
 // ===========================================================================
 // MOOD
@@ -349,6 +351,114 @@ export async function primeContext(
   }
 
   return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+}
+
+// ===========================================================================
+// PRIME CONTEXT COMPACT — flat bracketed format for small local models
+// (issue #3, N3 of the small-model-middleware epic).
+//
+// Same data sources as primeContext, but rendered through the pure
+// formatCompactContext util. Emits no markdown syntax — small models
+// (qwen2.5-7b, gemma3-4b) parse `**bold**` and `#` headings as content.
+// Hard ceiling ~1500 tokens.
+// ===========================================================================
+export const primeContextCompactSchema = primeContextSchema;
+
+export async function primeContextCompact(
+  experienceService: ExperienceService,
+  memoryService: MemoryService,
+  skillsService: import("../services/skills.js").SkillsService,
+  affectService: AffectService,
+  input: z.infer<typeof primeContextCompactSchema>
+) {
+  const ctx = await experienceService.primeContextStatic();
+
+  let taskExperiences: Awaited<ReturnType<typeof experienceService.recall>> = [];
+  let taskMemories: Awaited<ReturnType<typeof memoryService.search>> = [];
+  if (input.task_description && input.recall_limit > 0) {
+    const [exps, mems] = await Promise.all([
+      experienceService
+        .recall(input.task_description, { limit: input.recall_limit, includeLessons: true })
+        .catch(() => []),
+      memoryService
+        .search(input.task_description, undefined, input.recall_limit, 0.6)
+        .catch(() => []),
+    ]);
+    taskExperiences = exps;
+    taskMemories    = mems;
+  }
+
+  // affect_get is best-effort; the formatter omits the section if empty.
+  const affect = await affectService.get().catch(() => null);
+
+  let skillHints: CompactContextInput["skill_hints"];
+  if (input.task_type) {
+    try {
+      const recs = await skillsService.recommend(input.task_type, 2, 3);
+      if (recs.length > 0) {
+        skillHints = {
+          task_type: input.task_type,
+          skills: recs.map((r) => ({
+            skill: r.skill,
+            success_rate: r.success_rate,
+            n_total: r.n_total,
+            n_failure: r.n_failure,
+          })),
+        };
+      }
+    } catch (err) {
+      console.error("prime_context_compact: skill_recommend failed (non-fatal):", err);
+    }
+  }
+
+  const compactInput: CompactContextInput = {
+    task_description: input.task_description,
+    affect: affect ? {
+      curiosity:    affect.curiosity,
+      frustration:  affect.frustration,
+      satisfaction: affect.satisfaction,
+      confidence:   affect.confidence,
+    } : undefined,
+    mood: {
+      label: ctx.mood.label,
+      valence: ctx.mood.valence,
+      arousal: ctx.mood.arousal,
+      n: ctx.mood.n,
+      window_hours: ctx.mood.window_hours,
+    },
+    recent_pattern: ctx.recent_pattern.last_n > 0 ? {
+      last_n: ctx.recent_pattern.last_n,
+      success_rate: ctx.recent_pattern.success_rate,
+      avg_difficulty: ctx.recent_pattern.avg_difficulty,
+    } : undefined,
+    traits: ctx.top_traits.map((t) => ({
+      trait: t.trait,
+      polarity: t.polarity,
+      evidence_count: t.evidence_count,
+    })),
+    intentions: ctx.active_intentions.map((i) => ({
+      intention: i.intention,
+      priority: i.priority,
+      progress: i.progress,
+    })),
+    conflicts: ctx.open_conflicts.slice(0, 3).map((c) => ({
+      a_trait: c.a_trait,
+      b_trait: c.b_trait,
+      polarity_diff: c.polarity_diff,
+    })),
+    skill_hints: skillHints,
+    task_experiences: taskExperiences.slice(0, input.recall_limit).map((e) => ({
+      content: e.content,
+      outcome: e.outcome,
+      kind: e.kind,
+    })),
+    task_memories: taskMemories.slice(0, input.recall_limit).map((m) => ({
+      content: m.content,
+    })),
+  };
+
+  const text = formatCompactContext(compactInput);
+  return { content: [{ type: "text" as const, text }] };
 }
 
 // ===========================================================================

--- a/mcp-server/src/util/context-formatter.ts
+++ b/mcp-server/src/util/context-formatter.ts
@@ -1,0 +1,279 @@
+/**
+ * Compact context formatter for small-model consumers (issue #3, N3 of the
+ * small-model-middleware epic).
+ *
+ * The default `prime_context` tool emits markdown that's pleasant in Claude
+ * or Cursor but small local models (qwen2.5-7b, gemma3-4b) often parse the
+ * `**bold**` and `#` headings as content rather than structure. This module
+ * is a pure function that renders the same data as flat bracketed sections
+ * with no markdown syntax — what issue #3 specifies.
+ *
+ * Pure: no I/O, no Date.now(), no randomness. Same input → same output. The
+ * caller (e.g. a `prime_context_compact` MCP tool) is responsible for
+ * gathering the data from Supabase.
+ *
+ * Token budget: hard ceiling ~1500 tokens. Estimated as ~4 chars/token, so
+ * 6000 chars of post-render text. Per-section truncation keeps the bias
+ * predictable (we never silently drop the affect block to make room for
+ * recall hits — affect comes first, recall last).
+ */
+
+export interface AffectSnapshot {
+  curiosity?:    number;
+  frustration?:  number;
+  satisfaction?: number;
+  confidence?:   number;
+  valence?:      number | null;
+  arousal?:      number | null;
+}
+
+export interface MoodSnapshot {
+  label?:        string;        // "pleased", "neutral", "frustrated", …
+  valence?:      number;
+  arousal?:      number;
+  n?:            number;
+  window_hours?: number;
+}
+
+export interface RecentPattern {
+  last_n?:         number;
+  success_rate?:   number | null;  // 0..1
+  avg_difficulty?: number | null;  // 0..1
+}
+
+export interface TraitLine {
+  trait:           string;
+  polarity:        number;        // -1..1
+  evidence_count?: number;
+}
+
+export interface IntentionLine {
+  intention: string;
+  priority?: number;              // 0..1
+  progress?: number;              // 0..1
+}
+
+export interface ConflictLine {
+  a_trait:        string;
+  b_trait:        string;
+  polarity_diff?: number;         // 0..2
+}
+
+export interface SkillLine {
+  skill:        string;
+  success_rate?: number | null;   // 0..1
+  n_total?:     number;
+  n_failure?:   number;
+}
+
+export interface RecallHit {
+  content: string;
+  outcome?: string | null;        // success, partial, failure, unknown
+  kind?: string;                  // experience | lesson | memory | …
+}
+
+export interface CompactContextInput {
+  task_description?: string;
+  affect?:            AffectSnapshot;
+  mood?:              MoodSnapshot;
+  recent_pattern?:    RecentPattern;
+  traits?:            TraitLine[];
+  intentions?:        IntentionLine[];
+  conflicts?:         ConflictLine[];
+  skill_hints?:       { task_type: string; skills: SkillLine[] };
+  task_experiences?:  RecallHit[];
+  task_memories?:     RecallHit[];
+  /** Optional final hint paragraph (e.g. a SOUL.md sentence). */
+  soul_hint?:         string;
+}
+
+export interface CompactFormatOptions {
+  /** Hard char ceiling. Default 6000 (~1500 tokens). */
+  max_chars?: number;
+  /** Max items per recall section. Default 5. */
+  recall_per_section?: number;
+  /** Max chars per recall hit (truncated with …). Default 160. */
+  recall_truncate?: number;
+  /** Max items per traits/intentions/conflicts section. Default 5. */
+  list_per_section?: number;
+}
+
+const DEFAULTS: Required<CompactFormatOptions> = {
+  max_chars:           6000,
+  recall_per_section:  5,
+  recall_truncate:     160,
+  list_per_section:    5,
+};
+
+function fmtNum(n: number | null | undefined, digits = 2): string {
+  if (n == null || !Number.isFinite(n)) return "?";
+  return n.toFixed(digits);
+}
+
+function fmtPct(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "?";
+  return `${Math.round(n * 100)}%`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)).trimEnd() + "…";
+}
+
+function polaritySign(p: number): string {
+  if (p > 0.1) return "+";
+  if (p < -0.1) return "-";
+  return "·";
+}
+
+/**
+ * Render a CompactContextInput to a flat bracketed text block.
+ *
+ * Section order is fixed (so caching keys stay stable): state · mood ·
+ * pattern · identity · aspirations · tensions · skills · task ·
+ * facts · soul-hint. Empty sections are omitted entirely (no `[state]`
+ * with nothing under it).
+ *
+ * The function is deterministic given the same input. It does NOT call
+ * `new Date()` or any global state; the timestamp belongs to the caller.
+ */
+export function formatCompactContext(
+  input: CompactContextInput,
+  opts: CompactFormatOptions = {}
+): string {
+  const o = { ...DEFAULTS, ...opts };
+  const lines: string[] = [];
+
+  // [state] — agent_affect dimensions if any are present
+  if (input.affect && hasAnyAffect(input.affect)) {
+    lines.push("[state]");
+    const a = input.affect;
+    const parts: string[] = [];
+    if (a.curiosity    != null) parts.push(`curiosity ${fmtNum(a.curiosity)}`);
+    if (a.frustration  != null) parts.push(`frustration ${fmtNum(a.frustration)}`);
+    if (a.satisfaction != null) parts.push(`satisfaction ${fmtNum(a.satisfaction)}`);
+    if (a.confidence   != null) parts.push(`confidence ${fmtNum(a.confidence)}`);
+    if (a.valence      != null) parts.push(`valence ${fmtNum(a.valence)}`);
+    if (a.arousal      != null) parts.push(`arousal ${fmtNum(a.arousal)}`);
+    lines.push("  " + parts.join("  "));
+    lines.push("");
+  }
+
+  // [mood] — episodic mood from experiences (orthogonal to affect)
+  if (input.mood && (input.mood.label || (input.mood.n ?? 0) > 0)) {
+    const m = input.mood;
+    const window = m.window_hours ? `${m.window_hours}h` : "recent";
+    if ((m.n ?? 0) > 0) {
+      lines.push("[mood]");
+      lines.push(`  ${m.label ?? "neutral"} over ${window} (valence ${fmtNum(m.valence)}, arousal ${fmtNum(m.arousal)}, ${m.n} episodes)`);
+    } else {
+      lines.push("[mood]");
+      lines.push(`  quiet — no episodes in last ${window}`);
+    }
+    lines.push("");
+  }
+
+  // [recent pattern] — success-rate one-liner
+  if (input.recent_pattern && (input.recent_pattern.last_n ?? 0) > 0) {
+    const p = input.recent_pattern;
+    lines.push("[recent pattern]");
+    lines.push(`  last ${p.last_n} tasks: ${fmtPct(p.success_rate)} success, avg difficulty ${fmtNum(p.avg_difficulty)}`);
+    lines.push("");
+  }
+
+  // [identity] — soul traits
+  if (input.traits && input.traits.length) {
+    lines.push("[identity]");
+    for (const t of input.traits.slice(0, o.list_per_section)) {
+      const ev = t.evidence_count != null ? ` (ev ${t.evidence_count})` : "";
+      lines.push(`  ${polaritySign(t.polarity)} ${truncate(t.trait, 140)}${ev}`);
+    }
+    lines.push("");
+  }
+
+  // [aspirations] — active intentions
+  if (input.intentions && input.intentions.length) {
+    lines.push("[aspirations]");
+    for (const i of input.intentions.slice(0, o.list_per_section)) {
+      const meta: string[] = [];
+      if (i.priority != null) meta.push(`prio ${fmtNum(i.priority)}`);
+      if (i.progress != null) meta.push(`${fmtPct(i.progress)} done`);
+      const tail = meta.length ? `  (${meta.join(", ")})` : "";
+      lines.push(`  - ${truncate(i.intention, 160)}${tail}`);
+    }
+    lines.push("");
+  }
+
+  // [tensions] — open conflicts
+  if (input.conflicts && input.conflicts.length) {
+    lines.push("[tensions]");
+    for (const c of input.conflicts.slice(0, o.list_per_section)) {
+      const gap = c.polarity_diff != null ? `  (gap ${fmtNum(c.polarity_diff)})` : "";
+      lines.push(`  - "${truncate(c.a_trait, 80)}" vs "${truncate(c.b_trait, 80)}"${gap}`);
+    }
+    lines.push("");
+  }
+
+  // [skills] — skill recommendations for declared task_type
+  if (input.skill_hints && input.skill_hints.skills.length) {
+    lines.push(`[skills for ${input.skill_hints.task_type}]`);
+    for (const s of input.skill_hints.skills.slice(0, o.list_per_section)) {
+      const sr = fmtPct(s.success_rate);
+      const tot = s.n_total != null ? ` over ${s.n_total}` : "";
+      const fail = s.n_failure != null ? `, ${s.n_failure} fails` : "";
+      lines.push(`  - ${s.skill}: ${sr} success${tot}${fail}`);
+    }
+    lines.push("");
+  }
+
+  // [task] — applicable past experiences
+  if (input.task_experiences && input.task_experiences.length) {
+    lines.push("[task experiences]");
+    let i = 1;
+    for (const e of input.task_experiences.slice(0, o.recall_per_section)) {
+      const tag = e.kind === "lesson" ? "lesson" : (e.outcome ?? "exp");
+      lines.push(`  ${i}. [${tag}] ${truncate(e.content, o.recall_truncate)}`);
+      i += 1;
+    }
+    lines.push("");
+  }
+
+  // [facts] — applicable memories
+  if (input.task_memories && input.task_memories.length) {
+    lines.push("[facts]");
+    let i = 1;
+    for (const r of input.task_memories.slice(0, o.recall_per_section)) {
+      lines.push(`  ${i}. ${truncate(r.content, o.recall_truncate)}`);
+      i += 1;
+    }
+    lines.push("");
+  }
+
+  // [soul-hint] — single trailing sentence
+  if (input.soul_hint && input.soul_hint.trim()) {
+    lines.push("[soul-hint]");
+    lines.push(`  ${truncate(input.soul_hint.trim(), 240)}`);
+    lines.push("");
+  }
+
+  // Trim trailing blank line
+  while (lines.length && lines[lines.length - 1] === "") lines.pop();
+  let out = lines.join("\n");
+
+  // Hard ceiling — last-resort guard. The per-section caps above keep us well
+  // under 6000 chars in practice; this only fires on adversarial input.
+  if (out.length > o.max_chars) {
+    out = truncate(out, o.max_chars);
+  }
+  return out;
+}
+
+function hasAnyAffect(a: AffectSnapshot): boolean {
+  return [a.curiosity, a.frustration, a.satisfaction, a.confidence, a.valence, a.arousal]
+    .some((v) => v != null);
+}
+
+/** Rough token estimate (4 chars/token). Used by tests + budget assertions. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}


### PR DESCRIPTION
## Summary

Closes #3 (N3 of the small-model-middleware epic).

The default `prime_context` tool emits Markdown that's pleasant in Claude or Cursor but small local models (qwen2.5-7b, gemma3-4b) often parse `**bold**` and `#` headings as content rather than structure. This PR adds a parallel `prime_context_compact` MCP tool that renders the same data through a pure flat-bracketed formatter.

## What lands

### `mcp-server/src/util/context-formatter.ts` — pure deterministic formatter

`CompactContextInput` (affect, mood, traits, intentions, conflicts, skills, recall hits, soul-hint) → flat string. Section order is fixed; empty sections are omitted entirely. Hard ceiling 6000 chars / ~1500 tokens. Per-section caps keep the bias predictable — affect first, recall last.

### `prime_context_compact` MCP tool

Reads the same data sources as `prime_context` and feeds them through the formatter. Added to `CORE_TOOLS` so `MYCELIUM_TOOL_PROFILE=core` now exposes **6 tools** — back at the count the README/N1 documents.

### Tests

11 tests cover: empty input, section ordering, determinism, no-markdown invariant, recall truncation, list caps, empty-sections-omitted, token-budget enforcement on adversarial input, polarity sign mapping, and the literal issue-#3 example shape.

## Live output sample (from the running MCP server)

\`\`\`
[state]
  curiosity 0.50  frustration 0.33  satisfaction 0.33  confidence 0.89

[mood]
  pleased over 24h (valence 0.58, arousal 0.36, 24 episodes)

[recent pattern]
  last 10 tasks: 100% success, avg difficulty 0.39

[identity]
  + Wenn ein event-type Wire-Literal unpinned ist, dann konstant extrahieren … (ev 3)
  + Folge dem etablierten Muster: Extrahiere reine Helferfunktionen … (ev 3)
  …

[aspirations]
  - ich checke nächste Woche Montag um 9:00 Uhr meine E-Mails  (prio 0.60, 40% done)

[tensions]
  - "Folge dem etablierten Muster …" vs "Ich habe gelernt …"  (gap 0.50)
  …

[task experiences]
  1. [success] Issue #11 tick: pinned experiences.reflected client-input invariant …
  …

[facts]
  1. KOLLABORATIONS-REGEL (Reed 2026-04-23, Autonomy-Mode) …
  …
\`\`\`

**2616 Zeichen / ~654 Tokens** — gut unter dem 1500-Token-Ceiling.

## Test plan

- [x] 194/194 unit tests pass (11 new + 183 existing)
- [x] `MYCELIUM_TOOL_PROFILE=core` exposes 6 tools incl. `prime_context_compact`
- [x] E2E call against live DB returns flat block, no markdown
- [x] Token estimate stays < 1500 on real data
- [ ] Reed sanity-checks the section labels (issue spec said `[innerer Zustand]` German; PR uses English `[state]` to match the rest of the prime_context surface) — flippable

## Follow-ups (not in this PR)

- The data-gathering inside `primeContext` and `primeContextCompact` is duplicated. Refactor into a shared builder once a third consumer appears.
- Phase-2 of N3 could add a `lang: "de" | "en"` switch for German section labels — only needed once a small German-only model becomes the primary consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)