### PR TITLE
feat(swarm): migration 070 — nodes table for cryptographic identity (#75)

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -1,0 +1,454 @@
+# SWARM_SPEC — wire-format spec for the decentralized mycelium swarm
+
+**Spec version:** `1.0`
+**Status:** spec-only (no code lands against this PR; phases 1–9 of the
+Swarm Foundation Plan implement against this contract).
+**Audience:** anyone implementing a mycelium node — this repo, a port to
+another language, or an independent peer that wants to be reachable by the
+swarm.
+
+---
+
+## 0. Three unverletzliche Designprinzipien
+
+These three principles are non-negotiable. Any change to this spec, or any
+implementation of it, that weakens one of them is invalid and must be
+rejected before merge.
+
+1. **Souveränität.** Every node is owned and operated by its user.
+   The swarm has no central authority. A node can be disconnected from the
+   swarm at any moment and continue to function as a complete cognitive
+   substrate. Federation is opt-in; offline is the default-correct state.
+
+2. **Generalisierung-vor-Sharing.** Raw episodic memory never leaves the
+   node. Only knowledge that has already been generalized inside the
+   originating node — synthesized lessons, hub-anchor embeddings,
+   signed metadata — is eligible for the wire. The producing node decides
+   what is general enough to share; consumers cannot pull raw episodes.
+
+3. **Diversität.** The swarm's value is the spread of lived experience
+   across nodes, not the average. Sync protocols, trust functions, and any
+   future ranking machinery must preserve heterogeneity. Convergence
+   pressure (e.g. "everyone keeps the most-popular lesson") is an
+   anti-goal.
+
+These mirror the project's [`CONSTITUTION.md`](../CONSTITUTION.md) and the
+*Schwarm-These* memory (`3acb8bb1-f374-436c-a3db-df2af9e50a83`).
+
+---
+
+## 1. Spec versioning
+
+- The current spec version is the string `"1.0"`.
+- Every signed wire record and every `NodeAdvertisement` MUST carry a
+  `spec_version` field.
+- Version negotiation between two nodes is **strict equality on the
+  major component** for v1: a node implementing `"1.x"` MUST refuse to
+  consume records whose `spec_version` major differs from its own. Minor
+  bumps are reserved for backward-compatible additions (new optional
+  fields, new endpoints, new rejection rules); a v1.1 node MUST still
+  accept v1.0 records.
+- The string format is `"<major>.<minor>"`, both decimal integers,
+  no leading zeros, no whitespace. Future pre-release suffixes are out
+  of scope for v1.
+- Spec amendments are made by PR against this file; bumping `spec_version`
+  is the same kind of change as a Constitution amendment in spirit and
+  must explicitly justify why it does not weaken the three Designprinzipien
+  above.
+
+---
+
+## 2. JSON Canonical Form
+
+All signatures in this spec are computed over the **JSON Canonicalization
+Scheme (JCS), [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)**,
+applied to the record with the `signature` field omitted.
+
+JCS gives us a single deterministic byte sequence for any given JSON
+value. The relevant rules, restated for implementer convenience:
+
+- Object keys are sorted by **UTF-16 code unit** order (not Unicode code
+  point, not byte order).
+- Whitespace is removed; the encoding is the minimal compact form.
+- Strings use UTF-8 with the JSON-mandated escapes; no extra escapes.
+- Numbers are serialized using the **ECMAScript `Number.prototype.toString`**
+  algorithm as required by JCS.
+- The input is constrained to **I-JSON** (no duplicate keys, no NaN, no
+  Infinity, no `-0` distinct from `0`).
+
+### 2.1 Float embeddings under JCS — implementer warning
+
+Embeddings are arrays of 768 IEEE-754 double-precision floats. JCS
+serializes each via ECMAScript's number-to-string algorithm, which is
+**not** the same as a language's default `printf("%g")` or
+`json.dumps(float)`. Two implementations that round embeddings differently
+before signing will produce different signatures over byte-identical
+vectors.
+
+Rules for v1:
+
+- The producer MUST serialize each embedding component using a JCS-conformant
+  number serializer. Reference implementations exist in JS
+  ([`json-canonicalize`](https://www.npmjs.com/package/json-canonicalize)),
+  Rust ([`serde_json_canonicalizer`](https://docs.rs/serde_json_canonicalizer/)),
+  and others.
+- Embeddings MUST be transmitted as full-precision floats (no pre-truncation
+  to N decimal places). Truncating before signing is allowed, but the
+  truncated value is then the signed value — receivers cannot distinguish.
+- The producer MUST sign the canonical bytes, not the in-memory value.
+- A receiver computes the canonical bytes from the received JSON, verifies
+  the signature against those bytes, and only then trusts the parsed value.
+
+### 2.2 Signing inputs
+
+For a signed record `R`:
+
+1. Take the JSON object `R'` = `R` with the `signature` key removed.
+2. Compute `bytes = JCS(R')`.
+3. `signature = base64(Ed25519_sign(node_private_key, bytes))`.
+4. Re-attach `signature` to `R` for transport.
+
+Verification is the inverse: strip `signature`, JCS the remainder, verify
+against the producer node's published public key.
+
+### 2.3 Signature algorithm
+
+- v1 uses **Ed25519** exclusively (RFC 8032).
+- Public keys are 32 raw bytes, transported as unpadded base64url in
+  `pubkey` fields, padded base64 in `signature` fields. (The asymmetry is
+  inherited from common library defaults; both encodings are valid base64
+  variants and both are stable across implementations.)
+- Key rotation is **out of scope for v1** (see §6).
+
+---
+
+## 3. Wire types
+
+All wire types are JSON objects. Field types use the following shorthand:
+
+| shorthand | meaning |
+|---|---|
+| `string` | UTF-8 string, no NUL bytes |
+| `uuid` | RFC 4122 v4 UUID, lowercase, hyphenated, 36 chars |
+| `iso8601` | RFC 3339 date-time, UTC (`Z` suffix), millisecond precision: `2026-04-27T18:31:33.183Z` |
+| `int` | JSON number, integer, fits in int64, ≥ 0 unless noted |
+| `float` | JSON number, IEEE-754 double, finite (no NaN/Inf) |
+| `float[N]` | JSON array of exactly N `float` |
+| `string[]` | JSON array of `string`, may be empty |
+| `base64` | standard base64 with padding (RFC 4648 §4) |
+| `base64url` | URL-safe base64 without padding (RFC 4648 §5) |
+| `multihash` | self-describing hash per the multihash spec, base58btc-encoded; see §3.5 |
+| `https-url` | absolute URL, scheme MUST be `https`, no fragment, no userinfo |
+
+All timestamps in wire records are UTC. Local-zone timestamps are a v1
+hard error (§5).
+
+### 3.1 `Lesson`
+
+A generalized piece of knowledge that the producing node has decided is
+shareable. Lessons are the primary unit of swarm sync.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `id` | `uuid` | yes | Lesson identity. Stable across re-publishes. |
+| `content` | `string` | yes | The lesson text, in the producer's voice. ≤ 8 KiB UTF-8. |
+| `embedding` | `float[768]` | yes | Embedding of `content` from the producer's local model (see §3.6). |
+| `synthesized_from_cluster_size` | `int` | yes | Number of source episodes the producer condensed to make this lesson. ≥ 1. Provenance signal — receivers may weight by it. |
+| `origin_node_id` | `string` (multihash) | yes | The producing node's `node_id` (§3.5). |
+| `signed_at` | `iso8601` | yes | When the producer signed this record. |
+| `signature` | `base64` | yes | Ed25519 signature over JCS(record − signature) using `origin_node_id`'s key. |
+| `created_at` | `iso8601` | yes | When the lesson was first synthesized locally. May be earlier than `signed_at`. |
+| `tags` | `string[]` | no | Free-form classification hints. Producers SHOULD keep ≤ 16 tags, each ≤ 64 chars. |
+| `spec_version` | `string` | yes | Spec version this record conforms to (§1). |
+
+**Generalization rule.** A `Lesson` MUST NOT be a verbatim copy of a single
+episode. Producers MUST satisfy `synthesized_from_cluster_size ≥ 2` OR
+have a documented synthesis step that demonstrably abstracts (e.g. a REM
+synthesizer call). This is the on-wire enforcement of Designprinzip 2.
+
+### 3.2 `HubAnchor`
+
+A signed pointer to a region of embedding-space where the producing node
+has high local activity ("a hub I have a lot to say about"). Used by
+peers to discover whose lessons are likely to cover a given topic.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `embedding` | `float[768]` | yes | Centroid of the hub region, in the producer's embedding space. |
+| `hub_score` | `float` | yes | 0..1, the producer's internal centrality measure for this hub. Comparison across nodes is not guaranteed (§3.6). |
+| `local_memory_count` | `int` | yes | Number of local memories aggregated into this anchor. ≥ 1. |
+| `topic_label` | `string` | no | Short human-readable label, ≤ 256 chars. Hint only — not a key. |
+| `origin_node_id` | `string` (multihash) | yes | Producing node. |
+| `signed_at` | `iso8601` | yes | Signing time. |
+| `signature` | `base64` | yes | Ed25519 over JCS(record − signature). |
+| `spec_version` | `string` | yes | Spec version. |
+
+`HubAnchor` does not carry any episode content — only the centroid and
+counts. It is a pointer, not data.
+
+### 3.3 `NodeAdvertisement`
+
+A node's self-description, served at `/.well-known/mycelium-node` (§4) and
+relayed via `/swarm/peers`.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `node_id` | `string` (multihash) | yes | The node's identity. MUST equal `multihash(pubkey)` (§3.5). |
+| `pubkey` | `base64url` | yes | Ed25519 public key, 32 raw bytes, unpadded base64url. |
+| `display_name` | `string` | no | Human-friendly label, ≤ 64 chars. |
+| `endpoint_url` | `https-url` | yes | Base URL where this node's swarm endpoints (§4) are served. |
+| `spec_version` | `string` | yes | Highest spec version the node implements. |
+| `signed_at` | `iso8601` | yes | Signing time. |
+| `signature` | `base64` | yes | Ed25519 over JCS(record − signature). |
+
+Self-signing is required: the advertisement is signed by the same key it
+declares. Verification therefore needs no out-of-band trust root.
+
+### 3.4 `TrustEdge` (local-only)
+
+Trust is **local state**, never shared on the wire. It is specified here
+so all implementations agree on its shape.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `truster_node_id` | `string` (multihash) | yes | The node whose opinion this is (= the local node). |
+| `trustee_node_id` | `string` (multihash) | yes | The node being rated. |
+| `weight` | `float` | yes | 0..1. 0 = ignore everything from `trustee`, 1 = full weight. |
+| `reason` | `string` | yes | Free-form, ≤ 512 chars. Auditable note for the user. |
+| `updated_at` | `iso8601` | yes | Last change. |
+
+A node MAY expose its trust list to its operator (the user who owns the
+node) but MUST NOT expose it across the wire. There is intentionally no
+HTTP endpoint that returns `TrustEdge` records (§4).
+
+### 3.5 `node_id` — multihash of the public key
+
+`node_id` is a self-certifying identifier:
+
+```
+node_id = base58btc( multihash( sha2-256, pubkey_raw_bytes ) )
+```
+
+per the [multihash](https://multiformats.io/multihash/) spec, function
+code `0x12` (sha2-256), digest length 32. This makes a node's address
+verifiable without consulting any registry: you can hash the `pubkey`
+field of a `NodeAdvertisement` and check it matches `node_id`.
+
+### 3.6 Embedding model
+
+v1 fixes the embedding to **768-dimensional `nomic-embed-text`** vectors
+(matching the local Ollama model already used by mycelium). All wire
+records carrying an `embedding` field MUST use this model.
+
+This is a hard constraint, not a hint: cross-model embeddings are
+geometrically incomparable and would silently degrade `HubAnchor`
+matching. Mixing models is out of scope for v1; v2 will define a
+`embedding_model_id` field and per-model index segregation.
+
+---
+
+## 4. Endpoints
+
+All endpoints are HTTP/1.1 or HTTP/2 over TLS (`https://`). No WebSocket,
+no long-poll, no server push in v1. All response bodies are
+`application/json; charset=utf-8`.
+
+### 4.1 `GET /.well-known/mycelium-node`
+
+Returns this node's `NodeAdvertisement`.
+
+- **200**: body is a single `NodeAdvertisement` object.
+- This endpoint is **unauthenticated** and **idempotent**. Every node
+  exposes it. Discovery starts here.
+
+### 4.2 `GET /swarm/peers`
+
+Returns peers this node has chosen to relay. The list is the responding
+node's curated view, not a global directory.
+
+- **200**: body is `{ "peers": NodeAdvertisement[], "signed_at": iso8601, "signature": base64, "origin_node_id": string }`.
+- The wrapping envelope itself is signed by the responding node so the
+  receiver can attribute the curation choice.
+- A node SHOULD NOT include peers it does not currently trust (`TrustEdge.weight = 0`).
+- Pagination is out of scope for v1; if the list grows past one response,
+  a v1 node MAY truncate and the receiver MUST tolerate truncation.
+
+### 4.3 `GET /swarm/lessons`
+
+Returns signed `Lesson` records.
+
+Query parameters:
+
+| name | required | type | meaning |
+|---|---|---|---|
+| `since` | no | `iso8601` | Only lessons with `signed_at > since`. Default: epoch. |
+| `topic` | no | `base64url` of `float[768]` packed as little-endian float64 | Only lessons whose `embedding` cosine-distance to `topic` is below the responder's local threshold. Encoding: 768 × 8 = 6144 bytes → 8192 base64url chars. |
+| `limit` | no | `int` | Max lessons. Default 100. Hard cap 1000. |
+
+- **200**: body is `{ "lessons": Lesson[], "spec_version": string }`.
+- Each `Lesson` is independently signed by its `origin_node_id`. The
+  responding node MAY relay lessons it received from peers; the
+  signature is what authorizes consumption, not the transport.
+- **400**: malformed `topic` (wrong length, not base64url, etc.).
+
+### 4.4 `GET /swarm/hubs`
+
+Returns signed `HubAnchor` records produced by this node.
+
+- **200**: body is `{ "hubs": HubAnchor[], "spec_version": string }`.
+- v1 does not specify topic-filtered hub queries; the list is small by
+  construction (one anchor per high-centrality cluster).
+
+### 4.5 Common HTTP behavior
+
+- `Content-Type` on all responses: `application/json; charset=utf-8`.
+- `Cache-Control: no-store` on `NodeAdvertisement` responses
+  (`signed_at` is observable).
+- Rate limiting is implementation-defined. A v1 node MAY return **429**;
+  receivers MUST tolerate it.
+- Auth between peers: TLS only in v1. Per-request auth (HTTP Signatures,
+  capabilities, etc.) is out of scope.
+
+---
+
+## 5. Rejection rules
+
+A receiving node MUST reject an incoming record before it influences any
+local decision (recall ranking, hub-matching, peer selection, …) if any
+of the following holds. All implementations MUST agree on this list.
+
+1. **Wrong `spec_version` major.** `spec_version` major differs from the
+   receiver's implemented major (§1). → drop, do not log content.
+2. **Missing required field.** Any field marked "required" in §3 absent
+   or `null`. → drop.
+3. **Type mismatch.** Field present but wrong JSON type
+   (e.g. `local_memory_count` is a string). → drop.
+4. **Embedding shape mismatch.** `embedding` not exactly 768 elements,
+   or contains non-finite values. → drop.
+5. **Bad signature.** JCS-recompute + Ed25519-verify against the
+   declared `origin_node_id`'s public key fails. → drop.
+6. **`origin_node_id` ≠ multihash(pubkey)** for `NodeAdvertisement`. → drop.
+7. **Future-dated.** `signed_at > now + 5 minutes` (clock skew tolerance). → drop.
+8. **Stale-dated.** `signed_at < now − 90 days` for `Lesson` and
+   `HubAnchor`. v1 treats long-stale records as expired even if the
+   signature verifies. (Operational rationale: protects against replay of
+   superseded snapshots; the producing node will re-sign current records.)
+9. **`signed_at < created_at`** for `Lesson`. → drop.
+10. **Duplicate `id`** with a different `signature` for the same
+    `origin_node_id` and the same `signed_at`. → drop the later-arriving
+    one and flag the producer.
+11. **`Lesson` violates Generalization rule.**
+    `synthesized_from_cluster_size < 2`. → drop. (v1 enforces the floor
+    on the wire; the documented-synthesis-step exemption from §3.1 is a
+    producer-side rule, not visible on the wire, and v2 will add an
+    explicit `synthesis_method` field for it.)
+12. **`content` over size limit** (`Lesson.content` > 8 KiB,
+    `HubAnchor.topic_label` > 256 chars, `NodeAdvertisement.display_name` > 64). → drop.
+13. **`endpoint_url` not `https`** in a `NodeAdvertisement`. → drop.
+14. **Trust `weight` of 0** on the producer (local trust). → silently
+    drop, no log.
+15. **Body too large.** Receivers MAY enforce a body cap (recommended:
+    16 MiB for `/swarm/lessons` responses); records over the cap are
+    treated as a transport error, not a content-rejection — the receiver
+    SHOULD retry with a smaller `limit`.
+
+Records dropped under rules 1–13 SHOULD be counted in a local metric so
+the operator can see when a peer is misbehaving. Trust adjustments based
+on rejection counts are a v2 concern.
+
+---
+
+## 6. Out of scope for v1
+
+The following are intentionally **not** part of this spec. Implementations
+MUST NOT extend the wire format with these features under the v1 banner;
+they are reserved for v2.
+
+- **NAT traversal** — v1 nodes are reachable only at routable HTTPS
+  endpoints. Hole-punching, STUN/TURN, and relays are deferred.
+- **libp2p / Kademlia DHT** — discovery in v1 is bootstrap-list +
+  `/swarm/peers` gossip. No DHT.
+- **WebSocket / server push** — pull-only. Receivers poll.
+- **Key rotation** — `node_id` is permanent in v1; losing the key means
+  losing the identity. v2 will define a rotation envelope.
+- **Encrypted transport beyond HTTPS** — no end-to-end record encryption,
+  no per-record secrecy. Records are signed, not encrypted.
+- **Differential privacy / k-anonymity** on shared lessons — out of
+  scope. The Generalization rule (§3.1) is the v1 privacy posture.
+- **Per-request authentication** — TLS pins identity to endpoint, signed
+  records pin identity to content. No bearer tokens, no HTTP Signatures.
+- **Microtransactions** — Constitution Pillar 4 applies, but the v1
+  wire has no economic envelope. v2 will add a payment-channel field.
+- **Cross-model embeddings** — locked to 768-d nomic-embed-text in v1
+  (§3.6).
+- **Schema evolution within v1** — additive only via minor bumps; no
+  field removals, no semantics changes.
+
+---
+
+## 7. Node-to-node interaction
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Node A
+    participant B as Node B (peer)
+
+    Note over A: A wakes up, wants fresh lessons in topic T
+    A->>B: GET /.well-known/mycelium-node
+    B-->>A: NodeAdvertisement (signed by B)
+    A->>A: verify multihash(B.pubkey) == B.node_id
+    A->>A: check spec_version compatibility (§1)
+
+    A->>B: GET /swarm/peers
+    B-->>A: { peers: [...], signature: ... }
+    A->>A: verify envelope signature against B's pubkey
+    A->>A: queue new peers for later discovery
+
+    A->>B: GET /swarm/lessons?since=T0&topic=base64url(T)&limit=100
+    B-->>A: { lessons: [Lesson, Lesson, ...] }
+    loop for each Lesson L
+        A->>A: JCS-recompute L without signature
+        A->>A: Ed25519 verify(L.signature, key=L.origin_node_id)
+        A->>A: apply rejection rules §5
+        alt all checks pass
+            A->>A: ingest L (weighted by local TrustEdge for L.origin_node_id)
+        else any check fails
+            A->>A: drop L, increment local rejection counter
+        end
+    end
+
+    A->>B: GET /swarm/hubs
+    B-->>A: { hubs: [HubAnchor, ...] }
+    A->>A: same verify-then-rank loop
+```
+
+Key invariants visible in the diagram:
+
+- The transport-layer peer (B) is **not** trusted to vouch for content.
+  Every lesson is verified against its **origin** node's key, regardless
+  of who relayed it.
+- Trust is applied **after** signature verification. A signature only
+  proves provenance; weight is a local choice.
+- A node never asks a peer for raw episodes — only for already-
+  generalized `Lesson` and `HubAnchor` records (Designprinzip 2).
+
+---
+
+## 8. Constitution affirmation
+
+This spec touches:
+
+- **Pillar 1 — Decentralized, networked AI.** Reinforces it: discovery
+  via `.well-known` + gossip, no central registry, every endpoint
+  optional.
+- **Pillar 3 — Swarm intelligence.** Reinforces it: `Lesson` and
+  `HubAnchor` are the units that let many specialized nodes pool
+  knowledge without flattening difference.
+- **Pillar 6 — Cyber security.** Reinforces it: every record is signed,
+  identity is self-certifying via multihash, transport is TLS-only,
+  rejection rules are explicit and uniform.
+
+No pillar is weakened. Pillars 2 (Reproduction), 4 (Microtransactions),
+and 5 (Experts) are not touched by this spec and remain governed by their
+respective subsystems and by future swarm phases.

--- a/mcp-server/src/__tests__/migration-070-node-identity.test.ts
+++ b/mcp-server/src/__tests__/migration-070-node-identity.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 070 — node_identity table contract pin (Swarm Phase 1a, issue #75)
+//
+// Why this guard exists: this migration creates the cryptographic-identity
+// row that every later swarm phase depends on (provenance, signatures,
+// peer discovery — see docs/SWARM_SPEC.md, NodeAdvertisement). Two
+// contracts MUST hold before phase 1b writes the bootstrap row:
+//
+//   1. Table `nodes` exists with the documented columns and types.
+//   2. The partial unique index `nodes_only_one_self` exists and is
+//      conditional on `is_self`, so at most one row can ever carry
+//      is_self=true.
+//
+// We can't run the migration from this test — the autonomy loop is
+// explicitly forbidden from executing migrations (Reed runs them by hand
+// after merge). What we CAN pin is the canonical SQL text that produces
+// the contract. If a future edit weakens either contract, this test fails
+// before the migration ever hits a real database. Same defensive pattern
+// as the wire-literal pins in affect-*-event-type.test.ts.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/070_node_identity.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so a phrase like
+// "no DROP, no DELETE" inside a comment cannot accidentally satisfy or
+// violate a structural assertion.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent
+// or keyword-case drift (uppercase vs lowercase SQL keywords) without
+// weakening the structural contracts themselves.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+test("migration 070 creates the `nodes` table", () => {
+  // The table name is the join key for every later swarm phase. Renaming
+  // it would silently orphan provenance lookups in 1b / 2 / 3.
+  assert.match(SQL, /create table if not exists nodes\b/);
+});
+
+test("nodes.node_id is TEXT PRIMARY KEY", () => {
+  // node_id is the public, stable handle (multihash of the pubkey).
+  // PRIMARY KEY both pins uniqueness and gives downstream FKs a
+  // deterministic target column.
+  assert.match(SQL, /node_id\s+text\s+primary key/);
+});
+
+test("nodes.pubkey is BYTEA NOT NULL", () => {
+  // bytea, not text — Ed25519 public keys are 32 raw bytes. Storing them
+  // as bytea avoids base64 round-trips at every read. NOT NULL because an
+  // identity row without a pubkey is meaningless and breaks signature
+  // verification before it even starts.
+  assert.match(SQL, /pubkey\s+bytea\s+not null/);
+});
+
+test("nodes.display_name is TEXT (nullable, free-form)", () => {
+  // display_name is informational only — not unique, not required. Pin
+  // its presence and type so a future edit doesn't accidentally promote
+  // it to a uniqueness key (which would break peer-list ingestion the
+  // moment two operators choose the same nickname).
+  assert.match(SQL, /display_name\s+text(?!\s+not null)/);
+});
+
+test("nodes.is_self is BOOLEAN NOT NULL DEFAULT FALSE", () => {
+  // Defensive default: any peer we INSERT without spelling out is_self
+  // must NOT take ownership of this database. A nullable column or a
+  // DEFAULT TRUE would let the wrong row claim self-status and would
+  // also break the partial unique index below (NULL is excluded from the
+  // partial predicate, but DEFAULT TRUE would create an immediate
+  // duplicate the moment a second peer is inserted).
+  assert.match(SQL, /is_self\s+boolean\s+not null\s+default\s+false/);
+});
+
+test("nodes.created_at is TIMESTAMPTZ NOT NULL DEFAULT NOW()", () => {
+  // Timezone-aware (timestamptz, not timestamp), server-set. Federation
+  // timestamps must be unambiguous when nodes in different zones compare
+  // signed_at fields against created_at.
+  assert.match(SQL, /created_at\s+timestamptz\s+not null\s+default\s+now\(\)/);
+});
+
+test("partial unique index enforces 'at most one is_self row'", () => {
+  // The partial unique index is THE constraint that prevents two rows
+  // from claiming to be "this node". PostgreSQL has no native
+  // exactly-one-true constraint; a partial unique index on a constant
+  // expression with WHERE is_self does the job.
+  //
+  // Pinning the WHERE clause is essential — without it, the index would
+  // simply forbid duplicate values of the constant `1`, which is a
+  // useless (and silently broken) constraint that would let the second
+  // is_self=true row through.
+  assert.match(SQL, /create unique index if not exists nodes_only_one_self/);
+  assert.match(SQL, /on nodes\s*\(\(1\)\)\s+where is_self/);
+});
+
+test("migration is create-only (no DROP / DELETE statements)", () => {
+  // Hard rule from issue #75: the migration only creates. A stray
+  // DROP TABLE or DELETE FROM in 070 would either pre-empt later schema
+  // work or wipe a peer list that took weeks to accrue. Comments are
+  // already stripped above, so a documentation phrase like "no DROP" in
+  // the file header cannot trigger this guard.
+  assert.doesNotMatch(SQL, /\bdrop\s+(table|index|column|constraint|schema)\b/);
+  assert.doesNotMatch(SQL, /\bdelete\s+from\b/);
+});
+
+test("a second is_self=true row would violate the unique index", () => {
+  // This is the structural-equivalent of the "two rows with is_self=true
+  // fails" runtime assertion from the issue's acceptance criteria. We
+  // can't run the SQL, but we CAN verify the schema-level guarantee
+  // that produces that runtime behaviour:
+  //
+  //   * the index is UNIQUE,
+  //   * indexed on a constant expression `((1))` (so every qualifying
+  //     row collides on the same key),
+  //   * predicated on `WHERE is_self` (so non-self rows are exempt).
+  //
+  // All three together imply: any second row with is_self=true gets
+  // indexed at key=1 alongside the first, hits the UNIQUE violation,
+  // and the INSERT fails. If any of the three drifts, this assertion
+  // fails first and flags the regression at PR review time rather than
+  // after the migration has already shipped.
+  assert.match(
+    SQL,
+    /create unique index if not exists nodes_only_one_self\s+on nodes\s*\(\(1\)\)\s+where is_self/,
+  );
+});

--- a/supabase/migrations/070_node_identity.sql
+++ b/supabase/migrations/070_node_identity.sql
@@ -1,0 +1,40 @@
+-- 070_node_identity.sql — Swarm Phase 1a (issue #75)
+--
+-- Cryptographic identity of THIS mycelium node, and (later) any peers we
+-- have ever spoken to. Wire format defined by docs/SWARM_SPEC.md
+-- (NodeAdvertisement, landed in PR #78 / phase 0).
+--
+-- Verfassung pillar 1 (Souveränität): the PRIVATE key never lives in this
+-- table. It stays OUTSIDE the database in a chmod-600 file at
+-- ~/.mycelium/node.key. Only the public key and the derived node_id
+-- (multihash of the pubkey) are stored here. A DB compromise alone must
+-- not yield the secret.
+--
+-- This migration ONLY creates structure. No DROP, no DELETE, no data
+-- backfill. The bootstrap row that flips is_self=true is written by a
+-- separate keypair-generation script in phase 1b (different issue) — that
+-- script is the only place the private key is touched, immediately after
+-- which it is written to the chmod-600 file and discarded from memory.
+
+CREATE TABLE IF NOT EXISTS nodes (
+  node_id      TEXT PRIMARY KEY,                  -- multihash(pubkey), e.g. "mc1q..."
+  pubkey       BYTEA NOT NULL,                    -- raw Ed25519 public key (32 bytes)
+  display_name TEXT,                              -- free-form, not unique
+  is_self      BOOLEAN NOT NULL DEFAULT FALSE,    -- exactly one row may have true
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Partial unique index — at most one row may carry is_self=true. PostgreSQL
+-- has no native "exactly-one-true" constraint; a partial unique index on a
+-- constant expression with `WHERE is_self` enforces the "at most one" half.
+-- The "exactly one" half (i.e. presence of a self row at all) is the
+-- responsibility of the phase 1b bootstrap script, not of SQL.
+--
+-- The DEFAULT FALSE on is_self is what makes this safe against accidental
+-- INSERTs of peers without spelling out is_self — they fall outside the
+-- partial index and cannot collide with the self row.
+CREATE UNIQUE INDEX IF NOT EXISTS nodes_only_one_self
+  ON nodes ((1)) WHERE is_self;
+
+COMMENT ON TABLE nodes IS
+  'Mycelium swarm: cryptographic identity of this node and any peers we have ever spoken to. Private keys live OUTSIDE this row (chmod-600 file at ~/.mycelium/node.key). Wire format: docs/SWARM_SPEC.md NodeAdvertisement.';


### PR DESCRIPTION
Closes #75. Second step of the **Swarm Foundation Plan v1** — the cryptographic identity row that every later swarm phase depends on.

## Summary
- New migration `supabase/migrations/070_node_identity.sql` creates `nodes` (node_id PK, pubkey BYTEA, display_name, is_self, created_at). Schema-only — no DROP, no DELETE, no data backfill.
- Partial unique index `nodes_only_one_self ON nodes ((1)) WHERE is_self` enforces "at most one row may carry is_self=true".
- Sibling TS contract test `mcp-server/src/__tests__/migration-070-node-identity.test.ts` pins the canonical SQL (column types, defaults, partial predicate) so any drift fails before the migration ever hits a real database.

## Research summary
- Issue #74 (Phase 0, `docs/SWARM_SPEC.md`) is **closed** — `NodeAdvertisement` is the canonical wire format this row backs, so no dependency note needed.
- Recent migration style (055, 061, 066) uses uppercase SQL keywords, `TIMESTAMPTZ`, `BYTEA`, `BOOLEAN`. Adopted.
- Tests live in `mcp-server/src/__tests__/` and run via `npm test` (`tsc && node --test`). There is no pre-existing `tests/sql/` directory — the existing pattern is TS contract pins (e.g. `affect-recalled-event-type.test.ts`). The test for migration 070 follows that pattern: read the raw SQL file, normalise whitespace + case, assert the structural contracts via regex. We cannot RUN the migration from tests (autonomy loop is forbidden from executing migrations — Reed runs them by hand after merge), so static contract pins are the right tool.

## What this does NOT do
- Does NOT execute the migration. The file is committed only; Reed runs it manually.
- Does NOT include the keypair-generation script or the `~/.mycelium/node.key` writer — that is **Phase 1b** (separate issue).
- Does NOT implement the `node_identity_get` MCP tool — also Phase 1b.
- Does NOT implement signature services — Phase 2.
- Does NOT touch any other migration file or any CI/CD configuration.

## Constitution affirmation
**Pillar 1 — Decentralized, networked AI / Souveränität.** This is the touched pillar, and this PR strengthens it: the table schema deliberately stores **only** the public key and the derived `node_id`. The private key is excluded from the database by design and lives in a chmod-600 file at `~/.mycelium/node.key` (documented in the migration header). A DB compromise alone cannot yield the secret. No other pillar (Reproduction, Swarm Intelligence, Microtransactions, Experts in the Swarm, Cyber Security) is weakened — Cyber Security is reinforced by the same separation.

## Test plan
- [x] `cd mcp-server && npm test` passes (259 tests; 9 of them new for migration 070).
- [ ] After merge, Reed runs `cd scripts && bash migrate.sh` (or applies `070_node_identity.sql` directly) and confirms:
  - `\d nodes` shows columns `node_id text PK`, `pubkey bytea NOT NULL`, `display_name text`, `is_self boolean NOT NULL DEFAULT false`, `created_at timestamptz NOT NULL DEFAULT now()`.
  - `\di nodes_only_one_self` shows the partial unique index with `WHERE is_self`.
  - `INSERT INTO nodes (node_id, pubkey, is_self) VALUES ('x', '\x00', true);` succeeds; a second `INSERT INTO nodes (node_id, pubkey, is_self) VALUES ('y', '\x01', true);` fails with a unique-violation on `nodes_only_one_self`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)