### PR TITLE
docs(n6): two-instance pattern for mycelium-full + mycelium-core (#6)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -242,23 +242,46 @@ mycelium/
 
 Mycelium ist darauf ausgelegt, **ohne Cloud-LLM** auf einem Mac mini oder Laptop mit 16 GB RAM zu laufen. Damit ein 7-8B-Modell (z.B. `qwen3:8b` via Ollama) nicht an der Tool-Schema-Last erstickt, bietet der MCP-Server ein fokussiertes Profil:
 
-**`MYCELIUM_TOOL_PROFILE=core`** → nur die 5 essentiellen Tools werden registriert (`prime_context`, `recall`, `remember`, `absorb`, `digest`). Standard `full` registriert alle ~90 — für Claude/Codex geeignet, aber ~18k Token reines Schema sind für ein 8B-Modell zu viel.
+**`MYCELIUM_TOOL_PROFILE=core`** → nur die 6 essentiellen Tools werden registriert (`prime_context`, `prime_context_compact`, `recall`, `remember`, `absorb`, `digest`). Standard `full` registriert alle ~90 — für Claude/Codex geeignet, aber ~18k Token reines Schema sind für ein 8B-Modell zu viel.
 
-In der MCP-Config (`.mcp.json` oder die Settings deines Clients):
+`prime_context_compact` rendert dieselben Daten wie `prime_context` in einem flachen Bracket-Format ohne Markdown, das kleine lokale Modelle zuverlässiger parsen (siehe [Issue #3](../../issues/3)).
+
+### Zwei Profile parallel (empfohlen)
+
+Wenn du **beides** auf derselben Maschine fährst — ein Cloud-Modell (Claude / Codex) und ein lokales 7-8B-Modell — dann trag zwei MCP-Server-Einträge nebeneinander ein. Jeder Client verbindet sich mit dem Profil, das zu seiner Größe passt — kein Profil-Switchen, kein Konflikt. Beide Prozesse teilen sich denselben Supabase + Ollama-Backend.
 
 ```json
-"mycelium-core": {
-  "command": "node",
-  "args": ["/absolute/path/to/mycelium/mcp-server/dist/index.js"],
-  "env": {
-    "MYCELIUM_TOOL_PROFILE": "core",
-    "SUPABASE_URL": "http://localhost:54321",
-    "SUPABASE_KEY": "...",
-    "OLLAMA_URL": "http://localhost:11434",
-    "EMBEDDING_MODEL": "nomic-embed-text"
+{
+  "mcpServers": {
+    "mycelium-full": {
+      "command": "node",
+      "args": ["/absolute/path/to/mycelium/mcp-server/dist/index.js"],
+      "env": {
+        "MYCELIUM_TOOL_PROFILE": "full",
+        "MYCELIUM_AGENT_LABEL": "main-full",
+        "SUPABASE_URL": "http://localhost:54321",
+        "SUPABASE_KEY": "...",
+        "OLLAMA_URL": "http://localhost:11434",
+        "EMBEDDING_MODEL": "nomic-embed-text"
+      }
+    },
+    "mycelium-core": {
+      "command": "node",
+      "args": ["/absolute/path/to/mycelium/mcp-server/dist/index.js"],
+      "env": {
+        "MYCELIUM_TOOL_PROFILE": "core",
+        "MYCELIUM_AGENT_LABEL": "main-core",
+        "SUPABASE_URL": "http://localhost:54321",
+        "SUPABASE_KEY": "...",
+        "OLLAMA_URL": "http://localhost:11434",
+        "EMBEDDING_MODEL": "nomic-embed-text"
+      }
+    }
   }
 }
 ```
+
+Wenn du nur eine Modell-Klasse fährst, kannst du den anderen Eintrag weglassen. Beide Prozesse erscheinen einzeln im Agents-Tab des Dashboards — du siehst dort, welcher Client auf welchem Profil läuft.
 
 ### RAM-Tuning bei mehreren Modellen
 

--- a/README.md
+++ b/README.md
@@ -258,23 +258,46 @@ mycelium/
 
 Mycelium is designed to run **without a cloud LLM** on a Mac mini or laptop with 16 GB RAM. So that a 7–8B model (e.g. `qwen3:8b` via Ollama) doesn't choke on the tool schema load, the MCP server offers a focused profile:
 
-**`MYCELIUM_TOOL_PROFILE=core`** → only the 5 essential tools get registered (`prime_context`, `recall`, `remember`, `absorb`, `digest`). The default `full` registers everything — fine for Claude / Codex, but ~18k tokens of pure schema is too much for an 8B model.
+**`MYCELIUM_TOOL_PROFILE=core`** → only the 6 essential tools get registered (`prime_context`, `prime_context_compact`, `recall`, `remember`, `absorb`, `digest`). The default `full` registers everything — fine for Claude / Codex, but ~18k tokens of pure schema is too much for an 8B model.
 
-In the MCP config (`.mcp.json` or your client's settings):
+`prime_context_compact` renders the same data as `prime_context` in a flat bracketed format with no markdown, which small local models parse more reliably (see [issue #3](../../issues/3)).
+
+### Two profiles in parallel (recommended)
+
+If you run **both** a cloud-grade model (Claude / Codex) and a local 7–8B model on the same machine, declare two MCP server entries side-by-side. Each client connects to whichever profile fits its size — no profile-switching, no conflict. Both processes share the same Supabase + Ollama backend.
 
 ```json
-"mycelium-core": {
-  "command": "node",
-  "args": ["/absolute/path/to/mycelium/mcp-server/dist/index.js"],
-  "env": {
-    "MYCELIUM_TOOL_PROFILE": "core",
-    "SUPABASE_URL": "http://localhost:54321",
-    "SUPABASE_KEY": "...",
-    "OLLAMA_URL": "http://localhost:11434",
-    "EMBEDDING_MODEL": "nomic-embed-text"
+{
+  "mcpServers": {
+    "mycelium-full": {
+      "command": "node",
+      "args": ["/absolute/path/to/mycelium/mcp-server/dist/index.js"],
+      "env": {
+        "MYCELIUM_TOOL_PROFILE": "full",
+        "MYCELIUM_AGENT_LABEL": "main-full",
+        "SUPABASE_URL": "http://localhost:54321",
+        "SUPABASE_KEY": "...",
+        "OLLAMA_URL": "http://localhost:11434",
+        "EMBEDDING_MODEL": "nomic-embed-text"
+      }
+    },
+    "mycelium-core": {
+      "command": "node",
+      "args": ["/absolute/path/to/mycelium/mcp-server/dist/index.js"],
+      "env": {
+        "MYCELIUM_TOOL_PROFILE": "core",
+        "MYCELIUM_AGENT_LABEL": "main-core",
+        "SUPABASE_URL": "http://localhost:54321",
+        "SUPABASE_KEY": "...",
+        "OLLAMA_URL": "http://localhost:11434",
+        "EMBEDDING_MODEL": "nomic-embed-text"
+      }
+    }
   }
 }
 ```
+
+If you only run one tier of model, drop the other entry. Both processes appear separately in the dashboard's agents tab so you can see which profile a client is on.
 
 ### RAM tuning when running multiple models
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,6 +23,13 @@ automatisch und kann seine Werkzeuge (`remember`, `recall`, `prime_context`,
 > den absoluten Pfad zu deinem mycelium-Checkout — also den Ordner, in dem
 > `mcp-server/dist/index.js` liegt (z.B. `/Users/reed/mycelium`).
 
+> **Großes Modell + kleines lokales Modell parallel?** Trag zwei
+> mycelium-Einträge nebeneinander ein — `mycelium-full` (alle ~90 Tools)
+> für Claude/Codex und `mycelium-core` (6 Tools) für ein 7-8B-Modell wie
+> qwen3:8b. Beide Prozesse teilen sich denselben Backend, kein Konflikt.
+> Vollständiges Beispiel im README unter [„Betrieb auf schmaler
+> Hardware"](../README.de.md#betrieb-auf-schmaler-hardware-16-gb-ram).
+
 ---
 
 ## Claude Code

--- a/install.sh
+++ b/install.sh
@@ -397,6 +397,10 @@ step_final() {
          }
        }
 
+   Running a small local model alongside (qwen3:8b, gemma3:4b)? See README
+   §"Running on constrained hardware" for the two-profile pattern
+   (mycelium-full + mycelium-core side-by-side).
+
    Then restart your agent. ${C_GREEN}Done.${C_RESET}
 
 EOF


### PR DESCRIPTION
## Summary

Closes #6 — config-only path for Option 1 from the [research comment](https://github.com/Dewinator/mycelium/issues/6#issuecomment-4324856338). Zero new code; same MCP server binary, two `.mcp.json` entries side-by-side, distinct `MYCELIUM_TOOL_PROFILE` env per entry. Same Supabase + Ollama backend.

## What changes

| File | Change |
|---|---|
| `README.md` | §"Running on constrained hardware" gains a "Two profiles in parallel" subsection with the full two-entry example. Tool count 5 → 6 (post-N3). |
| `README.de.md` | Same in German. |
| `docs/setup.md` | Top-of-document note pointing readers running parallel models at the README section. |
| `install.sh` | Quick-example block gets a one-liner referencing the two-profile pattern. |

## Why two-instance over per-session filter

- **Zero code** — the filter monkey-patch (`mcp-server/src/index.ts:342-350`) operates at server startup. Per-session filtering would require dropping that abstraction and rewiring all 84 `server.tool()` calls.
- **Operationally honest** — both processes are visible in `launchctl`, `ps`, and the dashboard's agents tab. Distinct `MYCELIUM_AGENT_LABEL` ensures they don't collide on the unique `agents.label` constraint.
- **Reversible** — if a real use case later wants the same client (e.g. Claude Code) to expose different tool sets per workspace, per-session filtering is additive on top.

## Test plan

- [x] `bash -n install.sh` — syntax ok
- [x] Markdown renders cleanly in GitHub preview
- [x] German + English README sections stay in sync
- [x] Two-entry config example uses distinct `MYCELIUM_AGENT_LABEL` so the unique constraint on `agents.label` doesn't collide
- [ ] Reed verifies on his own setup that running both entries simultaneously surfaces both as live agents in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)