### PR TITLE
chore: gitignore site/ build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist/
 __pycache__/
 *.pyc
 
+# Astro landing-site build (lives in its own repo / build target — never tracked here)
+site/
+
 # Logs + ephemeral
 *.log
 *.sql.bak


### PR DESCRIPTION
Tiny housekeeping. The Astro landing-site build dir (`site/`, ~167 MB of `dist/` + `node_modules/`) lives outside this repo's pipeline but its parent showed up as `?? site/` in every `git status` because git walks until it finds a tracked file. Adding `site/` to `.gitignore` removes the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)