### PR TITLE
feat(n8): conservative regex fact extractor (#8)

### DIFF
--- a/mcp-server/src/__tests__/fact-extractor.test.ts
+++ b/mcp-server/src/__tests__/fact-extractor.test.ts
@@ -1,0 +1,162 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractFacts, extractFactTexts, type FactHit } from "../util/fact-extractor.js";
+
+// ---------------------------------------------------------------------------
+// Unit-level tests for individual patterns
+// ---------------------------------------------------------------------------
+
+test("ich habe gelernt — colon variant", () => {
+  const hits = extractFacts("Ich habe gelernt: keine Bastel-Lösungen, immer den sauberen Weg gehen.");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].pattern, "ich_habe_gelernt");
+  assert.equal(hits[0].text, "keine Bastel-Lösungen, immer den sauberen Weg gehen");
+});
+
+test("ich habe gelernt — comma+dass variant", () => {
+  const hits = extractFacts("Ich habe gelernt, dass Migrations immer auf beiden DBs angewandt werden müssen.");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].text, "Migrations immer auf beiden DBs angewandt werden müssen");
+});
+
+test("merk dir — colon variant", () => {
+  const hits = extractFacts("Merk dir: Reed will keine Markdown-Antworten von kleinen Modellen.");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].pattern, "merk_dir");
+  assert.equal(hits[0].text, "Reed will keine Markdown-Antworten von kleinen Modellen");
+});
+
+test("wichtig — colon-delimited only", () => {
+  const hits = extractFacts("Wichtig: agent_neurochemistry.history hatte einen Wrapper-Bug.");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].text, "agent_neurochemistry.history hatte einen Wrapper-Bug");
+});
+
+test("@remember — annotation style", () => {
+  const hits = extractFacts("Note for the next session — @remember PostgREST cache muss nach migration NOTIFY'd werden.");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].pattern, "at_remember");
+  assert.equal(hits[0].text, "PostgREST cache muss nach migration NOTIFY'd werden.");
+});
+
+test("note to self — English variant", () => {
+  const hits = extractFacts("Note to self: never amend a published commit without checking pre-commit hooks.");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].pattern, "note_to_self");
+});
+
+test("multiple patterns in one message — preserves source order", () => {
+  const msg = [
+    "Wichtig: PR #56 schloss den Affect-Loop.",
+    "Ich habe gelernt: Phase-3 hatte den neurochem-Pfad gekappt.",
+    "@remember mig 065 wraps that.",
+  ].join(" ");
+  const hits = extractFacts(msg);
+  assert.equal(hits.length, 3);
+  assert.equal(hits[0].pattern, "wichtig");
+  assert.equal(hits[1].pattern, "ich_habe_gelernt");
+  assert.equal(hits[2].pattern, "at_remember");
+});
+
+test("empty/whitespace input returns no hits", () => {
+  assert.deepEqual(extractFacts(""), []);
+  assert.deepEqual(extractFacts("   \n  \t"), []);
+});
+
+test("determinism — same input twice", () => {
+  const msg = "Ich habe gelernt: tests first. Wichtig: kein Markdown.";
+  const a = extractFacts(msg);
+  const b = extractFacts(msg);
+  assert.deepEqual(a, b);
+});
+
+test("RegExp lastIndex isolation — repeat calls don't leak state", () => {
+  const msg = "Ich habe gelernt: das hier merkt sich der Agent.";
+  for (let i = 0; i < 3; i++) {
+    const hits = extractFacts(msg);
+    assert.equal(hits.length, 1, `iteration ${i}: expected 1 hit, got ${hits.length}`);
+  }
+});
+
+test("extractFactTexts — convenience returns text strings only", () => {
+  const out = extractFactTexts("Ich habe gelernt: x. Wichtig: y.");
+  assert.deepEqual(out, ["x", "y"]);
+});
+
+// ---------------------------------------------------------------------------
+// Precision benchmark — issue #8 acceptance criterion
+//
+// 20 conversation snippets, half intentionally true positives (a real fact
+// signal that SHOULD be captured), half adversarial (the trigger phrase is
+// present but in a context that should NOT count — e.g. "die wichtige Frage
+// ist…", a quoted past statement, etc.).
+//
+// Precision = TP / (TP + FP). Target: ≥ 0.80.
+// Recall is secondary by design — the issue explicitly chose precision.
+// ---------------------------------------------------------------------------
+
+interface Sample {
+  msg:           string;
+  is_positive:   boolean;
+  /** Optional substring expected in the captured text, when is_positive. */
+  expect_text?:  string;
+}
+
+const SAMPLES: Sample[] = [
+  // --- True positives (should produce ≥1 hit with the expected text) ---
+  { msg: "Ich habe gelernt: PRs immer mit Test-Plan dokumentieren.",                            is_positive: true,  expect_text: "PRs immer mit Test-Plan" },
+  { msg: "Merk dir: Reed mag flat-bracketed Format ohne Markdown.",                              is_positive: true,  expect_text: "Reed mag flat-bracketed" },
+  { msg: "Wichtig: agent_affect ist ein Singleton, kein Per-User-Record.",                       is_positive: true,  expect_text: "Singleton" },
+  { msg: "Folgesession: @remember mig 064 ist live, mig 065 schließt den loop.",                 is_positive: true,  expect_text: "mig 064 ist live" },
+  { msg: "Note to self: stop suggesting destructive git ops without confirmation.",             is_positive: true,  expect_text: "stop suggesting destructive" },
+  { msg: "Ich habe gelernt, dass sleep > 300s den Prompt-Cache verlässt.",                       is_positive: true,  expect_text: "sleep > 300s" },
+  { msg: "Wichtig: bei jedem record_experience valence UND arousal ehrlich setzen.",             is_positive: true,  expect_text: "valence UND arousal" },
+  { msg: "merk dir, openclaw bleibt authority — mycelium ist nur die memory-Schicht.",           is_positive: true,  expect_text: "openclaw bleibt authority" },
+  { msg: "@remember claudeMd is the auto-loaded context file, settings.json is for hooks",       is_positive: true,  expect_text: "claudeMd" },
+  { msg: "Ich habe gelernt: SELECT * mit jsonb_array_elements wickelt rekursiv ein.",            is_positive: true,  expect_text: "SELECT *" },
+
+  // --- True negatives (the trigger word is present but the context is wrong) ---
+  { msg: "Die wichtige Frage ist, ob der Reverse-Loop funktioniert.",                            is_positive: false },
+  { msg: "Was hast du heute gelernt? — Ich habe gelernt: nichts heute, war frei.",               is_positive: true,  expect_text: "nichts heute, war frei" },
+  // ↑ This one is technically positive — the user stated a fact. Keep as TP.
+  { msg: "Wir wissen, was wichtig ist im Code-Review.",                                          is_positive: false },
+  { msg: "Stell dir das mal vor — was würdest du merken?",                                       is_positive: false },
+  { msg: "@anthropic ist ein anderer Tag, nicht @remember.",                                     is_positive: false },
+  { msg: "Note: that thread had no actionable items.",                                           is_positive: false },
+  { msg: "Wichtige Werte sind in env vars; siehe .mcp.json.",                                    is_positive: false },
+  { msg: "Sie merkt dir das schon, keine Sorge.",                                                is_positive: false },
+  { msg: "Ich glaube, das hat noch keiner gelernt — also kein Take-away.",                       is_positive: false },
+  { msg: "Wichtig zu wissen: ist auch ein gängiger Ausdruck.",                                   is_positive: false },
+  // ↑ no colon → should NOT match `wichtig`. Verifies the colon-required rule.
+];
+
+test("precision benchmark — ≥80% on 20 conversation snippets", () => {
+  let tp = 0, fp = 0, fn = 0;
+
+  for (const s of SAMPLES) {
+    const hits = extractFacts(s.msg);
+    const matched = hits.length > 0;
+
+    if (matched && s.is_positive) {
+      tp += 1;
+      if (s.expect_text) {
+        const found = hits.some((h: FactHit) => h.text.includes(s.expect_text!));
+        assert.ok(found, `expected text "${s.expect_text}" in hits for: "${s.msg}" — got ${JSON.stringify(hits)}`);
+      }
+    } else if (matched && !s.is_positive) {
+      fp += 1;
+      console.error(`FP: "${s.msg}" → ${JSON.stringify(hits)}`);
+    } else if (!matched && s.is_positive) {
+      fn += 1;
+    }
+    // !matched && !s.is_positive → TN, ignored
+  }
+
+  const precision = tp / Math.max(1, tp + fp);
+  const recall    = tp / Math.max(1, tp + fn);
+  console.log(`benchmark: tp=${tp} fp=${fp} fn=${fn} → precision=${precision.toFixed(2)} recall=${recall.toFixed(2)}`);
+
+  assert.ok(precision >= 0.80, `precision ${precision.toFixed(2)} < 0.80 target (tp=${tp}, fp=${fp})`);
+  // Sanity floor on recall — if it dropped to 0 we'd pass precision but extract nothing.
+  assert.ok(recall >= 0.50, `recall ${recall.toFixed(2)} < 0.50 sanity floor (tp=${tp}, fn=${fn})`);
+});

--- a/mcp-server/src/util/fact-extractor.ts
+++ b/mcp-server/src/util/fact-extractor.ts
@@ -1,0 +1,133 @@
+/**
+ * Conservative regex-based fact extractor (issue #8, N8 of the
+ * small-model-middleware epic).
+ *
+ * Goal: detect sentences that the user explicitly marked as
+ * memory-worthy, without LLM in the loop. Auto-Absorb (N4) calls this
+ * over each user message; matches become MCP `absorb` calls.
+ *
+ * Design constraint: very few, very safe patterns. Better to miss 10% of
+ * memory-relevant statements than to flood the memory base with noise.
+ * The acceptance criterion (#8) is precision ≥ 80% on a 20-snippet
+ * benchmark — recall is explicitly secondary.
+ *
+ * Pure: no I/O, no globals, no Date.now(). Same input → same output.
+ */
+
+export type FactPattern =
+  | "merk_dir"
+  | "wichtig"
+  | "at_remember"
+  | "ich_habe_gelernt"
+  | "note_to_self";
+
+export interface FactHit {
+  pattern:        FactPattern;
+  /** The captured fact text — what should land in `absorb`. Trimmed, no trigger phrase. */
+  text:           string;
+  /** 0..1; pattern-level prior, not a learned probability. */
+  confidence:     number;
+  /** Char offset in the original input (start of the trigger phrase). */
+  offset:         number;
+}
+
+interface PatternDef {
+  id:        FactPattern;
+  /** RegExp must have a single capture group around the fact text. Case-insensitive. */
+  re:        RegExp;
+  /** Pattern-level prior. Calibrated by the benchmark snippet set. */
+  baseConf:  number;
+}
+
+/**
+ * The five trigger patterns specified by issue #8.
+ *
+ * Common rules:
+ * - Anchored at sentence start (^ inside an `m` flag) OR after `.!?` whitespace
+ *   so we don't catch them mid-sentence ("die wichtige Frage ist…" should NOT
+ *   match the `wichtig` trigger).
+ * - The captured fact extends to the end of the line / next sentence break.
+ * - DOTALL is intentionally OFF — facts are line-bounded; multi-line content
+ *   would need a stronger trigger anyway.
+ */
+const PATTERNS: PatternDef[] = [
+  {
+    id: "ich_habe_gelernt",
+    // "ich habe gelernt: …" or "ich habe gelernt, dass …"
+    re: /(?:^|(?<=[.!?]\s))\s*ich\s+habe\s+gelernt[:,]\s*(?:dass\s+)?(.+?)(?:[.!?](?:\s|$)|$)/gim,
+    baseConf: 0.9,
+  },
+  {
+    id: "merk_dir",
+    // "merk dir: …" / "merk dir, …" — sentence start only.
+    // Excludes "merk dir das" without colon/comma to avoid imperatives that
+    // continue past "dir" with arbitrary content.
+    re: /(?:^|(?<=[.!?]\s))\s*merk\s+dir[:,]\s*(.+?)(?:[.!?](?:\s|$)|$)/gim,
+    baseConf: 0.9,
+  },
+  {
+    id: "wichtig",
+    // "wichtig: …" — colon-delimited. Bare "wichtig," is too noisy
+    // ("wichtig, dass du kommst" → conversational filler), so colon required.
+    re: /(?:^|(?<=[.!?]\s))\s*wichtig:\s*(.+?)(?:[.!?](?:\s|$)|$)/gim,
+    baseConf: 0.85,
+  },
+  {
+    id: "at_remember",
+    // "@remember …" — explicit annotation, very high signal.
+    // Captures until end of line (no terminal punctuation needed because the
+    // annotation itself is the marker — the user often writes it as a tag).
+    re: /(?:^|\s)@remember\s+(.+?)(?:\n|$)/gim,
+    baseConf: 0.95,
+  },
+  {
+    id: "note_to_self",
+    // "note to self: …" — English variant.
+    re: /(?:^|(?<=[.!?]\s))\s*note\s+to\s+self[:,]\s*(.+?)(?:[.!?](?:\s|$)|$)/gim,
+    baseConf: 0.9,
+  },
+];
+
+/**
+ * Extract memory-worthy fact statements from a user message.
+ *
+ * Returns hits in original order (offset-ascending). Multiple matches of the
+ * same pattern in one message are all returned; deduplication is the
+ * caller's job (Auto-Absorb collapses identical text).
+ *
+ * The captured text is trimmed but not otherwise normalised — the caller
+ * should run absorb's existing classification/embedding over it.
+ */
+export function extractFacts(input: string): FactHit[] {
+  if (!input || input.length === 0) return [];
+  const hits: FactHit[] = [];
+  for (const def of PATTERNS) {
+    // Important: clone the RegExp per call so the lastIndex state from a
+    // previous call doesn't leak. The module-level `re` carries `g` flag.
+    const re = new RegExp(def.re.source, def.re.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(input)) !== null) {
+      const text = (m[1] ?? "").trim();
+      if (text.length === 0) continue;
+      hits.push({
+        pattern:    def.id,
+        text,
+        confidence: def.baseConf,
+        offset:     m.index,
+      });
+      // Guard against zero-length matches infinite-looping (unlikely with
+      // these patterns but defensive).
+      if (m.index === re.lastIndex) re.lastIndex += 1;
+    }
+  }
+  hits.sort((a, b) => a.offset - b.offset);
+  return hits;
+}
+
+/**
+ * Convenience: just the captured text strings, in order. Useful for callers
+ * that don't need pattern provenance — most of Auto-Absorb does.
+ */
+export function extractFactTexts(input: string): string[] {
+  return extractFacts(input).map((h) => h.text);
+}


### PR DESCRIPTION
## Summary

Closes #8 (N8 of the small-model-middleware epic).

Pure regex-based extractor for the Auto-Absorb pipeline (N4): a user message goes in, a list of memory-worthy fact statements comes out. No LLM in the loop, no I/O, no globals — same input → same output.

## Five trigger patterns

| pattern | example | confidence prior |
|---|---|---|
| `ich_habe_gelernt` | `Ich habe gelernt: PRs immer mit Test-Plan dokumentieren.` | 0.90 |
| `merk_dir` | `Merk dir: Reed mag flat-bracketed Format ohne Markdown.` | 0.90 |
| `wichtig` | `Wichtig: agent_affect ist ein Singleton.` (colon required) | 0.85 |
| `at_remember` | `@remember mig 064 ist live.` (annotation, highest signal) | 0.95 |
| `note_to_self` | `Note to self: stop suggesting destructive git ops.` | 0.90 |

Each pattern anchors at sentence start (^/m or after `.!? `) so trigger phrases mid-sentence don't match. `wichtig` requires a colon — bare `wichtig,` was too noisy ("wichtig, dass du kommst").

## Acceptance benchmark (issue #8 §Akzeptanzkriterium)

20 conversation snippets, precision target **≥ 80%**:

| | count |
|---|---|
| true positives detected | 10 |
| false positives | **0** |
| false negatives | 1 |
| **precision** | **1.00** |
| **recall** | **0.91** |

Recall is explicitly secondary by design — the issue picks "miss 10% rather than flood the memory base with noise."

## Adversarial coverage

The 9 negatives in the benchmark exercise the failure modes the issue calls out:

- "Die **wichtige** Frage ist…" — adjective in subject, not trigger
- "Wir wissen, was **wichtig** ist…" — predicate, not trigger
- "**Wichtig** zu wissen: ist auch ein gängiger Ausdruck." — colon-rule (no `wichtig:` prefix → no match)
- "**@anthropic** ist ein anderer Tag, nicht @remember." — different tag, must not match
- "Sie **merkt** dir das schon" — third person, not imperative
- … etc.

All 9 produce zero hits.

## Determinism

RegExps with the `g` flag carry mutable `lastIndex`. The implementation clones the source RegExp per call so repeat calls on identical input always return identical hits. A test pins this with three sequential calls.

## Test plan

- [x] 206/206 unit tests pass (12 new + 194 existing)
- [x] Each trigger pattern has a positive-shape test
- [x] Precision benchmark over 20 snippets meets target
- [x] Determinism verified on repeat calls
- [x] RegExp `lastIndex` leak guarded

## Out of scope

- **N4 Auto-Absorb wiring** — the post-processor that calls `extractFacts` over each LLM output and feeds matches into MCP `absorb`. Depends on N2 (Reverse-Proxy).
- **3B-model upgrade path** mentioned in the issue body. Premature — we should run the regex variant in production for a few weeks first and only upgrade if observed recall drops below tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)