### PR TITLE
feat(n4): auto-digest — closes #4 (small-model epic core complete)

### DIFF
--- a/mcp-server/src/__tests__/middleware-digester.test.ts
+++ b/mcp-server/src/__tests__/middleware-digester.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Digester unit tests — exercise the silent-skip + advisory-lock + tick-
+ * counter logic. The actual record_experience RPC + ollama embed are stubbed
+ * by pointing the digester at unreachable URLs (port 1, reserved). All
+ * "fired" digests would land as failures; we test the routing / decision
+ * logic, not the RPC contract (the MCP server's tests cover that).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SessionTracker } from "../middleware/session-tracker.js";
+import { Digester } from "../middleware/digester.js";
+
+function freshDigester(opts: { now?: () => number; idleMs?: number } = {}) {
+  const tracker = new SessionTracker({ idleMs: opts.idleMs ?? 1000, now: opts.now });
+  const digester = new Digester(tracker, {
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:1",
+    tickMs:      999_999,           // tests call tick() manually
+  });
+  return { tracker, digester };
+}
+
+test("digester — silent session is skipped, no RPC attempt", async () => {
+  let now = 1_000_000;
+  const { tracker, digester } = freshDigester({ now: () => now });
+  // Touch with no user_present + no errors → session is silent.
+  tracker.touch({ client_key: "k", model: "qwen" });
+  now += 2000;
+  const r = await digester.tick();
+  assert.equal(r.fired, 0);
+  assert.equal(r.skipped_silent, 1);
+  assert.equal(r.failed, 0);
+  // The session must be DROPPED so a new message starts fresh.
+  assert.equal(tracker.size(), 0);
+});
+
+test("digester — non-idle sessions are not touched", async () => {
+  let now = 1_000_000;
+  const { tracker, digester } = freshDigester({ now: () => now, idleMs: 5_000 });
+  tracker.touch({ client_key: "k", user_present: true });
+  now += 1000;  // still well under idle threshold
+  const r = await digester.tick();
+  assert.equal(r.fired, 0);
+  assert.equal(r.skipped_silent, 0);
+  assert.equal(r.failed, 0);
+  assert.equal(tracker.size(), 1);
+});
+
+test("digester — non-silent + idle session attempts the RPC", async () => {
+  let now = 1_000_000;
+  const { tracker, digester } = freshDigester({ now: () => now });
+  tracker.touch({ client_key: "k", user_present: true, model: "qwen" });
+  tracker.touch({ client_key: "k", upstream_ok: true });
+  now += 2000;
+  const r = await digester.tick();
+  // Network is dead → fails. The point is: it ATTEMPTED the digest
+  // (i.e. didn't skip-silent), and the lock was rolled back so the next
+  // tick can retry.
+  assert.equal(r.fired, 0);
+  assert.equal(r.skipped_silent, 0);
+  assert.equal(r.failed, 1);
+  // Session still tracked because cancel rolled back the lock.
+  assert.equal(tracker.size(), 1);
+});
+
+test("digester — advisory lock prevents concurrent fires of the same session", async () => {
+  let now = 1_000_000;
+  const { tracker, digester } = freshDigester({ now: () => now });
+  tracker.touch({ client_key: "k", user_present: true });
+  now += 2000;
+  // First tick acquires the lock and tries to fire (will fail on network).
+  const t1 = digester.tick();
+  // Second tick fires while the first is in-flight — but we can't easily
+  // simulate true concurrency in node:test. Easier: verify reapIdle()
+  // skips locked sessions. That's the property the lock provides.
+  assert.equal(tracker.markDigestStart("k"), false);  // lock NOT acquirable
+  await t1;
+});
+
+test("digester — outcome derivation rules match the spec", async () => {
+  let now = 1_000_000;
+  const { tracker, digester } = freshDigester({ now: () => now });
+  // One user msg + one assistant + zero errors → success
+  // We can't see the outcome from outside without DB, but we CAN check
+  // that the right code path runs by exercising tick() with each pattern.
+  tracker.touch({ client_key: "ok", user_present: true });
+  tracker.touch({ client_key: "ok", upstream_ok: true });
+  tracker.touch({ client_key: "err", user_present: true });
+  tracker.touch({ client_key: "err", upstream_ok: false });
+  now += 2000;
+  const r = await digester.tick();
+  // Both attempted (no silent skip), both failed at network — but the
+  // important property here is no silent skip and no double-fire.
+  assert.equal(r.fired, 0);
+  assert.equal(r.skipped_silent, 0);
+  assert.equal(r.failed, 2);
+});
+
+test("digester — stats accumulate across ticks", async () => {
+  let now = 1_000_000;
+  const { tracker, digester } = freshDigester({ now: () => now });
+  tracker.touch({ client_key: "silent" });   // touched but no user msg
+  now += 2000;
+  await digester.tick();
+  await digester.tick();   // empty tick — already drained
+  const s = digester.stats();
+  assert.equal(s.ticks, 2);
+  assert.equal(s.total_skipped_silent, 1);
+  assert.ok(s.last_tick_at !== null);
+});
+
+test("digester — start/stop is idempotent", () => {
+  const { digester } = freshDigester();
+  digester.start();
+  digester.start();   // 2nd start is a no-op
+  digester.stop();
+  digester.stop();    // 2nd stop is a no-op
+  // Just checking no throw — verified by reaching this assertion.
+  assert.ok(true);
+});

--- a/mcp-server/src/__tests__/middleware-session-tracker.test.ts
+++ b/mcp-server/src/__tests__/middleware-session-tracker.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SessionTracker } from "../middleware/session-tracker.js";
+
+test("tracker — buildKey strips ipv6-mapped prefix and trims user-agent", () => {
+  const k1 = SessionTracker.buildKey("::ffff:127.0.0.1", "Claude/1.0");
+  const k2 = SessionTracker.buildKey("127.0.0.1", "Claude/1.0");
+  assert.equal(k1, k2);
+});
+
+test("tracker — touch creates session on first sight, increments counts", () => {
+  const t = new SessionTracker();
+  const s = t.touch({ client_key: "k", model: "qwen2.5:7b", user_present: true });
+  assert.ok(s.session_id);
+  assert.equal(s.user_messages, 1);
+  assert.equal(s.assistant_messages, 0);
+  assert.equal(s.errors, 0);
+  assert.deepEqual([...s.models_seen], ["qwen2.5:7b"]);
+});
+
+test("tracker — repeat touches accumulate counts and unique models", () => {
+  const t = new SessionTracker();
+  t.touch({ client_key: "k", model: "qwen2.5:7b", user_present: true });
+  t.touch({ client_key: "k", model: "qwen2.5:7b", upstream_ok: true });
+  t.touch({ client_key: "k", model: "qwen2.5:3b", upstream_ok: false });
+  const s = t.touch({ client_key: "k", model: "qwen2.5:3b", user_present: true });
+  assert.equal(s.user_messages, 2);
+  assert.equal(s.assistant_messages, 1);
+  assert.equal(s.errors, 1);
+  assert.deepEqual([...s.models_seen].sort(), ["qwen2.5:3b", "qwen2.5:7b"]);
+});
+
+test("tracker — reapIdle returns sessions past the threshold only", () => {
+  let now = 1_000_000;
+  const t = new SessionTracker({ idleMs: 1000, now: () => now });
+  // session A is touched at t=0, then ages to 1500ms → idle
+  t.touch({ client_key: "A", user_present: true });
+  // session B is touched at t=1000, then ages 500ms → fresh (under threshold)
+  now += 1000;
+  t.touch({ client_key: "B", user_present: true });
+  now += 500;
+  const idle = t.reapIdle();
+  assert.equal(idle.length, 1);
+  assert.equal(idle[0].client_key, "A");
+  assert.ok(idle[0].idle_ms >= 1000);
+});
+
+test("tracker — markDigestStart succeeds once, then blocks until finish/cancel", () => {
+  const t = new SessionTracker();
+  t.touch({ client_key: "k", user_present: true });
+  assert.equal(t.markDigestStart("k"), true);
+  assert.equal(t.markDigestStart("k"), false);  // advisory lock held
+  t.cancelDigest("k");
+  assert.equal(t.markDigestStart("k"), true);
+  t.finishDigest("k");
+  assert.equal(t.markDigestStart("k"), false);  // session removed
+});
+
+test("tracker — finishDigest removes session, next touch starts a new id", () => {
+  const t = new SessionTracker();
+  const s1 = t.touch({ client_key: "k", user_present: true });
+  t.finishDigest("k");
+  const s2 = t.touch({ client_key: "k", user_present: true });
+  assert.notEqual(s1.session_id, s2.session_id);
+});
+
+test("tracker — reapIdle skips sessions already mid-digest", () => {
+  let now = 1_000_000;
+  const t = new SessionTracker({ idleMs: 1000, now: () => now });
+  t.touch({ client_key: "k", user_present: true });
+  now += 1500;
+  assert.equal(t.markDigestStart("k"), true);
+  // Now reapIdle should NOT see it again — would cause double-digest
+  assert.equal(t.reapIdle().length, 0);
+});
+
+test("tracker — overflow eviction drops oldest by last_activity_at", () => {
+  let now = 1_000_000;
+  const t = new SessionTracker({ maxSessions: 2, now: () => now });
+  t.touch({ client_key: "a" });
+  now += 100;
+  t.touch({ client_key: "b" });
+  now += 100;
+  t.touch({ client_key: "c" });            // overflow → "a" evicted
+  assert.equal(t.size(), 2);
+  const keys = t.snapshot().map((s) => s.client_key);
+  assert.ok(keys.includes("b"));
+  assert.ok(keys.includes("c"));
+  assert.ok(!keys.includes("a"));
+});
+
+test("tracker — snapshot reports current idle_ms relative to clock", () => {
+  let now = 1_000_000;
+  const t = new SessionTracker({ now: () => now });
+  t.touch({ client_key: "k", user_present: true });
+  now += 5_000;
+  const snap = t.snapshot();
+  assert.equal(snap.length, 1);
+  assert.equal(snap[0].idle_ms, 5_000);
+});

--- a/mcp-server/src/middleware/digester.ts
+++ b/mcp-server/src/middleware/digester.ts
@@ -1,0 +1,204 @@
+/**
+ * Auto-Digest runner — fires record_experience for sessions that have been
+ * idle past N9's threshold (#4 N4 + N9 spec).
+ *
+ * Wraps a SessionTracker:
+ *   - on a timer (default 60s), reapIdle() — find sessions idle ≥ 30min
+ *   - for each, mark advisory-lock-in-flight (no double-digest)
+ *   - skip silent sessions (no user msgs and no errors) per N9 §default
+ *   - call record_experience RPC with aggregated session metadata
+ *   - finishDigest() to drop the session row
+ *
+ * record_experience triggers compute_affect (mig 062) which in turn
+ * triggers neurochem_apply via the affect→neurochem reverse loop
+ * (mig 065). The Auto-Digest is therefore a single RPC call that lights
+ * up the entire downstream cognitive pipeline.
+ */
+
+import { PostgrestClient } from "@supabase/postgrest-js";
+import type { SessionTracker, SessionSnapshot } from "./session-tracker.js";
+
+export interface DigesterOptions {
+  supabaseUrl:     string;
+  supabaseKey:     string;
+  ollamaUrl?:      string;
+  embeddingModel?: string;
+  /** Tick interval in ms. Default 60s. */
+  tickMs?:         number;
+}
+
+export interface DigestResult {
+  fired:   number;
+  skipped_silent: number;
+  failed:  number;
+}
+
+export interface DigesterStats {
+  total_fired:         number;
+  total_skipped_silent: number;
+  total_failed:        number;
+  last_tick_at:        number | null;
+  ticks:               number;
+}
+
+export class Digester {
+  private db: PostgrestClient;
+  private ollamaUrl: string;
+  private embeddingModel: string;
+  private tracker: SessionTracker;
+  private tickMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private firedCount = 0;
+  private silentCount = 0;
+  private failedCount = 0;
+  private tickCount = 0;
+  private lastTickAt: number | null = null;
+
+  constructor(tracker: SessionTracker, opts: DigesterOptions) {
+    this.tracker = tracker;
+    this.db = new PostgrestClient(opts.supabaseUrl, {
+      headers: opts.supabaseKey
+        ? { Authorization: `Bearer ${opts.supabaseKey}`, apikey: opts.supabaseKey }
+        : {},
+    });
+    this.ollamaUrl      = opts.ollamaUrl ?? "http://127.0.0.1:11434";
+    this.embeddingModel = opts.embeddingModel ?? "nomic-embed-text";
+    this.tickMs         = opts.tickMs ?? 60_000;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    // unref so the timer doesn't keep node alive past SIGTERM.
+    this.timer = setInterval(() => { void this.tick(); }, this.tickMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  /**
+   * One pass of the idle-sweep. Returns counts so tests don't have to wait
+   * on the timer; they can call tick() directly with an injected clock.
+   */
+  async tick(): Promise<DigestResult> {
+    this.tickCount += 1;
+    this.lastTickAt = Date.now();
+    const result: DigestResult = { fired: 0, skipped_silent: 0, failed: 0 };
+    const candidates = this.tracker.reapIdle();
+    for (const c of candidates) {
+      if (!this.tracker.markDigestStart(c.client_key)) continue;  // someone got there first
+      try {
+        const fired = await this.fireOne(c);
+        if (fired) {
+          this.tracker.finishDigest(c.client_key);
+          result.fired += 1;
+          this.firedCount += 1;
+        } else {
+          // Silent session — drop the tracking row so the next message
+          // starts fresh, but don't write a digest.
+          this.tracker.finishDigest(c.client_key);
+          result.skipped_silent += 1;
+          this.silentCount += 1;
+        }
+      } catch (err) {
+        // Per N9 §3 "transient verloren" — log and forget. Do NOT retry
+        // from this layer. Cancel the lock so the next tick can re-attempt.
+        result.failed += 1;
+        this.failedCount += 1;
+        this.tracker.cancelDigest(c.client_key);
+        console.error(`[middleware] auto-digest failed (${c.client_key}):`,
+          err instanceof Error ? err.message : String(err));
+      }
+    }
+    return result;
+  }
+
+  stats(): DigesterStats {
+    return {
+      total_fired:          this.firedCount,
+      total_skipped_silent: this.silentCount,
+      total_failed:         this.failedCount,
+      last_tick_at:         this.lastTickAt,
+      ticks:                this.tickCount,
+    };
+  }
+
+  /**
+   * Decide + write one digest. Returns true if record_experience landed,
+   * false for silent-session skip.
+   */
+  private async fireOne(c: SessionSnapshot): Promise<boolean> {
+    // N9 §default — silent sessions don't get digested. A session is
+    // silent if it has zero user messages AND zero errors. The
+    // assistant_messages alone are not a reason to digest (a long stream
+    // of model output without any human prompt is rare and not
+    // experience-worthy).
+    if (c.user_messages === 0 && c.errors === 0) return false;
+
+    const summary = this.buildSummary(c);
+    const outcome = this.deriveOutcome(c);
+    const embedding = await this.embed(summary);
+
+    const { error } = await this.db.rpc("record_experience", {
+      p_summary:           summary,
+      p_embedding:         embedding,
+      p_session_id:        c.session_id,
+      p_task_type:         null,
+      p_details:           JSON.stringify({
+        user_messages:      c.user_messages,
+        assistant_messages: c.assistant_messages,
+        models_seen:        c.models_seen,
+        errors:             c.errors,
+        idle_ms:            c.idle_ms,
+        duration_ms:        c.last_activity_at - c.started_at,
+        client_key:         c.client_key,
+      }),
+      p_outcome:           outcome,
+      p_difficulty:        0.5,
+      p_confidence_before: null,
+      p_confidence_after:  null,
+      p_user_sentiment:    null,
+      p_valence:           outcome === "success" ? 0.3 : outcome === "failure" ? -0.3 : 0,
+      p_arousal:           0.2,
+      p_what_worked:       null,
+      p_what_failed:       c.errors > 0 ? `${c.errors} upstream error(s)` : null,
+      p_tools_used:        c.models_seen,
+      p_tags:              ["middleware:auto-digest"],
+      p_metadata:          { source: "middleware:auto-digest" },
+    });
+    if (error) throw new Error(error.message ?? JSON.stringify(error));
+    return true;
+  }
+
+  private buildSummary(c: SessionSnapshot): string {
+    const minutes = Math.round((c.last_activity_at - c.started_at) / 60_000);
+    const models = c.models_seen.length ? c.models_seen.join(", ") : "no model";
+    return [
+      `Middleware session ended (idle ≥30min).`,
+      `${c.user_messages} user message(s), ${c.assistant_messages} assistant reply(ies),`,
+      `${c.errors} error(s) over ~${minutes} min via ${models}.`,
+    ].join(" ");
+  }
+
+  private deriveOutcome(c: SessionSnapshot): "success" | "partial" | "failure" | "unknown" {
+    if (c.user_messages === 0) return "unknown";
+    if (c.errors === 0 && c.assistant_messages > 0) return "success";
+    if (c.errors > 0 && c.assistant_messages > 0) return "partial";
+    if (c.errors > 0 && c.assistant_messages === 0) return "failure";
+    return "unknown";
+  }
+
+  private async embed(text: string): Promise<number[]> {
+    const r = await fetch(new URL("/api/embed", this.ollamaUrl), {
+      method:  "POST",
+      headers: { "Content-Type": "application/json" },
+      body:    JSON.stringify({ model: this.embeddingModel, input: text }),
+    });
+    if (!r.ok) throw new Error(`ollama embed failed: HTTP ${r.status}`);
+    const j = (await r.json()) as { embeddings?: number[][] };
+    const v = j.embeddings?.[0];
+    if (!v) throw new Error("ollama embed returned no vector");
+    return v;
+  }
+}

--- a/mcp-server/src/middleware/proxy.ts
+++ b/mcp-server/src/middleware/proxy.ts
@@ -32,6 +32,8 @@
 import http from "node:http";
 import { PrimeFetcher } from "./prime-fetcher.js";
 import { Absorber } from "./absorber.js";
+import { SessionTracker } from "./session-tracker.js";
+import { Digester } from "./digester.js";
 import { injectContext, lastUserText, type ChatMessage } from "./inject.js";
 
 interface OllamaChatRequest {
@@ -76,6 +78,23 @@ const absorber = AUTO_ABSORB_ON ? new Absorber({
   embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
 }) : null;
 
+// Auto-Digest (#4 + N9 spec). Per-session state, idle-30min trigger.
+// MYCELIUM_PROXY_AUTO_DIGEST=0 disables; default on. Tick frequency
+// configurable via MYCELIUM_PROXY_DIGEST_TICK_MS (default 60s).
+const AUTO_DIGEST_ON = (process.env.MYCELIUM_PROXY_AUTO_DIGEST ?? "1") !== "0";
+const IDLE_MS    = Number(process.env.MYCELIUM_PROXY_IDLE_MS    ?? 30 * 60 * 1_000);
+const TICK_MS    = Number(process.env.MYCELIUM_PROXY_DIGEST_TICK_MS ?? 60_000);
+
+const tracker = new SessionTracker({ idleMs: IDLE_MS });
+const digester = AUTO_DIGEST_ON ? new Digester(tracker, {
+  supabaseUrl:    SUPABASE_URL,
+  supabaseKey:    SUPABASE_KEY,
+  ollamaUrl:      OLLAMA_URL,
+  embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
+  tickMs:         TICK_MS,
+}) : null;
+digester?.start();
+
 async function readBody(req: http.IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) chunks.push(Buffer.from(chunk));
@@ -118,6 +137,19 @@ async function handleChat(req: http.IncomingMessage, res: http.ServerResponse): 
   const taskType = (req.headers["x-mycelium-task-type"] as string | undefined)?.trim() || undefined;
 
   const taskText = lastUserText(parsed.messages);
+
+  // N4 Auto-Digest — touch session BEFORE fetch so a session is tracked
+  // even when the prime fetcher fails or the upstream is dead.
+  const clientKey = SessionTracker.buildKey(
+    req.socket.remoteAddress,
+    req.headers["user-agent"] as string | undefined,
+  );
+  tracker.touch({
+    client_key:   clientKey,
+    model:        parsed.model,
+    user_present: Boolean(taskText),
+  });
+
   // Diff cache hit count before/after to detect whether THIS call landed in
   // the cache. Cheaper than threading an "isHit" flag through the fetcher.
   const cacheBefore = fetcher.cacheStats()?.hits ?? 0;
@@ -147,10 +179,16 @@ async function handleChat(req: http.IncomingMessage, res: http.ServerResponse): 
 
   // N4 (Auto-Absorb): conservative regex extractor over user + assistant
   // text. Best-effort, fired in the background — must not delay the
-  // response. Auto-Digest is a separate follow-up (needs N9's session
-  // boundary state machine).
+  // response.
   const ct = upstream.headers.get("content-type") ?? "application/json; charset=utf-8";
   const buf = Buffer.from(await upstream.arrayBuffer());
+
+  // Update session state with the upstream outcome.
+  tracker.touch({
+    client_key:   clientKey,
+    model:        parsed.model,
+    upstream_ok:  upstream.status >= 200 && upstream.status < 300,
+  });
 
   if (absorber) {
     const assistantText = extractAssistantText(buf, ct);
@@ -188,6 +226,13 @@ async function handleHealth(_req: http.IncomingMessage, res: http.ServerResponse
     upstreams: Object.assign({}, ...checks),
     cache: fetcher.cacheStats(),
     auto_absorb: absorber ? absorber.stats() : { enabled: false },
+    auto_digest: digester ? {
+      enabled:  true,
+      idle_ms:  IDLE_MS,
+      tick_ms:  TICK_MS,
+      sessions: tracker.size(),
+      ...digester.stats(),
+    } : { enabled: false },
     phase: 1,
   });
 }
@@ -253,5 +298,5 @@ server.listen(PROXY_PORT, "127.0.0.1", () => {
   console.error(`  → health check: curl http://127.0.0.1:${PROXY_PORT}/health`);
 });
 
-process.on("SIGTERM", () => { server.close(() => process.exit(0)); });
-process.on("SIGINT",  () => { server.close(() => process.exit(0)); });
+process.on("SIGTERM", () => { digester?.stop(); server.close(() => process.exit(0)); });
+process.on("SIGINT",  () => { digester?.stop(); server.close(() => process.exit(0)); });

--- a/mcp-server/src/middleware/session-tracker.ts
+++ b/mcp-server/src/middleware/session-tracker.ts
@@ -1,0 +1,208 @@
+/**
+ * Per-session state for the small-model middleware (issue #4 Auto-Digest,
+ * companion to N9's digest-trigger spec).
+ *
+ * The proxy is HTTP, so we don't have an MCP `initialize` handshake to lean
+ * on for session identity. Instead we synthesize a session key from
+ * `${remoteAddress}|${userAgent}` — pragmatic, stable for the lifetime of
+ * a typical client run. Different clients on the same host get distinct
+ * sessions through their User-Agent string.
+ *
+ * Once a session has been idle longer than `idleMs` (default 30min per
+ * N9 §primary trigger) the digest-runner picks it up via `reapIdle()`.
+ *
+ * Pure data layer — no I/O. The runner (digester.ts) consumes
+ * `SessionSnapshot` and decides whether to fire `record_experience`.
+ */
+
+import { randomUUID } from "node:crypto";
+
+export interface SessionState {
+  session_id:        string;       // stable UUID, lives until digest fires
+  client_key:        string;       // ip|user-agent
+  started_at:        number;       // first activity timestamp (ms)
+  last_activity_at:  number;       // most-recent chat timestamp (ms)
+  user_messages:     number;
+  assistant_messages: number;
+  models_seen:       Set<string>;  // ollama model IDs invoked this session
+  errors:            number;       // upstream non-2xx responses
+  digest_in_flight:  boolean;      // in-process advisory lock per N9 §re-entry
+}
+
+export interface SessionSnapshot {
+  session_id:        string;
+  client_key:        string;
+  started_at:        number;
+  last_activity_at:  number;
+  idle_ms:           number;
+  user_messages:     number;
+  assistant_messages: number;
+  models_seen:       string[];
+  errors:            number;
+}
+
+export interface TouchInput {
+  client_key:    string;
+  model?:        string;            // ollama model_id
+  user_present?: boolean;           // a non-empty user message exists in this turn
+  upstream_ok?:  boolean;           // upstream returned 2xx
+}
+
+export interface SessionTrackerOptions {
+  /** Idle threshold in ms before a session is eligible for digest. Default 30min. */
+  idleMs?:  number;
+  /** For tests: inject a clock. */
+  now?:     () => number;
+  /** Soft cap on tracked sessions; oldest evicted on overflow. Default 100. */
+  maxSessions?: number;
+}
+
+const DEFAULT_IDLE_MS    = 30 * 60 * 1_000;
+const DEFAULT_MAX_SESSIONS = 100;
+
+export class SessionTracker {
+  private map = new Map<string, SessionState>();
+  private readonly idleMs: number;
+  private readonly now:    () => number;
+  private readonly maxSessions: number;
+
+  constructor(opts: SessionTrackerOptions = {}) {
+    this.idleMs      = opts.idleMs      ?? DEFAULT_IDLE_MS;
+    this.now         = opts.now         ?? Date.now;
+    this.maxSessions = opts.maxSessions ?? DEFAULT_MAX_SESSIONS;
+  }
+
+  /** Build a session key from request properties. Public so tests + the proxy
+   *  share one definition. */
+  static buildKey(remoteAddr: string | undefined, userAgent: string | undefined): string {
+    const ip = (remoteAddr ?? "unknown").replace(/^::ffff:/, "");  // strip IPv4-mapped-v6 prefix
+    const ua = (userAgent ?? "unknown").trim().slice(0, 80);
+    return `${ip}|${ua}`;
+  }
+
+  /**
+   * Record activity on a session. Returns the session state so the caller
+   * can read the (possibly newly-minted) session_id for downstream
+   * record_experience calls.
+   */
+  touch(input: TouchInput): SessionState {
+    const t = this.now();
+    let s = this.map.get(input.client_key);
+    if (!s) {
+      s = {
+        session_id:         randomUUID(),
+        client_key:         input.client_key,
+        started_at:         t,
+        last_activity_at:   t,
+        user_messages:      0,
+        assistant_messages: 0,
+        models_seen:        new Set(),
+        errors:             0,
+        digest_in_flight:   false,
+      };
+      this.map.set(input.client_key, s);
+      this.evictIfFull();
+    }
+    s.last_activity_at = t;
+    if (input.user_present) s.user_messages += 1;
+    if (input.upstream_ok === true) s.assistant_messages += 1;
+    if (input.upstream_ok === false) s.errors += 1;
+    if (input.model) s.models_seen.add(input.model);
+    return s;
+  }
+
+  /**
+   * Find sessions that have been idle longer than `idleMs` and are NOT
+   * already mid-digest. Returns snapshots; does NOT mutate the tracker —
+   * the caller flips `digest_in_flight` via `markDigestStart` once it has
+   * decided to act.
+   */
+  reapIdle(): SessionSnapshot[] {
+    const t = this.now();
+    const out: SessionSnapshot[] = [];
+    for (const s of this.map.values()) {
+      if (s.digest_in_flight) continue;
+      const idle = t - s.last_activity_at;
+      if (idle < this.idleMs) continue;
+      out.push({
+        session_id:         s.session_id,
+        client_key:         s.client_key,
+        started_at:         s.started_at,
+        last_activity_at:   s.last_activity_at,
+        idle_ms:            idle,
+        user_messages:      s.user_messages,
+        assistant_messages: s.assistant_messages,
+        models_seen:        [...s.models_seen],
+        errors:             s.errors,
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Mark a session's digest as in-flight (advisory lock). Returns true if
+   * the lock was acquired, false if another invocation already holds it.
+   *
+   * In-process only. Cross-process duplicate-digest protection isn't needed
+   * because the middleware is single-process by design (the proxy listens
+   * on one port).
+   */
+  markDigestStart(client_key: string): boolean {
+    const s = this.map.get(client_key);
+    if (!s) return false;
+    if (s.digest_in_flight) return false;
+    s.digest_in_flight = true;
+    return true;
+  }
+
+  /**
+   * Remove a session entirely after a successful digest. The next request
+   * from the same client_key starts a fresh session id — that's what N9
+   * §6 ("session boundary") specifies.
+   */
+  finishDigest(client_key: string): void {
+    this.map.delete(client_key);
+  }
+
+  /** Roll back the digest-in-flight flag without removing the session
+   *  — used when the digester decided to skip (silent session). */
+  cancelDigest(client_key: string): void {
+    const s = this.map.get(client_key);
+    if (s) s.digest_in_flight = false;
+  }
+
+  /** All currently tracked sessions, for /health. */
+  snapshot(): SessionSnapshot[] {
+    const t = this.now();
+    return [...this.map.values()].map((s) => ({
+      session_id:         s.session_id,
+      client_key:         s.client_key,
+      started_at:         s.started_at,
+      last_activity_at:   s.last_activity_at,
+      idle_ms:            t - s.last_activity_at,
+      user_messages:      s.user_messages,
+      assistant_messages: s.assistant_messages,
+      models_seen:        [...s.models_seen],
+      errors:             s.errors,
+    }));
+  }
+
+  /** Total tracked session count. */
+  size(): number { return this.map.size; }
+
+  private evictIfFull(): void {
+    while (this.map.size > this.maxSessions) {
+      // Oldest by last_activity_at — same LRU spirit as the prime cache.
+      let oldestKey: string | null = null;
+      let oldestT = Infinity;
+      for (const [k, s] of this.map) {
+        if (s.last_activity_at < oldestT) {
+          oldestT = s.last_activity_at;
+          oldestKey = k;
+        }
+      }
+      if (!oldestKey) return;
+      this.map.delete(oldestKey);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #4 by landing **Auto-Digest**. PR #65 added Auto-Absorb (per-turn fact capture); this PR adds the session-end side per N9's spec. With this merged, the small-model epic's core (N1–N4, N6–N9) is done; only N5 (benchmarks) and N10 (docs) remain.

## Architecture (per N9 §primary trigger and §re-entry)

- **\`session-tracker.ts\`** (208 LOC) — \`Map<clientKey, SessionState>\`. Client key = \`\${remoteAddress}|\${userAgent}\`. Per session: started_at, last_activity_at, user_messages, assistant_messages, models_seen, errors, digest_in_flight (advisory lock). Stable \`session_id\` (UUID) lives until the digest fires; the next request starts a fresh id.
- **\`digester.ts\`** (204 LOC) — \`setInterval(60s default)\` → \`tracker.reapIdle()\` → for each candidate, advisory-lock + \`fireOne()\`. Silent sessions (zero user msgs and zero errors) are dropped without writing — per N9 §default. Failures roll the lock back so the next tick can retry; per N9 §3 transient errors are forgotten.
- **\`proxy.ts\`** wiring — \`tracker.touch()\` before and after fetch. \`digester.start()\` on boot, \`.stop()\` on SIGTERM/SIGINT.
- **\`/health\`** surface includes \`auto_digest\` stats.

### Env knobs

| | default |
|---|---|
| \`MYCELIUM_PROXY_AUTO_DIGEST\` | \`1\` |
| \`MYCELIUM_PROXY_IDLE_MS\` | \`1_800_000\` (30min) |
| \`MYCELIUM_PROXY_DIGEST_TICK_MS\` | \`60_000\` |

## What lights up downstream

\`record_experience\` INSERT triggers \`compute_affect\` (mig 062), which trigger-fires \`apply_neurochem_from_trigger\` (mig 065). One Auto-Digest RPC therefore cascades through the entire cognitive pipeline:

\`\`\`
digest → experience INSERT → compute_affect → agent_affect → neurochem TD-error
\`\`\`

## Live verification

With \`IDLE_MS=5000\`, \`TICK_MS=2000\` for fast testing:

- Pre: 0 digests, 0 sessions
- 1 chat → 1 active session (sessions=1, ticks counter incrementing)
- 8s idle → digest fired (\`total_fired: 1\`, sessions: 0)
- DB: experiences row with the right summary, \`tools_used=[qwen2.5:7b-instruct]\`, tag \`middleware:auto-digest\`
- **\`agent_neurochemistry.main.updated_at == experiences.created_at\`** → reverse-loop confirmed end-to-end

Note on \"0 assistant reply(ies)\" in the live summary: with a 5s-idle test window the digester tick fired DURING a long Ollama load — the after-fetch touch hadn't happened yet, so the digest captured truth-at-tick-time. Per N9 §re-entry \"finish-then-resume\" this is correct. Won't happen in production with the 30min default.

## Tests

16 new tests (**250 total green**):

- **tracker**: key normalization, touch counters, reapIdle threshold, advisory lock semantics, finishDigest removes session, overflow eviction
- **digester**: silent skip, non-idle preserved, network-failure rollback, lock prevents concurrency, stats accumulation, idempotent start/stop

All against unreachable URLs — the unit suite stays Supabase-free.

## Out of scope

- **Cross-process digest dedupe** — single proxy by design
- **Crash recovery** — N9 §3 explicitly transient
- **Compaction-boundary trigger** — N9 §sekundär; needs a per-client signal the proxy doesn't yet receive

🤖 Generated with [Claude Code](https://claude.com/claude-code)