### PR TITLE
feat(install): one-shot middleware service alongside dashboard

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -86,6 +86,23 @@ schema?*
 
 ## Running
 
+### Easiest — via `install.sh` (registers a service)
+
+```bash
+curl -sSf https://raw.githubusercontent.com/Dewinator/mycelium/main/install.sh | bash
+```
+
+The installer brings up Docker + the dashboard, then registers a second
+launchd / systemd-user unit (`com.mycelium.middleware` on macOS,
+`mycelium-middleware.service` on Linux) that runs the proxy on port 18794
+and restarts on crash. Pass `--no-middleware` to skip.
+
+The unit reads its config from `docker/.env` automatically — the operator
+only ever has to put `JWT_SECRET` there (which `setup.sh` already does for
+the dashboard). The proxy mints its own service-role JWT on boot.
+
+### Manual
+
 The middleware reuses the MCP-server build artifact:
 
 ```bash
@@ -93,6 +110,13 @@ cd mycelium
 npm --prefix mcp-server install
 npm --prefix mcp-server run build
 
+# All env vars are optional — proxy bootstraps from docker/.env
+node mcp-server/dist/middleware/proxy.js
+```
+
+Override anything explicitly when needed:
+
+```bash
 SUPABASE_URL=http://localhost:54321 \
 SUPABASE_KEY=<service-role-jwt> \
 OLLAMA_URL=http://localhost:11434 \

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@
 # Options:
 #   --yes               assume "yes" for all prompts (non-interactive)
 #   --no-autostart      do not register a launchd / systemd service
+#   --no-middleware     do not install the small-model middleware service
 #   --target DIR        install directory (default: ./mycelium)
 #   --branch BRANCH     git branch to check out (default: main)
 #   --skip-models       skip ollama model pulls
@@ -42,6 +43,7 @@ hint()   { printf "  ${C_DIM}%s${C_RESET}\n" "$*"; }
 # ─── defaults ────────────────────────────────────────────────────────────────
 ASSUME_YES=0
 NO_AUTOSTART=0
+NO_MIDDLEWARE=0
 SKIP_MODELS=0
 SKIP_DOCKER=0
 PRINT_ONLY=0
@@ -54,6 +56,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --yes)            ASSUME_YES=1 ;;
     --no-autostart)   NO_AUTOSTART=1 ;;
+    --no-middleware)  NO_MIDDLEWARE=1 ;;
     --skip-models)    SKIP_MODELS=1 ;;
     --skip-docker)    SKIP_DOCKER=1 ;;
     --print-only)     PRINT_ONLY=1 ;;
@@ -367,12 +370,99 @@ step_autostart() {
   fi
   if [[ "$PRINT_ONLY" -eq 1 ]]; then
     hint "would install $OS auto-start unit pointing at $TARGET_DIR/scripts/dashboard-server.mjs"
+    if [[ "$NO_MIDDLEWARE" -ne 1 ]]; then
+      hint "would also install $OS middleware unit on port 18794"
+    fi
     return 0
   fi
   case "$OS" in
     mac)   step_autostart_mac ;;
     linux) step_autostart_linux ;;
   esac
+  if [[ "$NO_MIDDLEWARE" -ne 1 ]]; then
+    case "$OS" in
+      mac)   step_middleware_mac ;;
+      linux) step_middleware_linux ;;
+    esac
+  else
+    info "skipping middleware service (--no-middleware)"
+  fi
+}
+
+step_middleware_mac() {
+  local plist_path="$HOME/Library/LaunchAgents/com.mycelium.middleware.plist"
+  local node_bin
+  node_bin="$(command -v node)"
+  if [[ -f "$plist_path" ]]; then
+    ok "middleware LaunchAgent already exists: $plist_path"
+    return 0
+  fi
+  info "writing middleware LaunchAgent → $plist_path"
+  mkdir -p "$(dirname "$plist_path")"
+  cat > "$plist_path" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.mycelium.middleware</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$node_bin</string>
+    <string>$TARGET_DIR/mcp-server/dist/middleware/proxy.js</string>
+  </array>
+  <key>WorkingDirectory</key><string>$TARGET_DIR</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OLLAMA_URL</key><string>http://127.0.0.1:11434</string>
+    <key>SUPABASE_URL</key><string>http://127.0.0.1:54321</string>
+    <key>MYCELIUM_PROXY_PORT</key><string>18794</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$TARGET_DIR/.logs/middleware.out.log</string>
+  <key>StandardErrorPath</key><string>$TARGET_DIR/.logs/middleware.err.log</string>
+</dict>
+</plist>
+PLIST
+  mkdir -p "$TARGET_DIR/.logs"
+  launchctl unload "$plist_path" 2>/dev/null || true
+  launchctl load "$plist_path"
+  ok "middleware service running on http://127.0.0.1:18794"
+  hint "tip: 'curl http://127.0.0.1:18794/health' to inspect; 'tail -f $TARGET_DIR/.logs/middleware.err.log' for logs."
+}
+
+step_middleware_linux() {
+  local unit_path="$HOME/.config/systemd/user/mycelium-middleware.service"
+  local node_bin
+  node_bin="$(command -v node)"
+  if [[ -f "$unit_path" ]]; then
+    ok "middleware systemd-user unit already exists: $unit_path"
+    return 0
+  fi
+  info "writing middleware systemd-user unit → $unit_path"
+  mkdir -p "$(dirname "$unit_path")"
+  cat > "$unit_path" <<UNIT
+[Unit]
+Description=mycelium middleware (small-model proxy on 18794)
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$TARGET_DIR
+Environment=OLLAMA_URL=http://127.0.0.1:11434
+Environment=SUPABASE_URL=http://127.0.0.1:54321
+Environment=MYCELIUM_PROXY_PORT=18794
+ExecStart=$node_bin $TARGET_DIR/mcp-server/dist/middleware/proxy.js
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+UNIT
+  systemctl --user daemon-reload
+  systemctl --user enable --now mycelium-middleware.service
+  ok "middleware service running on http://127.0.0.1:18794"
+  hint "tip: 'systemctl --user status mycelium-middleware' to inspect."
 }
 
 step_final() {

--- a/mcp-server/src/middleware/proxy.ts
+++ b/mcp-server/src/middleware/proxy.ts
@@ -30,11 +30,57 @@
  */
 
 import http from "node:http";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
 import { PrimeFetcher } from "./prime-fetcher.js";
 import { Absorber } from "./absorber.js";
 import { SessionTracker } from "./session-tracker.js";
 import { Digester } from "./digester.js";
 import { injectContext, lastUserText, type ChatMessage } from "./inject.js";
+
+// ---------------------------------------------------------------------------
+// docker/.env bootstrap — same pattern as scripts/dashboard-server.mjs.
+// Lets the middleware run as a LaunchAgent / systemd unit without requiring
+// the operator to copy the service-role JWT into a plist.
+// process.env still wins over .env values when both are present.
+// ---------------------------------------------------------------------------
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT      = path.resolve(__dirname, "..", "..", "..");
+const ENV_FILE  = path.join(ROOT, "docker", ".env");
+
+async function loadDotenv(filePath: string): Promise<Record<string, string>> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const out: Record<string, string> = {};
+    for (const line of raw.split(/\r?\n/)) {
+      const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (m) out[m[1]] = m[2];
+    }
+    return out;
+  } catch { return {}; }
+}
+
+function b64url(buf: Buffer | string): string {
+  return Buffer.from(buf).toString("base64")
+    .replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/** Mint a service-role JWT from JWT_SECRET, mirroring dashboard-server.mjs. */
+function signServiceRoleJwt(secret: string): string {
+  const header  = { alg: "HS256", typ: "JWT" };
+  const payload = { role: "service_role", iss: "supabase", iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60 };
+  const h = b64url(JSON.stringify(header));
+  const p = b64url(JSON.stringify(payload));
+  const sig = crypto.createHmac("sha256", secret).update(`${h}.${p}`).digest();
+  return `${h}.${p}.${b64url(sig)}`;
+}
+
+const dotenv = await loadDotenv(ENV_FILE);
+function envOr(name: string, fallback?: string): string | undefined {
+  return process.env[name] ?? dotenv[name] ?? fallback;
+}
 
 interface OllamaChatRequest {
   model:    string;
@@ -47,22 +93,35 @@ interface OllamaChatRequest {
   tools?:   unknown[];
 }
 
-const PROXY_PORT      = Number(process.env.MYCELIUM_PROXY_PORT ?? 18794);
-const OLLAMA_URL      = process.env.OLLAMA_URL ?? "http://127.0.0.1:11434";
-const SUPABASE_URL    = process.env.SUPABASE_URL;
-const SUPABASE_KEY    = process.env.SUPABASE_KEY ?? process.env.SUPABASE_ANON_KEY;
-const RECALL_LIMIT    = Number(process.env.MYCELIUM_PROXY_RECALL_LIMIT ?? 5);
+const PROXY_PORT   = Number(envOr("MYCELIUM_PROXY_PORT", "18794"));
+const OLLAMA_URL   = envOr("OLLAMA_URL", "http://127.0.0.1:11434")!;
+const RECALL_LIMIT = Number(envOr("MYCELIUM_PROXY_RECALL_LIMIT", "5"));
 
+// SUPABASE_URL is straightforward; SUPABASE_KEY can come from three places
+// in priority order: explicit env, explicit dotenv, or self-minted from
+// JWT_SECRET (the LaunchAgent path — operator only has to put JWT_SECRET in
+// docker/.env, which is already there for the dashboard).
+const SUPABASE_URL = envOr("SUPABASE_URL", "http://127.0.0.1:54321")!;
+let SUPABASE_KEY = envOr("SUPABASE_KEY") ?? envOr("SUPABASE_ANON_KEY");
+if (!SUPABASE_KEY) {
+  const secret = envOr("JWT_SECRET");
+  if (secret) {
+    SUPABASE_KEY = signServiceRoleJwt(secret);
+    console.error("[middleware] minted SUPABASE_KEY from JWT_SECRET in docker/.env");
+  }
+}
 if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error("[middleware] FATAL: SUPABASE_URL and SUPABASE_KEY must be set");
+  console.error("[middleware] FATAL: SUPABASE_URL + SUPABASE_KEY (or JWT_SECRET) must be set in env or docker/.env");
   process.exit(1);
 }
+
+const EMBED_MODEL = envOr("EMBEDDING_MODEL", "nomic-embed-text")!;
 
 const fetcher = new PrimeFetcher({
   supabaseUrl:    SUPABASE_URL,
   supabaseKey:    SUPABASE_KEY,
   ollamaUrl:      OLLAMA_URL,
-  embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
+  embeddingModel: EMBED_MODEL,
   recallLimit:    RECALL_LIMIT,
 });
 
@@ -70,27 +129,27 @@ const fetcher = new PrimeFetcher({
 // Set MYCELIUM_PROXY_AUTO_ABSORB=0 to disable. Default ON because the
 // whole point of the small-model epic is to capture learning the user
 // would otherwise have to enter manually with `remember`.
-const AUTO_ABSORB_ON = (process.env.MYCELIUM_PROXY_AUTO_ABSORB ?? "1") !== "0";
+const AUTO_ABSORB_ON = (envOr("MYCELIUM_PROXY_AUTO_ABSORB", "1") ?? "1") !== "0";
 const absorber = AUTO_ABSORB_ON ? new Absorber({
   supabaseUrl:    SUPABASE_URL,
   supabaseKey:    SUPABASE_KEY,
   ollamaUrl:      OLLAMA_URL,
-  embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
+  embeddingModel: EMBED_MODEL,
 }) : null;
 
 // Auto-Digest (#4 + N9 spec). Per-session state, idle-30min trigger.
 // MYCELIUM_PROXY_AUTO_DIGEST=0 disables; default on. Tick frequency
 // configurable via MYCELIUM_PROXY_DIGEST_TICK_MS (default 60s).
-const AUTO_DIGEST_ON = (process.env.MYCELIUM_PROXY_AUTO_DIGEST ?? "1") !== "0";
-const IDLE_MS    = Number(process.env.MYCELIUM_PROXY_IDLE_MS    ?? 30 * 60 * 1_000);
-const TICK_MS    = Number(process.env.MYCELIUM_PROXY_DIGEST_TICK_MS ?? 60_000);
+const AUTO_DIGEST_ON = (envOr("MYCELIUM_PROXY_AUTO_DIGEST", "1") ?? "1") !== "0";
+const IDLE_MS    = Number(envOr("MYCELIUM_PROXY_IDLE_MS",         String(30 * 60 * 1_000)));
+const TICK_MS    = Number(envOr("MYCELIUM_PROXY_DIGEST_TICK_MS",  String(60_000)));
 
 const tracker = new SessionTracker({ idleMs: IDLE_MS });
 const digester = AUTO_DIGEST_ON ? new Digester(tracker, {
   supabaseUrl:    SUPABASE_URL,
   supabaseKey:    SUPABASE_KEY,
   ollamaUrl:      OLLAMA_URL,
-  embeddingModel: process.env.EMBEDDING_MODEL ?? "nomic-embed-text",
+  embeddingModel: EMBED_MODEL,
   tickMs:         TICK_MS,
 }) : null;
 digester?.start();


### PR DESCRIPTION
Roadmap phase 3 — *\"install as simple as possible\"*. With the small-model epic landed (#1, all sub-issues closed), the middleware needed manual env wiring + manual launch. This PR makes \`install.sh\` register a second \`launchd\` / \`systemd-user\` unit so the proxy comes up automatically alongside the dashboard.

## Two changes

### 1. \`proxy.ts\` bootstraps from \`docker/.env\` — same pattern as \`dashboard-server.mjs\`

\`process.env\` still wins when present, so explicit overrides keep working. \`SUPABASE_KEY\` resolution order:

1. \`process.env.SUPABASE_KEY\` / \`SUPABASE_ANON_KEY\` (explicit)
2. dotenv \`SUPABASE_KEY\` / \`SUPABASE_ANON_KEY\`
3. **minted on boot from \`JWT_SECRET\` in dotenv** — the LaunchAgent path

\`setup.sh\` already populates \`JWT_SECRET\`; the operator never has to copy a service-role JWT anywhere.

### 2. \`install.sh\` gains \`step_middleware_mac\` / \`step_middleware_linux\`

| flag | default | effect |
|---|---|---|
| \`--no-middleware\` | install | skip the second service |

The unit:
- runs \`node \$TARGET_DIR/mcp-server/dist/middleware/proxy.js\`
- sets \`OLLAMA_URL=http://127.0.0.1:11434\` + \`SUPABASE_URL=http://127.0.0.1:54321\` explicitly (docker/.env's OLLAMA_URL is \`host.docker.internal\` for the docker context, not the host)
- KeepAlive on macOS, \`Restart=always\` on Linux
- logs to \`\$TARGET_DIR/.logs/middleware.{out,err}.log\` on macOS, journalctl on Linux

## Verified

- \`bash -n install.sh\`: ok
- \`install.sh --help\` shows \`--no-middleware\`
- \`install.sh --print-only\` emits \`would also install … middleware unit on port 18794\`
- Live boot **without explicit env**:
  ```
  [middleware] minted SUPABASE_KEY from JWT_SECRET in docker/.env
  mycelium middleware (Phase 1) listening on http://127.0.0.1:18794
  ```
- 250/250 unit tests still green

## Doc update

\`docs/middleware.md\` gains an \"Easiest — via install.sh\" subsection. Manual launch path kept below for hackers / per-instance overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)