### PR TITLE
feat(dashboard): mobile UX overhaul — sticky header, bottom-nav, sheet modals

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -54,13 +54,14 @@
   }
   *,*::before,*::after { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text); font-family: var(--sans); -webkit-font-smoothing: antialiased; }
-  body { min-height: 100vh; display: grid; grid-template-columns: 200px 1fr; }
+  body { min-height: 100vh; min-height: 100dvh; display: grid; grid-template-columns: 200px 1fr; }
   a { color: var(--accent); text-decoration: none; }
 
   .sidebar {
     background: var(--bg-elev); border-right: 1px solid var(--border);
     padding: 18px 12px 16px; display: flex; flex-direction: column; gap: 12px;
-    position: sticky; top: 0; align-self: start; height: 100vh;
+    position: sticky; top: 0; align-self: start;
+    height: 100vh; height: 100dvh;
     overflow-y: auto; z-index: 30;
   }
   .main { padding: 20px 28px 48px; min-width: 0; }
@@ -454,7 +455,10 @@
   @media (max-width: 900px) {
     body { grid-template-columns: 1fr; }
     .sidebar {
-      position: fixed; top: 0; left: 0; width: 260px; height: 100vh;
+      position: fixed; top: 0; left: 0; width: 260px;
+      height: 100vh; height: 100dvh;
+      padding-top: max(18px, env(safe-area-inset-top));
+      padding-bottom: max(16px, env(safe-area-inset-bottom));
       transform: translateX(-100%); transition: transform .2s ease;
       box-shadow: var(--shadow);
     }
@@ -641,7 +645,9 @@
       radial-gradient(ellipse at 75% 80%, rgba(34,211,238,0.05), transparent 60%),
       radial-gradient(circle at 50% 50%, #0d1d2c 0%, #050b13 100%);
     border: 1px solid #1a2b3d; border-radius: var(--radius);
-    height: calc(100vh - 220px); min-height: 520px; overflow: hidden;
+    height: calc(100vh - 220px);
+    height: calc(100svh - 220px);
+    min-height: 520px; overflow: hidden;
     box-shadow: inset 0 0 90px rgba(0,0,0,0.6), var(--shadow);
   }
   :root[data-theme="light"] .syn-stage {
@@ -708,7 +714,10 @@
   }
 
   @media (max-width: 820px) {
-    .syn-stage { height: calc(100vh - 200px); min-height: 420px; }
+    .syn-stage {
+      height: calc(100svh - 180px);
+      min-height: 420px;
+    }
     .syn-details {
       top: auto; bottom: 0; left: 0; right: 0; width: 100%;
       max-height: 55%;
@@ -829,6 +838,229 @@
   .stat-row .stat-label { color: var(--text); font-size: 13px; }
   .stat-row .stat-label .sub { display: block; color: var(--text-dim); font-size: 11px; margin-top: 2px; font-weight: 400; }
   .stat-row .stat-value { font-family: var(--mono); font-variant-numeric: tabular-nums; color: var(--text); font-size: 14px; font-weight: 500; }
+
+  /* ================================================================== */
+  /*   Mobile bottom-nav — primary thumb-zone navigation (≤ 900 px)     */
+  /*   Mirrors sidebar app-nav. Identity-aware: subtle accent line,     */
+  /*   translucent panel like syn-legend — fits the cognitive/bio feel. */
+  /* ================================================================== */
+  .bottom-nav { display: none; }
+  .bottom-nav .nav-item {
+    flex: 1; flex-direction: column; align-items: center; justify-content: center;
+    gap: 2px; padding: 6px 4px; min-height: 56px; border-radius: 10px;
+    color: var(--text-faint); font-size: 11px; line-height: 1.1;
+  }
+  .bottom-nav .nav-item .bn-icon { font-size: 18px; line-height: 1; }
+  .bottom-nav .nav-item .bn-label {
+    font-size: 11px; letter-spacing: 0.02em;
+    max-width: 100%; white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis;
+  }
+  .bottom-nav .nav-item.active {
+    background: var(--accent-soft); color: var(--accent); font-weight: 600;
+  }
+  .bottom-nav .nav-item:hover { color: var(--text); }
+  .bottom-nav .nav-item.active:hover { color: var(--accent); }
+
+  /* ================================================================== */
+  /*   Mobile refinements 2026-04-27 — sticky header, sheets, scroll-   */
+  /*   rails, touch-targets ≥ 40 px, safe-area insets, dvh viewports.   */
+  /*   Layered AFTER all earlier rules so it cleanly overrides them.    */
+  /* ================================================================== */
+  @media (max-width: 900px) {
+    /* Lock the page width to the viewport so a stray long word, an
+       inline-styled wide element, or a debug overlay never causes the
+       whole document to scroll horizontally. overflow-x:clip is the
+       2026 idiom — does not establish a scrolling container. */
+    html, body { overflow-x: clip; }
+    body { max-width: 100vw; }
+    /* Long single-word strings (URLs, slugs, hashes) wrap instead of
+       blowing out a flex item's intrinsic min-width. */
+    .panel-intro, .card, .kpi .label, .kpi .hint, table.mem td.content {
+      overflow-wrap: anywhere;
+    }
+    /* Sticky compact header: stays reachable while scrolling, backdrop
+       blur keeps it readable over content, safe-area-top respects notch. */
+    header.top {
+      position: sticky; top: 0; z-index: 25;
+      margin: -14px -16px 14px;
+      padding: max(8px, env(safe-area-inset-top)) 14px 8px;
+      gap: 8px;
+      background: color-mix(in srgb, var(--bg) 88%, transparent);
+      backdrop-filter: saturate(140%) blur(10px);
+      -webkit-backdrop-filter: saturate(140%) blur(10px);
+      border-bottom: 1px solid var(--border);
+    }
+    /* Status line wraps to its own row beneath burger + controls so it
+       can breathe; controls stay in a single tight cluster on the right. */
+    header.top .status-line {
+      order: 3; flex-basis: 100%;
+      font-size: 12px; padding-top: 4px;
+      border-top: 1px dashed var(--border); margin-top: 4px;
+    }
+    header.top .controls {
+      gap: 6px; flex-wrap: wrap; justify-content: flex-end;
+    }
+
+    /* Burger: square 40 × 40 touch-target, larger glyph, no drift. */
+    .burger {
+      width: 40px; height: 40px; padding: 0;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 20px; line-height: 1;
+    }
+
+    /* Header buttons: meet the 40 × 40 touch-target heuristic without
+       eating the entire row. All four collapse to icon-only on phones. */
+    header.top .controls .btn {
+      width: 40px; height: 40px; padding: 0;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 0; line-height: 1; position: relative;
+    }
+    header.top .controls .btn::before { font-size: 16px; line-height: 1; }
+    #setup-link::before { content: "⚙"; }
+    #lang-toggle {
+      /* Lang-toggle keeps a tiny 2-letter label so users see the locale.
+         Width auto so "DE"/"EN" fits without an icon glyph. */
+      width: auto !important; min-width: 40px; padding: 0 10px !important;
+      font-size: 11px !important; letter-spacing: 0.04em;
+    }
+    #lang-toggle::before { content: none; }
+    #refresh::before { content: "↻"; }
+    #theme::before   { content: "◐"; }
+
+    /* Content gets a small bottom buffer so the bottom-nav never overlaps
+       the last card (footer included). Calc accounts for safe-area-bottom. */
+    .main {
+      padding-bottom: calc(72px + env(safe-area-inset-bottom));
+    }
+
+    /* Cortex two-level nav: groups stay wrapped chips, sub-tabs become a
+       single-row scroll-snap rail — swipe horizontally instead of
+       wall-of-buttons wrap. Edges fade so users see there is more. */
+    .cortex-groups {
+      gap: 6px; padding-bottom: 6px; margin-bottom: 10px;
+      overflow-x: auto; flex-wrap: nowrap; scrollbar-width: none;
+      scroll-snap-type: x proximity;
+    }
+    .cortex-groups::-webkit-scrollbar { display: none; }
+    .cortex-group-btn {
+      flex: 0 0 auto; min-height: 36px; scroll-snap-align: start;
+    }
+    .cortex-subtabs {
+      gap: 4px; margin-bottom: 14px;
+      overflow-x: auto; flex-wrap: nowrap; scrollbar-width: none;
+      scroll-snap-type: x proximity;
+      -webkit-mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+              mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+    }
+    .cortex-subtabs::-webkit-scrollbar { display: none; }
+    .cortex-subtabs .tab {
+      flex: 0 0 auto; min-height: 36px; padding: 7px 12px; font-size: 12.5px;
+      scroll-snap-align: start;
+    }
+
+    /* Bottom-nav: only here. Floating panel above the home-indicator. */
+    .bottom-nav {
+      display: flex;
+      position: fixed; left: 8px; right: 8px;
+      bottom: max(8px, env(safe-area-inset-bottom));
+      z-index: 28;
+      gap: 4px; padding: 6px;
+      background: color-mix(in srgb, var(--bg-elev) 92%, transparent);
+      backdrop-filter: saturate(140%) blur(12px);
+      -webkit-backdrop-filter: saturate(140%) blur(12px);
+      border: 1px solid var(--border); border-radius: 16px;
+      box-shadow: var(--shadow);
+    }
+    /* Hide the redundant sidebar app-nav on mobile — bottom-nav owns it.
+       Sidebar drawer remains for settings / brand / future per-cortex
+       deep-links; if drawer is empty we still let the user open it. */
+    .sidebar .app-nav { display: none; }
+    .sidebar .brand { margin-bottom: 8px; }
+    .sidebar { padding: 14px 12px 12px; }
+
+    /* Cards & intro: trim vertical real-estate without losing legibility. */
+    .card { padding: 14px; border-radius: 10px; overflow-x: visible; }
+    .panel-intro { margin: -2px 0 14px; padding: 10px 12px; font-size: 12.5px; }
+    .panel-intro .sub { margin-top: 4px; font-size: 11.5px; }
+
+    /* KPI grid: keep the 2-up grid (set further down at 520) but tighten
+       the auto-fit version for the 520-900 band. */
+    .grid-kpi { gap: 10px; }
+    .kpi .label { margin-bottom: 6px; }
+    .kpi .value { font-size: 22px; }
+
+    /* Tables: clip horizontal overflow at the card boundary and let the
+       table itself scroll — beats the entire card scrolling sideways. */
+    .card > table.mem,
+    .card .mem-scroll { display: block; max-width: 100%; overflow-x: auto; }
+    .card { overflow-x: clip; }
+    table.mem td.content { max-width: 220px; }
+
+    /* Modals → bottom-sheet pattern. Uses [id$="-modal"] to catch every
+       inline-styled overlay without rewriting their HTML. The inner card
+       gets pulled to the bottom of the viewport, full width, with a
+       drag-handle visual. dvh keeps it sized correctly while the iOS URL
+       bar collapses; max-height respects safe-area-bottom. */
+    [id$="-modal"] {
+      align-items: flex-end !important;
+      padding: 0 !important;
+    }
+    [id$="-modal"] > .card,
+    [id$="-modal"] > div[style*="background:var(--bg-elev)"] {
+      max-width: 100% !important;
+      width: 100% !important;
+      max-height: calc(92dvh - env(safe-area-inset-bottom)) !important;
+      border-radius: 18px 18px 0 0 !important;
+      padding-bottom: calc(20px + env(safe-area-inset-bottom)) !important;
+      animation: sheet-up 0.22s cubic-bezier(.32,.72,.36,1);
+    }
+    [id$="-modal"] > .card::before,
+    [id$="-modal"] > div[style*="background:var(--bg-elev)"]::before {
+      content: ""; display: block; width: 36px; height: 4px;
+      background: var(--text-faint); border-radius: 2px; opacity: 0.4;
+      margin: -4px auto 12px;
+    }
+    @keyframes sheet-up {
+      from { transform: translateY(100%); }
+      to   { transform: translateY(0); }
+    }
+
+    /* General touch-targets: any .btn picks up a 40 px floor on mobile. */
+    .btn { min-height: 40px; }
+    .syn-toolbar .syn-btn,
+    .syn-toolbar .syn-btn-icon { min-height: 36px; }
+
+    /* Toast/notification host already lives at right:20px;bottom:20px —
+       lift it above the bottom-nav and the iPhone home-indicator. */
+    body > div[style*="right:20px"][style*="bottom:20px"],
+    body > div[style*="right: 20px"][style*="bottom: 20px"] {
+      bottom: calc(80px + env(safe-area-inset-bottom)) !important;
+      right: 12px !important;
+    }
+  }
+
+  /* Phone-tier refinements (≤ 520 px) — tighter still, smaller chrome. */
+  @media (max-width: 520px) {
+    .main { padding: 12px 12px calc(80px + env(safe-area-inset-bottom)); }
+    header.top { margin: -12px -12px 12px; padding-left: 12px; padding-right: 12px; }
+    .grid-kpi { grid-template-columns: 1fr 1fr; gap: 8px; }
+    .kpi .value { font-size: 20px; }
+    .card { padding: 12px; }
+    .bottom-nav .nav-item .bn-label { font-size: 10px; }
+    .panel-intro { padding: 9px 11px; font-size: 12px; line-height: 1.5; }
+    .section-head { margin: 16px 0 6px; }
+    /* Synapsen-toolbar: stack vertically so search + stats both breathe. */
+    .syn-toolbar {
+      padding: 8px; gap: 6px;
+      flex-direction: column; align-items: stretch;
+    }
+    .syn-toolbar > .syn-group { width: 100%; }
+    .syn-toolbar .syn-stats { width: 100%; justify-content: flex-start; margin-left: 0; }
+    .syn-search-wrap { width: 100%; }
+    .syn-toolbar input[type="text"]#syn-search { width: 100%; min-width: 0; }
+    .syn-views { align-self: flex-start; }
+  }
 
 </style>
 <!-- Three.js (UMD bundle, last UMD release before module-only) — powers the
@@ -1729,6 +1961,25 @@
     quelle: <code>POST /api/rpc/dashboard_stats</code> &middot; proxy: <code>scripts/dashboard-server.mjs</code>
   </footer>
   </main>
+
+  <!-- Mobile bottom-nav: thumb-zone primary navigation. Mirrors the sidebar
+       app-nav (cortex / agents / settings); active-state is kept in sync via
+       the shared .nav-item click handler that toggles every button matching
+       data-nav. Visible only ≤ 900 px (display rule in mobile media query). -->
+  <nav class="bottom-nav" id="bottom-nav" aria-label="primary">
+    <button class="nav-item active" data-nav="cortex">
+      <span class="bn-icon" aria-hidden="true">◉</span>
+      <span class="bn-label" data-i18n="nav.cortex">cortex</span>
+    </button>
+    <button class="nav-item" data-nav="agents">
+      <span class="bn-icon" aria-hidden="true">◐</span>
+      <span class="bn-label" data-i18n="nav.agents">agenten</span>
+    </button>
+    <button class="nav-item" data-nav="settings">
+      <span class="bn-icon" aria-hidden="true">◇</span>
+      <span class="bn-label" data-i18n="nav.settings">einstellungen</span>
+    </button>
+  </nav>
 
 <script type="module">
   // Bootstrap i18n before the main dashboard script runs.
@@ -4304,11 +4555,13 @@ document.querySelectorAll(".tab").forEach(btn => {
   });
 });
 
-// outer app-nav switching (cortex / agents / settings)
+// outer app-nav switching (cortex / agents / settings).
+// Mirrors active state across all .nav-item buttons that share the same
+// data-nav — sidebar (desktop) and bottom-nav (mobile) stay in sync.
 document.querySelectorAll(".nav-item").forEach(btn => {
   btn.addEventListener("click", () => {
     const name = btn.dataset.nav;
-    document.querySelectorAll(".nav-item").forEach(b => b.classList.toggle("active", b === btn));
+    document.querySelectorAll(".nav-item").forEach(b => b.classList.toggle("active", b.dataset.nav === name));
     document.querySelectorAll(".nav-panel").forEach(p => p.classList.toggle("active", p.id === "nav-panel-" + name));
     if (name === "agents") loadAgentRegistry();
     else stopAgentRegistryPolling();


### PR DESCRIPTION
## Why now

Roadmap point 3 in `CLAUDE.md` is *Dashboard verbessern. Lesbar, vollständig, Anfänger-tauglich.* The mobile pass had drifted: a 260 px drawer behind a **non-sticky** burger, fixed `vh` viewports fighting the iOS URL bar, four header buttons crammed into one row, modals at `90vh` overlapping the home-indicator, and the cortex sub-tabs wrapping to four rows on a 360 px screen.

This PR aligns the dashboard with current mobile best practice (sticky compact header, thumb-zone bottom-nav, `dvh` / `svh` viewports, 40 px touch targets, safe-area insets, sheet pattern for modals) **without restructuring desktop** and without introducing a build step.

## How

All changes are layered *after* the existing CSS inside two media queries (`≤ 900 px`, `≤ 520 px`) plus:

- A small new `<nav class="bottom-nav">` block before the closing `</main>`.
- A one-line sync in the `.nav-item` click handler so sidebar (desktop) and bottom-nav (mobile) keep their `active` state in lock-step:
  ```js
  document.querySelectorAll(".nav-item").forEach(b =>
    b.classList.toggle("active", b.dataset.nav === name));
  ```
- Inline `100vh` references (sidebar / synapsen-stage) gain an `100dvh` / `100svh` fallback line so the iOS URL-bar collapse no longer reflows the layout.

Existing IDs, RPC calls, i18n keys, and the desktop layout are untouched. The bottom-nav reuses the `nav.cortex` / `nav.agents` / `nav.settings` i18n keys already wired for the sidebar — no dictionary additions.

## What you see on a phone now

| Surface | Before | After |
|---|---|---|
| Header | wraps to 2–3 rows, burger scrolls away | sticky compact, backdrop-blur, status on its own row, all 4 controls collapse to icon-only (⚙ DE ↻ ◐) |
| Top-level nav | drawer-only, 260 px-wide overlay | floating bottom-nav above home-indicator, mirrors sidebar app-nav |
| Cortex sub-tabs | 14 buttons wrap to 3–4 rows | single-row horizontal scroll-snap rail with edge-fade mask |
| Modals | `90vh`, full corners, overlaps URL bar | bottom-sheet with rounded top + drag-handle, `dvh`-sized, respects safe-area-bottom |
| KPI grid | becomes 1 col below 520 (sparse) | stays 2-up for density |
| Touch targets | 28–34 px tall | ≥ 40 px (≥ 36 px for compact secondary chips) |
| Long strings | could blow out viewport | `overflow-x: clip` + `overflow-wrap: anywhere` |

## Test plan

- [x] Verified visually at 360 / 414 / 768 px via headless Chrome iframe rig
- [ ] Open on real iPhone (Tailscale → `:8787`) and confirm:
  - [ ] Sticky header stays put; status line readable
  - [ ] Bottom-nav switches between cortex / agents / settings
  - [ ] Sidebar drawer still opens via burger and via swipe-area gestures
  - [ ] Cortex group + sub-tab rails scroll-snap, edge fade visible
  - [ ] Synapsen toolbar collapses cleanly at ≤ 520 px
  - [ ] Open `+ neues projekt` and breed/cull/genome modals — slide up as sheets, all controls reachable above home-indicator
  - [ ] Toggle DE/EN, theme — header buttons remain tappable as icon-only
- [ ] Desktop unaffected (≥ 1280 px regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)