### PR TITLE
feat(n4): auto-absorb post-processor (#4 partial)

### DIFF
--- a/mcp-server/src/__tests__/middleware-absorber.test.ts
+++ b/mcp-server/src/__tests__/middleware-absorber.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Auto-Absorb tests — exercise the dedupe + stats logic via a stubbed
+ * embed/insert path. Live Supabase integration would couple the unit
+ * suite to the docker stack; the absorber's contract surfaces (which
+ * patterns it picks up, how it dedupes, when it gives up) are testable
+ * without DB.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractFacts } from "../util/fact-extractor.js";
+
+test("absorber — extractFacts gives the right hit count to feed the absorber", () => {
+  // Sanity: this is the contract the absorber depends on. If extractFacts
+  // changes, the absorber's per-turn count changes too — test the join.
+  const userText = "Ich habe gelernt: PRs immer mit Test-Plan dokumentieren.";
+  const assistantText = "Verstanden, ich werde das beachten. @remember test-plan-policy";
+  const userHits = extractFacts(userText);
+  const assistantHits = extractFacts(assistantText);
+  assert.equal(userHits.length, 1);
+  assert.equal(userHits[0].pattern, "ich_habe_gelernt");
+  assert.equal(assistantHits.length, 1);
+  assert.equal(assistantHits[0].pattern, "at_remember");
+});
+
+test("absorber — dedupe key collapses identical text across user/assistant sides", () => {
+  // The absorber dedupes by `${pattern}::${text.toLowerCase()}`. Verify the
+  // join here so a refactor that drops side-awareness doesn't accidentally
+  // double-count.
+  const text = "wichtiger Fakt";
+  const pattern = "wichtig";
+  const keyA = `${pattern}::${text.toLowerCase()}`;
+  const keyB = `${pattern}::${text.toLowerCase()}`;
+  assert.equal(keyA, keyB);
+  assert.notEqual(keyA, `${pattern}::${text.toUpperCase()}`); // case sensitivity matters? no — both sides lowercase
+});
+
+test("absorber — stats schema is stable", async () => {
+  // We construct an Absorber with bogus URLs and just check the stats
+  // shape. No real network calls fired.
+  const { Absorber } = await import("../middleware/absorber.js");
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:0",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:0",
+  });
+  const s = a.stats();
+  assert.equal(s.total_absorbed, 0);
+  assert.equal(s.total_skipped, 0);
+  assert.equal(s.total_failed, 0);
+  assert.equal(s.by_pattern.ich_habe_gelernt, 0);
+  assert.equal(s.by_pattern.merk_dir, 0);
+  assert.equal(s.by_pattern.wichtig, 0);
+  assert.equal(s.by_pattern.at_remember, 0);
+  assert.equal(s.by_pattern.note_to_self, 0);
+});
+
+test("absorber — failure counters increment when embed/insert errors out", async () => {
+  // Both URLs point to a dead port — embed will fail fast, every absorb
+  // attempt counts as a failure. processTurn() must NOT throw.
+  const { Absorber } = await import("../middleware/absorber.js");
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:1",  // port 1 is reserved, connection refused
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:1",
+  });
+  const r = await a.processTurn(
+    "Ich habe gelernt: tests first.",
+    "Note to self: keep mocking the network in unit tests.",
+  );
+  assert.equal(r.absorbed, 0);
+  assert.equal(r.failed, 2);             // both hits failed at embed step
+  const s = a.stats();
+  assert.equal(s.total_failed, 2);
+  assert.equal(s.total_absorbed, 0);
+});
+
+test("absorber — empty input is a no-op (no errors, no attempts)", async () => {
+  const { Absorber } = await import("../middleware/absorber.js");
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:1",
+  });
+  const r = await a.processTurn(undefined, undefined);
+  assert.equal(r.absorbed, 0);
+  assert.equal(r.skipped, 0);
+  assert.equal(r.failed, 0);
+});
+
+test("absorber — non-trigger text produces no absorbs and no failures", async () => {
+  const { Absorber } = await import("../middleware/absorber.js");
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:1",
+  });
+  // Both messages have NO trigger phrases → extractFacts returns []. The
+  // absorber should not even attempt to embed.
+  const r = await a.processTurn(
+    "wie geht es dir heute?",
+    "ich bin ein KI-modell, mir geht es gut.",
+  );
+  assert.equal(r.absorbed, 0);
+  assert.equal(r.skipped, 0);
+  assert.equal(r.failed, 0);
+});
+
+test("absorber — maxPerTurn caps how many hits are forwarded", async () => {
+  const { Absorber } = await import("../middleware/absorber.js");
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:1",
+    maxPerTurn:  2,
+  });
+  // Six trigger hits in user msg alone — cap should limit to 2.
+  const userText = [
+    "Ich habe gelernt: a.",
+    "Ich habe gelernt: b.",
+    "Ich habe gelernt: c.",
+    "Wichtig: d.",
+    "Wichtig: e.",
+    "Wichtig: f.",
+  ].join(" ");
+  const r = await a.processTurn(userText, undefined);
+  // All 2 attempted ones fail (network), but the cap prevented a 3rd attempt.
+  assert.equal(r.failed, 2);
+  assert.equal(r.absorbed, 0);
+});

--- a/mcp-server/src/middleware/absorber.ts
+++ b/mcp-server/src/middleware/absorber.ts
@@ -1,0 +1,169 @@
+/**
+ * Auto-Absorb post-processor for the small-model middleware (issue #4, N4
+ * — partial: Auto-Absorb only; Auto-Digest is a separate follow-up).
+ *
+ * The middleware (#2) sees both the user's prompt and the model's reply.
+ * After every chat turn, run the conservative regex extractor (#8) over
+ * BOTH sides and feed any matches into mycelium's memory store as
+ * lightweight `general` memories.
+ *
+ * Design constraints
+ * ------------------
+ * - **Best-effort.** Failures (Supabase down, Ollama embed slow) must NOT
+ *   delay the chat response. The proxy fires absorb in the background
+ *   without awaiting.
+ * - **Conservative.** Only N8's hard-trigger patterns. No LLM
+ *   classification.
+ * - **Process-local dedupe.** A short-TTL Set of fact-text hashes
+ *   suppresses obvious within-session repeats so the same "ich habe
+ *   gelernt: …" statement spread across a turn-by-turn back-and-forth
+ *   doesn't create N copies. Cross-process dedupe is the existing
+ *   `findSimilar` path on the MCP-server side; the nightly sleep cycle
+ *   also dedupes (mig 029-style consolidation).
+ * - **Annotated source.** Every middleware-side memory carries
+ *   `source='middleware:auto-absorb'` and `metadata.pattern=<trigger>`
+ *   so an operator (or N5 benchmark) can isolate auto-absorb's
+ *   contribution from manual `remember` calls.
+ */
+
+import { PostgrestClient } from "@supabase/postgrest-js";
+import { extractFacts, type FactPattern } from "../util/fact-extractor.js";
+import { TtlLruCache } from "./prime-cache.js";
+
+export interface AbsorberOptions {
+  supabaseUrl:    string;
+  supabaseKey:    string;
+  ollamaUrl?:     string;
+  embeddingModel?: string;
+  /** TTL for the in-process dedupe Set. Default 10min. */
+  dedupeTtlMs?:   number;
+  /** Soft cap on absorbs per chat turn — guards against pathological inputs. */
+  maxPerTurn?:    number;
+}
+
+export interface AbsorbResult {
+  absorbed: number;
+  skipped:  number;     // duplicates within process window
+  failed:   number;     // embed or insert error
+}
+
+export interface AbsorberStats {
+  total_absorbed: number;
+  total_skipped:  number;
+  total_failed:   number;
+  by_pattern:     Record<FactPattern, number>;
+}
+
+const DEFAULT_DEDUPE_TTL = 10 * 60 * 1_000;
+const DEFAULT_MAX_PER_TURN = 5;
+
+/**
+ * Stateful absorber. Per-process. Holds a tiny dedupe cache and aggregate
+ * stats. The proxy holds one instance for its lifetime.
+ */
+export class Absorber {
+  private db: PostgrestClient;
+  private ollamaUrl: string;
+  private embeddingModel: string;
+  private dedupe: TtlLruCache<true>;
+  private maxPerTurn: number;
+  private absorbedCount = 0;
+  private skippedCount  = 0;
+  private failedCount   = 0;
+  private byPattern: Record<FactPattern, number> = {
+    ich_habe_gelernt: 0, merk_dir: 0, wichtig: 0, at_remember: 0, note_to_self: 0,
+  };
+
+  constructor(opts: AbsorberOptions) {
+    this.db = new PostgrestClient(opts.supabaseUrl, {
+      headers: opts.supabaseKey
+        ? { Authorization: `Bearer ${opts.supabaseKey}`, apikey: opts.supabaseKey }
+        : {},
+    });
+    this.ollamaUrl      = opts.ollamaUrl ?? "http://127.0.0.1:11434";
+    this.embeddingModel = opts.embeddingModel ?? "nomic-embed-text";
+    this.dedupe = new TtlLruCache<true>({
+      ttlMs:   opts.dedupeTtlMs ?? DEFAULT_DEDUPE_TTL,
+      maxSize: 500,
+    });
+    this.maxPerTurn = opts.maxPerTurn ?? DEFAULT_MAX_PER_TURN;
+  }
+
+  /**
+   * Process the user + assistant texts of one chat turn. Runs in the
+   * background — the caller does not await. Errors are logged, not thrown.
+   * Returns a Promise mainly for tests; the proxy fires-and-forgets.
+   */
+  async processTurn(userText: string | undefined, assistantText: string | undefined): Promise<AbsorbResult> {
+    const result: AbsorbResult = { absorbed: 0, skipped: 0, failed: 0 };
+    const hits = [
+      ...extractFacts(userText ?? "").map((h) => ({ ...h, side: "user" as const })),
+      ...extractFacts(assistantText ?? "").map((h) => ({ ...h, side: "assistant" as const })),
+    ].slice(0, this.maxPerTurn);
+
+    for (const hit of hits) {
+      // Dedupe key: pattern + text. Same fact captured in user AND
+      // assistant within window counts once.
+      const dedupeKey = `${hit.pattern}::${hit.text.toLowerCase()}`;
+      if (this.dedupe.get(dedupeKey)) {
+        result.skipped += 1;
+        this.skippedCount += 1;
+        continue;
+      }
+      try {
+        await this.absorbOne(hit.text, hit.pattern, hit.side);
+        this.dedupe.set(dedupeKey, true);
+        result.absorbed += 1;
+        this.absorbedCount += 1;
+        this.byPattern[hit.pattern] += 1;
+      } catch (err) {
+        result.failed += 1;
+        this.failedCount += 1;
+        console.error(`[middleware] auto-absorb failed (${hit.pattern}):`,
+          err instanceof Error ? err.message : String(err));
+      }
+    }
+    return result;
+  }
+
+  stats(): AbsorberStats {
+    return {
+      total_absorbed: this.absorbedCount,
+      total_skipped:  this.skippedCount,
+      total_failed:   this.failedCount,
+      by_pattern:     { ...this.byPattern },
+    };
+  }
+
+  private async absorbOne(text: string, pattern: FactPattern, side: "user" | "assistant"): Promise<void> {
+    const embedding = await this.embed(text);
+    const { error } = await this.db
+      .from("memories")
+      .insert({
+        content:  text,
+        category: "general",
+        tags:     [`auto-absorb`, `pattern:${pattern}`, `side:${side}`],
+        embedding,
+        metadata: { pattern, side, captured_at: new Date().toISOString() },
+        source:   "middleware:auto-absorb",
+        importance: 0.3,
+        valence:    0.0,
+        arousal:    0.0,
+        pinned:     false,
+      });
+    if (error) throw new Error(error.message ?? JSON.stringify(error));
+  }
+
+  private async embed(text: string): Promise<number[]> {
+    const r = await fetch(new URL("/api/embed", this.ollamaUrl), {
+      method:  "POST",
+      headers: { "Content-Type": "application/json" },
+      body:    JSON.stringify({ model: this.embeddingModel, input: text }),
+    });
+    if (!r.ok) throw new Error(`ollama embed failed: HTTP ${r.status}`);
+    const j = (await r.json()) as { embeddings?: number[][] };
+    const v = j.embeddings?.[0];
+    if (!v) throw new Error("ollama embed returned no vector");
+    return v;
+  }
+}

--- a/mcp-server/src/middleware/proxy.ts
+++ b/mcp-server/src/middleware/proxy.ts
@@ -31,6 +31,7 @@
 
 import http from "node:http";
 import { PrimeFetcher } from "./prime-fetcher.js";
+import { Absorber } from "./absorber.js";
 import { injectContext, lastUserText, type ChatMessage } from "./inject.js";
 
 interface OllamaChatRequest {
@@ -62,6 +63,18 @@ const fetcher = new PrimeFetcher({
   embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
   recallLimit:    RECALL_LIMIT,
 });
+
+// Auto-Absorb post-processor (#4 partial — N4-Auto-Absorb only).
+// Set MYCELIUM_PROXY_AUTO_ABSORB=0 to disable. Default ON because the
+// whole point of the small-model epic is to capture learning the user
+// would otherwise have to enter manually with `remember`.
+const AUTO_ABSORB_ON = (process.env.MYCELIUM_PROXY_AUTO_ABSORB ?? "1") !== "0";
+const absorber = AUTO_ABSORB_ON ? new Absorber({
+  supabaseUrl:    SUPABASE_URL,
+  supabaseKey:    SUPABASE_KEY,
+  ollamaUrl:      OLLAMA_URL,
+  embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
+}) : null;
 
 async function readBody(req: http.IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -132,12 +145,20 @@ async function handleChat(req: http.IncomingMessage, res: http.ServerResponse): 
     });
   }
 
-  // TODO(N4): hook point for auto-digest — record session activity here so
-  // the idle-timer can fire a record_experience downstream. Not active in
-  // Phase 1.
-
+  // N4 (Auto-Absorb): conservative regex extractor over user + assistant
+  // text. Best-effort, fired in the background — must not delay the
+  // response. Auto-Digest is a separate follow-up (needs N9's session
+  // boundary state machine).
   const ct = upstream.headers.get("content-type") ?? "application/json; charset=utf-8";
   const buf = Buffer.from(await upstream.arrayBuffer());
+
+  if (absorber) {
+    const assistantText = extractAssistantText(buf, ct);
+    void absorber.processTurn(taskText, assistantText)
+      .catch((e) => console.error("[middleware] auto-absorb threw:",
+        e instanceof Error ? e.message : String(e)));
+  }
+
   res.writeHead(upstream.status, {
     "Content-Type":              ct,
     "Content-Length":            String(buf.length),
@@ -166,6 +187,7 @@ async function handleHealth(_req: http.IncomingMessage, res: http.ServerResponse
     targets: { ollama: OLLAMA_URL, supabase: SUPABASE_URL },
     upstreams: Object.assign({}, ...checks),
     cache: fetcher.cacheStats(),
+    auto_absorb: absorber ? absorber.stats() : { enabled: false },
     phase: 1,
   });
 }
@@ -185,6 +207,23 @@ const server = http.createServer((req, res) => {
   res.writeHead(404, { "Content-Type": "text/plain" });
   res.end("not found");
 });
+
+/**
+ * Pull the assistant message text out of an Ollama /api/chat response. The
+ * shape is {message: {role, content}, ...}. Returns undefined when the body
+ * isn't JSON or doesn't carry the field — auto-absorb then runs on user
+ * text only.
+ */
+function extractAssistantText(buf: Buffer, contentType: string): string | undefined {
+  if (!contentType.includes("application/json")) return undefined;
+  try {
+    const j = JSON.parse(buf.toString("utf8")) as { message?: { role?: string; content?: string } };
+    if (j.message?.role === "assistant" && typeof j.message.content === "string") {
+      return j.message.content;
+    }
+  } catch { /* best-effort */ }
+  return undefined;
+}
 
 async function passThrough(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   const upstreamUrl = new URL(req.url ?? "/", OLLAMA_URL);


### PR DESCRIPTION
## Summary

Lands the **Auto-Absorb** half of #4. Auto-Digest is a separate follow-up — it needs N9's session-boundary state machine, distinct mental model worth its own PR. This issue stays open until both halves land.

The middleware (#2) sees both prompt and reply on every chat turn. After the response is sent, run the conservative regex extractor (#8) over both sides and INSERT every hit as a lightweight \`general\` memory with full provenance.

## Live verification

Sent through the proxy:
\`\`\`
Ich habe gelernt: Auto-Absorb Tests müssen network mocken statt echte calls.
\`\`\`

~400 ms later in \`memories\`:

| field | value |
|---|---|
| content | \`Auto-Absorb Tests müssen network mocken statt echte calls\` |
| tags | \`{auto-absorb, pattern:ich_habe_gelernt, side:user}\` |
| source | \`middleware:auto-absorb\` |
| metadata.pattern | \`ich_habe_gelernt\` |

\`/health\` reports:
\`\`\`json
"auto_absorb": {
  "total_absorbed": 1,
  "total_skipped": 0,
  "total_failed": 0,
  "by_pattern": { "ich_habe_gelernt": 1, ... }
}
\`\`\`

## Constraints respected

- **Conservative.** Only N8's hard-trigger patterns. The 20-snippet precision benchmark (#8) carries over — no false-positives on adversarial input.
- **Best-effort.** \`absorber.processTurn(...)\` runs in the background after the upstream response is already sent. Embed/insert failures are logged, never propagate to the user.
- **Process-local dedupe.** A 10-min TTL set of \`\${pattern}::\${text}\` hashes suppresses within-session repeats. Cross-process dedupe stays the nightly-sleep job.
- **Annotated source.** Every memory carries \`source='middleware:auto-absorb'\` so an operator can isolate auto-absorb's contribution from manual \`remember\` calls.
- **Cap per turn** (default 5) — guards against pathological inputs.
- **Off-switch.** \`MYCELIUM_PROXY_AUTO_ABSORB=0\` disables. Default on.

## Tests

7 new tests (**234 total green**). All against the \`Absorber\` class with unreachable URLs — no live Supabase needed in the unit suite. Pinned: extractFacts join contract, dedupe key shape, stats schema, failure-counter increment when network is dead, no-op on empty input, no-op on non-trigger text, maxPerTurn cap.

## Out of scope

- **Auto-Digest** — separate PR, depends on N9's session-boundary state machine
- **Cross-process dedupe** — nightly sleep already handles it
- **3B-model classifier upgrade** mentioned in the issue body — defer until regex-precision drops below tolerance in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)