### PR TITLE
fix(dashboard): activate3D actually uses ForceGraph3D, not the hand-rolled path

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6503,8 +6503,6 @@ const SYN = (() => {
   }
 
   function activate3D() {
-    if (!three.scene) { if (!init3D()) return; }
-    rebuildScene3D();
     const mount = $("syn-canvas-3d");
     if (mount) mount.style.display = "block";
     if (canvas) canvas.style.display = "none";
@@ -6512,9 +6510,27 @@ const SYN = (() => {
     if (h2) h2.style.display = "none";
     if (h3) h3.style.display = "";
     three.on = true;
+    clearSynError();
+
+    // Primary path: 3d-force-graph (Vasturiano). Particle trails along
+    // weighted edges, deformed-Icosahedron somata, organic curved tubes.
+    // Falls back to the hand-rolled Three.js path if the vendor file
+    // didn't load (corp proxy, blocked bundle, etc.).
+    if (typeof ForceGraph3D !== "undefined") {
+      const fg = ensureForceGraph();
+      if (fg) {
+        fg.graphData(buildGraphData());
+        // ForceGraph runs its own animation loop — kill any leftover
+        // hand-rolled rAF from a previous activation.
+        if (three.rafId) { cancelAnimationFrame(three.rafId); three.rafId = null; }
+        return;
+      }
+    }
+    // Fallback — hand-rolled scene
+    if (!three.scene) { if (!init3D()) return; }
+    rebuildScene3D();
     if (three.rafId) cancelAnimationFrame(three.rafId);
     three.rafId = requestAnimationFrame(render3D);
-    // Resolution für Line2-Materials nach Mount-Sichtbarkeit nachziehen.
     requestAnimationFrame(() => resize3D());
   }
 
@@ -6522,6 +6538,8 @@ const SYN = (() => {
     three.on = false;
     if (three.rafId) cancelAnimationFrame(three.rafId);
     three.rafId = null;
+    // ForceGraph keeps its own renderer alive between activations — leaving
+    // the mount hidden is enough; the graph re-attaches on next activate3D.
     const mount = $("syn-canvas-3d");
     if (mount) mount.style.display = "none";
     if (canvas) canvas.style.display = "";


### PR DESCRIPTION
Follow-up to #71. That PR added the missing 3d-force-graph vendor file but the 3D-tab still showed *plain spheres + flat lines* — because \`activate3D()\` never reached \`ensureForceGraph()\`. It dispatched straight into the legacy \`init3D + render3D\` path. The whole \`buildGraphData\` + \`ensureForceGraph\` block (~200 LOC starting at line 6294) was dead code.

## Fix

\`activate3D()\` now tries \`typeof ForceGraph3D !== \"undefined\"\` first:

- if the vendor loaded → \`ensureForceGraph()\` → \`fg.graphData(buildGraphData())\` with fresh state
- ForceGraph runs its own animation loop, so the hand-rolled rAF gets cancelled when the FG path activates (no double-budget)
- if ForceGraph3D is undefined for any reason → fall back to legacy \`init3D + render3D\` (PR #71's safety net is preserved)

\`ingest()\` already calls \`activate3D()\` at the end of every data refresh, so the new path also covers the \"new memories arrive while 3D is open\" case.

## What the user sees

Now: deformed-Icosahedron somata, curved tubes, particle trails along weighted Hebbian edges, specular highlights — all the \`nodeThreeObject\` + \`linkDirectionalParticles\` code that's been sitting unused.

Browser hard-reload may be needed if \`index.html\` was cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)