### PR TITLE
feat(swarm): node identity bootstrap + node_identity_get tool (#76)

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -1,0 +1,454 @@
+# SWARM_SPEC — wire-format spec for the decentralized mycelium swarm
+
+**Spec version:** `1.0`
+**Status:** spec-only (no code lands against this PR; phases 1–9 of the
+Swarm Foundation Plan implement against this contract).
+**Audience:** anyone implementing a mycelium node — this repo, a port to
+another language, or an independent peer that wants to be reachable by the
+swarm.
+
+---
+
+## 0. Three unverletzliche Designprinzipien
+
+These three principles are non-negotiable. Any change to this spec, or any
+implementation of it, that weakens one of them is invalid and must be
+rejected before merge.
+
+1. **Souveränität.** Every node is owned and operated by its user.
+   The swarm has no central authority. A node can be disconnected from the
+   swarm at any moment and continue to function as a complete cognitive
+   substrate. Federation is opt-in; offline is the default-correct state.
+
+2. **Generalisierung-vor-Sharing.** Raw episodic memory never leaves the
+   node. Only knowledge that has already been generalized inside the
+   originating node — synthesized lessons, hub-anchor embeddings,
+   signed metadata — is eligible for the wire. The producing node decides
+   what is general enough to share; consumers cannot pull raw episodes.
+
+3. **Diversität.** The swarm's value is the spread of lived experience
+   across nodes, not the average. Sync protocols, trust functions, and any
+   future ranking machinery must preserve heterogeneity. Convergence
+   pressure (e.g. "everyone keeps the most-popular lesson") is an
+   anti-goal.
+
+These mirror the project's [`CONSTITUTION.md`](../CONSTITUTION.md) and the
+*Schwarm-These* memory (`3acb8bb1-f374-436c-a3db-df2af9e50a83`).
+
+---
+
+## 1. Spec versioning
+
+- The current spec version is the string `"1.0"`.
+- Every signed wire record and every `NodeAdvertisement` MUST carry a
+  `spec_version` field.
+- Version negotiation between two nodes is **strict equality on the
+  major component** for v1: a node implementing `"1.x"` MUST refuse to
+  consume records whose `spec_version` major differs from its own. Minor
+  bumps are reserved for backward-compatible additions (new optional
+  fields, new endpoints, new rejection rules); a v1.1 node MUST still
+  accept v1.0 records.
+- The string format is `"<major>.<minor>"`, both decimal integers,
+  no leading zeros, no whitespace. Future pre-release suffixes are out
+  of scope for v1.
+- Spec amendments are made by PR against this file; bumping `spec_version`
+  is the same kind of change as a Constitution amendment in spirit and
+  must explicitly justify why it does not weaken the three Designprinzipien
+  above.
+
+---
+
+## 2. JSON Canonical Form
+
+All signatures in this spec are computed over the **JSON Canonicalization
+Scheme (JCS), [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)**,
+applied to the record with the `signature` field omitted.
+
+JCS gives us a single deterministic byte sequence for any given JSON
+value. The relevant rules, restated for implementer convenience:
+
+- Object keys are sorted by **UTF-16 code unit** order (not Unicode code
+  point, not byte order).
+- Whitespace is removed; the encoding is the minimal compact form.
+- Strings use UTF-8 with the JSON-mandated escapes; no extra escapes.
+- Numbers are serialized using the **ECMAScript `Number.prototype.toString`**
+  algorithm as required by JCS.
+- The input is constrained to **I-JSON** (no duplicate keys, no NaN, no
+  Infinity, no `-0` distinct from `0`).
+
+### 2.1 Float embeddings under JCS — implementer warning
+
+Embeddings are arrays of 768 IEEE-754 double-precision floats. JCS
+serializes each via ECMAScript's number-to-string algorithm, which is
+**not** the same as a language's default `printf("%g")` or
+`json.dumps(float)`. Two implementations that round embeddings differently
+before signing will produce different signatures over byte-identical
+vectors.
+
+Rules for v1:
+
+- The producer MUST serialize each embedding component using a JCS-conformant
+  number serializer. Reference implementations exist in JS
+  ([`json-canonicalize`](https://www.npmjs.com/package/json-canonicalize)),
+  Rust ([`serde_json_canonicalizer`](https://docs.rs/serde_json_canonicalizer/)),
+  and others.
+- Embeddings MUST be transmitted as full-precision floats (no pre-truncation
+  to N decimal places). Truncating before signing is allowed, but the
+  truncated value is then the signed value — receivers cannot distinguish.
+- The producer MUST sign the canonical bytes, not the in-memory value.
+- A receiver computes the canonical bytes from the received JSON, verifies
+  the signature against those bytes, and only then trusts the parsed value.
+
+### 2.2 Signing inputs
+
+For a signed record `R`:
+
+1. Take the JSON object `R'` = `R` with the `signature` key removed.
+2. Compute `bytes = JCS(R')`.
+3. `signature = base64(Ed25519_sign(node_private_key, bytes))`.
+4. Re-attach `signature` to `R` for transport.
+
+Verification is the inverse: strip `signature`, JCS the remainder, verify
+against the producer node's published public key.
+
+### 2.3 Signature algorithm
+
+- v1 uses **Ed25519** exclusively (RFC 8032).
+- Public keys are 32 raw bytes, transported as unpadded base64url in
+  `pubkey` fields, padded base64 in `signature` fields. (The asymmetry is
+  inherited from common library defaults; both encodings are valid base64
+  variants and both are stable across implementations.)
+- Key rotation is **out of scope for v1** (see §6).
+
+---
+
+## 3. Wire types
+
+All wire types are JSON objects. Field types use the following shorthand:
+
+| shorthand | meaning |
+|---|---|
+| `string` | UTF-8 string, no NUL bytes |
+| `uuid` | RFC 4122 v4 UUID, lowercase, hyphenated, 36 chars |
+| `iso8601` | RFC 3339 date-time, UTC (`Z` suffix), millisecond precision: `2026-04-27T18:31:33.183Z` |
+| `int` | JSON number, integer, fits in int64, ≥ 0 unless noted |
+| `float` | JSON number, IEEE-754 double, finite (no NaN/Inf) |
+| `float[N]` | JSON array of exactly N `float` |
+| `string[]` | JSON array of `string`, may be empty |
+| `base64` | standard base64 with padding (RFC 4648 §4) |
+| `base64url` | URL-safe base64 without padding (RFC 4648 §5) |
+| `multihash` | self-describing hash per the multihash spec, base58btc-encoded; see §3.5 |
+| `https-url` | absolute URL, scheme MUST be `https`, no fragment, no userinfo |
+
+All timestamps in wire records are UTC. Local-zone timestamps are a v1
+hard error (§5).
+
+### 3.1 `Lesson`
+
+A generalized piece of knowledge that the producing node has decided is
+shareable. Lessons are the primary unit of swarm sync.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `id` | `uuid` | yes | Lesson identity. Stable across re-publishes. |
+| `content` | `string` | yes | The lesson text, in the producer's voice. ≤ 8 KiB UTF-8. |
+| `embedding` | `float[768]` | yes | Embedding of `content` from the producer's local model (see §3.6). |
+| `synthesized_from_cluster_size` | `int` | yes | Number of source episodes the producer condensed to make this lesson. ≥ 1. Provenance signal — receivers may weight by it. |
+| `origin_node_id` | `string` (multihash) | yes | The producing node's `node_id` (§3.5). |
+| `signed_at` | `iso8601` | yes | When the producer signed this record. |
+| `signature` | `base64` | yes | Ed25519 signature over JCS(record − signature) using `origin_node_id`'s key. |
+| `created_at` | `iso8601` | yes | When the lesson was first synthesized locally. May be earlier than `signed_at`. |
+| `tags` | `string[]` | no | Free-form classification hints. Producers SHOULD keep ≤ 16 tags, each ≤ 64 chars. |
+| `spec_version` | `string` | yes | Spec version this record conforms to (§1). |
+
+**Generalization rule.** A `Lesson` MUST NOT be a verbatim copy of a single
+episode. Producers MUST satisfy `synthesized_from_cluster_size ≥ 2` OR
+have a documented synthesis step that demonstrably abstracts (e.g. a REM
+synthesizer call). This is the on-wire enforcement of Designprinzip 2.
+
+### 3.2 `HubAnchor`
+
+A signed pointer to a region of embedding-space where the producing node
+has high local activity ("a hub I have a lot to say about"). Used by
+peers to discover whose lessons are likely to cover a given topic.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `embedding` | `float[768]` | yes | Centroid of the hub region, in the producer's embedding space. |
+| `hub_score` | `float` | yes | 0..1, the producer's internal centrality measure for this hub. Comparison across nodes is not guaranteed (§3.6). |
+| `local_memory_count` | `int` | yes | Number of local memories aggregated into this anchor. ≥ 1. |
+| `topic_label` | `string` | no | Short human-readable label, ≤ 256 chars. Hint only — not a key. |
+| `origin_node_id` | `string` (multihash) | yes | Producing node. |
+| `signed_at` | `iso8601` | yes | Signing time. |
+| `signature` | `base64` | yes | Ed25519 over JCS(record − signature). |
+| `spec_version` | `string` | yes | Spec version. |
+
+`HubAnchor` does not carry any episode content — only the centroid and
+counts. It is a pointer, not data.
+
+### 3.3 `NodeAdvertisement`
+
+A node's self-description, served at `/.well-known/mycelium-node` (§4) and
+relayed via `/swarm/peers`.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `node_id` | `string` (multihash) | yes | The node's identity. MUST equal `multihash(pubkey)` (§3.5). |
+| `pubkey` | `base64url` | yes | Ed25519 public key, 32 raw bytes, unpadded base64url. |
+| `display_name` | `string` | no | Human-friendly label, ≤ 64 chars. |
+| `endpoint_url` | `https-url` | yes | Base URL where this node's swarm endpoints (§4) are served. |
+| `spec_version` | `string` | yes | Highest spec version the node implements. |
+| `signed_at` | `iso8601` | yes | Signing time. |
+| `signature` | `base64` | yes | Ed25519 over JCS(record − signature). |
+
+Self-signing is required: the advertisement is signed by the same key it
+declares. Verification therefore needs no out-of-band trust root.
+
+### 3.4 `TrustEdge` (local-only)
+
+Trust is **local state**, never shared on the wire. It is specified here
+so all implementations agree on its shape.
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `truster_node_id` | `string` (multihash) | yes | The node whose opinion this is (= the local node). |
+| `trustee_node_id` | `string` (multihash) | yes | The node being rated. |
+| `weight` | `float` | yes | 0..1. 0 = ignore everything from `trustee`, 1 = full weight. |
+| `reason` | `string` | yes | Free-form, ≤ 512 chars. Auditable note for the user. |
+| `updated_at` | `iso8601` | yes | Last change. |
+
+A node MAY expose its trust list to its operator (the user who owns the
+node) but MUST NOT expose it across the wire. There is intentionally no
+HTTP endpoint that returns `TrustEdge` records (§4).
+
+### 3.5 `node_id` — multihash of the public key
+
+`node_id` is a self-certifying identifier:
+
+```
+node_id = base58btc( multihash( sha2-256, pubkey_raw_bytes ) )
+```
+
+per the [multihash](https://multiformats.io/multihash/) spec, function
+code `0x12` (sha2-256), digest length 32. This makes a node's address
+verifiable without consulting any registry: you can hash the `pubkey`
+field of a `NodeAdvertisement` and check it matches `node_id`.
+
+### 3.6 Embedding model
+
+v1 fixes the embedding to **768-dimensional `nomic-embed-text`** vectors
+(matching the local Ollama model already used by mycelium). All wire
+records carrying an `embedding` field MUST use this model.
+
+This is a hard constraint, not a hint: cross-model embeddings are
+geometrically incomparable and would silently degrade `HubAnchor`
+matching. Mixing models is out of scope for v1; v2 will define a
+`embedding_model_id` field and per-model index segregation.
+
+---
+
+## 4. Endpoints
+
+All endpoints are HTTP/1.1 or HTTP/2 over TLS (`https://`). No WebSocket,
+no long-poll, no server push in v1. All response bodies are
+`application/json; charset=utf-8`.
+
+### 4.1 `GET /.well-known/mycelium-node`
+
+Returns this node's `NodeAdvertisement`.
+
+- **200**: body is a single `NodeAdvertisement` object.
+- This endpoint is **unauthenticated** and **idempotent**. Every node
+  exposes it. Discovery starts here.
+
+### 4.2 `GET /swarm/peers`
+
+Returns peers this node has chosen to relay. The list is the responding
+node's curated view, not a global directory.
+
+- **200**: body is `{ "peers": NodeAdvertisement[], "signed_at": iso8601, "signature": base64, "origin_node_id": string }`.
+- The wrapping envelope itself is signed by the responding node so the
+  receiver can attribute the curation choice.
+- A node SHOULD NOT include peers it does not currently trust (`TrustEdge.weight = 0`).
+- Pagination is out of scope for v1; if the list grows past one response,
+  a v1 node MAY truncate and the receiver MUST tolerate truncation.
+
+### 4.3 `GET /swarm/lessons`
+
+Returns signed `Lesson` records.
+
+Query parameters:
+
+| name | required | type | meaning |
+|---|---|---|---|
+| `since` | no | `iso8601` | Only lessons with `signed_at > since`. Default: epoch. |
+| `topic` | no | `base64url` of `float[768]` packed as little-endian float64 | Only lessons whose `embedding` cosine-distance to `topic` is below the responder's local threshold. Encoding: 768 × 8 = 6144 bytes → 8192 base64url chars. |
+| `limit` | no | `int` | Max lessons. Default 100. Hard cap 1000. |
+
+- **200**: body is `{ "lessons": Lesson[], "spec_version": string }`.
+- Each `Lesson` is independently signed by its `origin_node_id`. The
+  responding node MAY relay lessons it received from peers; the
+  signature is what authorizes consumption, not the transport.
+- **400**: malformed `topic` (wrong length, not base64url, etc.).
+
+### 4.4 `GET /swarm/hubs`
+
+Returns signed `HubAnchor` records produced by this node.
+
+- **200**: body is `{ "hubs": HubAnchor[], "spec_version": string }`.
+- v1 does not specify topic-filtered hub queries; the list is small by
+  construction (one anchor per high-centrality cluster).
+
+### 4.5 Common HTTP behavior
+
+- `Content-Type` on all responses: `application/json; charset=utf-8`.
+- `Cache-Control: no-store` on `NodeAdvertisement` responses
+  (`signed_at` is observable).
+- Rate limiting is implementation-defined. A v1 node MAY return **429**;
+  receivers MUST tolerate it.
+- Auth between peers: TLS only in v1. Per-request auth (HTTP Signatures,
+  capabilities, etc.) is out of scope.
+
+---
+
+## 5. Rejection rules
+
+A receiving node MUST reject an incoming record before it influences any
+local decision (recall ranking, hub-matching, peer selection, …) if any
+of the following holds. All implementations MUST agree on this list.
+
+1. **Wrong `spec_version` major.** `spec_version` major differs from the
+   receiver's implemented major (§1). → drop, do not log content.
+2. **Missing required field.** Any field marked "required" in §3 absent
+   or `null`. → drop.
+3. **Type mismatch.** Field present but wrong JSON type
+   (e.g. `local_memory_count` is a string). → drop.
+4. **Embedding shape mismatch.** `embedding` not exactly 768 elements,
+   or contains non-finite values. → drop.
+5. **Bad signature.** JCS-recompute + Ed25519-verify against the
+   declared `origin_node_id`'s public key fails. → drop.
+6. **`origin_node_id` ≠ multihash(pubkey)** for `NodeAdvertisement`. → drop.
+7. **Future-dated.** `signed_at > now + 5 minutes` (clock skew tolerance). → drop.
+8. **Stale-dated.** `signed_at < now − 90 days` for `Lesson` and
+   `HubAnchor`. v1 treats long-stale records as expired even if the
+   signature verifies. (Operational rationale: protects against replay of
+   superseded snapshots; the producing node will re-sign current records.)
+9. **`signed_at < created_at`** for `Lesson`. → drop.
+10. **Duplicate `id`** with a different `signature` for the same
+    `origin_node_id` and the same `signed_at`. → drop the later-arriving
+    one and flag the producer.
+11. **`Lesson` violates Generalization rule.**
+    `synthesized_from_cluster_size < 2`. → drop. (v1 enforces the floor
+    on the wire; the documented-synthesis-step exemption from §3.1 is a
+    producer-side rule, not visible on the wire, and v2 will add an
+    explicit `synthesis_method` field for it.)
+12. **`content` over size limit** (`Lesson.content` > 8 KiB,
+    `HubAnchor.topic_label` > 256 chars, `NodeAdvertisement.display_name` > 64). → drop.
+13. **`endpoint_url` not `https`** in a `NodeAdvertisement`. → drop.
+14. **Trust `weight` of 0** on the producer (local trust). → silently
+    drop, no log.
+15. **Body too large.** Receivers MAY enforce a body cap (recommended:
+    16 MiB for `/swarm/lessons` responses); records over the cap are
+    treated as a transport error, not a content-rejection — the receiver
+    SHOULD retry with a smaller `limit`.
+
+Records dropped under rules 1–13 SHOULD be counted in a local metric so
+the operator can see when a peer is misbehaving. Trust adjustments based
+on rejection counts are a v2 concern.
+
+---
+
+## 6. Out of scope for v1
+
+The following are intentionally **not** part of this spec. Implementations
+MUST NOT extend the wire format with these features under the v1 banner;
+they are reserved for v2.
+
+- **NAT traversal** — v1 nodes are reachable only at routable HTTPS
+  endpoints. Hole-punching, STUN/TURN, and relays are deferred.
+- **libp2p / Kademlia DHT** — discovery in v1 is bootstrap-list +
+  `/swarm/peers` gossip. No DHT.
+- **WebSocket / server push** — pull-only. Receivers poll.
+- **Key rotation** — `node_id` is permanent in v1; losing the key means
+  losing the identity. v2 will define a rotation envelope.
+- **Encrypted transport beyond HTTPS** — no end-to-end record encryption,
+  no per-record secrecy. Records are signed, not encrypted.
+- **Differential privacy / k-anonymity** on shared lessons — out of
+  scope. The Generalization rule (§3.1) is the v1 privacy posture.
+- **Per-request authentication** — TLS pins identity to endpoint, signed
+  records pin identity to content. No bearer tokens, no HTTP Signatures.
+- **Microtransactions** — Constitution Pillar 4 applies, but the v1
+  wire has no economic envelope. v2 will add a payment-channel field.
+- **Cross-model embeddings** — locked to 768-d nomic-embed-text in v1
+  (§3.6).
+- **Schema evolution within v1** — additive only via minor bumps; no
+  field removals, no semantics changes.
+
+---
+
+## 7. Node-to-node interaction
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Node A
+    participant B as Node B (peer)
+
+    Note over A: A wakes up, wants fresh lessons in topic T
+    A->>B: GET /.well-known/mycelium-node
+    B-->>A: NodeAdvertisement (signed by B)
+    A->>A: verify multihash(B.pubkey) == B.node_id
+    A->>A: check spec_version compatibility (§1)
+
+    A->>B: GET /swarm/peers
+    B-->>A: { peers: [...], signature: ... }
+    A->>A: verify envelope signature against B's pubkey
+    A->>A: queue new peers for later discovery
+
+    A->>B: GET /swarm/lessons?since=T0&topic=base64url(T)&limit=100
+    B-->>A: { lessons: [Lesson, Lesson, ...] }
+    loop for each Lesson L
+        A->>A: JCS-recompute L without signature
+        A->>A: Ed25519 verify(L.signature, key=L.origin_node_id)
+        A->>A: apply rejection rules §5
+        alt all checks pass
+            A->>A: ingest L (weighted by local TrustEdge for L.origin_node_id)
+        else any check fails
+            A->>A: drop L, increment local rejection counter
+        end
+    end
+
+    A->>B: GET /swarm/hubs
+    B-->>A: { hubs: [HubAnchor, ...] }
+    A->>A: same verify-then-rank loop
+```
+
+Key invariants visible in the diagram:
+
+- The transport-layer peer (B) is **not** trusted to vouch for content.
+  Every lesson is verified against its **origin** node's key, regardless
+  of who relayed it.
+- Trust is applied **after** signature verification. A signature only
+  proves provenance; weight is a local choice.
+- A node never asks a peer for raw episodes — only for already-
+  generalized `Lesson` and `HubAnchor` records (Designprinzip 2).
+
+---
+
+## 8. Constitution affirmation
+
+This spec touches:
+
+- **Pillar 1 — Decentralized, networked AI.** Reinforces it: discovery
+  via `.well-known` + gossip, no central registry, every endpoint
+  optional.
+- **Pillar 3 — Swarm intelligence.** Reinforces it: `Lesson` and
+  `HubAnchor` are the units that let many specialized nodes pool
+  knowledge without flattening difference.
+- **Pillar 6 — Cyber security.** Reinforces it: every record is signed,
+  identity is self-certifying via multihash, transport is TLS-only,
+  rejection rules are explicit and uniform.
+
+No pillar is weakened. Pillars 2 (Reproduction), 4 (Microtransactions),
+and 5 (Experts) are not touched by this spec and remain governed by their
+respective subsystems and by future swarm phases.

--- a/mcp-server/src/__tests__/migration-070-node-identity.test.ts
+++ b/mcp-server/src/__tests__/migration-070-node-identity.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 070 — node_identity table contract pin (Swarm Phase 1a, issue #75)
+//
+// Why this guard exists: this migration creates the cryptographic-identity
+// row that every later swarm phase depends on (provenance, signatures,
+// peer discovery — see docs/SWARM_SPEC.md, NodeAdvertisement). Two
+// contracts MUST hold before phase 1b writes the bootstrap row:
+//
+//   1. Table `nodes` exists with the documented columns and types.
+//   2. The partial unique index `nodes_only_one_self` exists and is
+//      conditional on `is_self`, so at most one row can ever carry
+//      is_self=true.
+//
+// We can't run the migration from this test — the autonomy loop is
+// explicitly forbidden from executing migrations (Reed runs them by hand
+// after merge). What we CAN pin is the canonical SQL text that produces
+// the contract. If a future edit weakens either contract, this test fails
+// before the migration ever hits a real database. Same defensive pattern
+// as the wire-literal pins in affect-*-event-type.test.ts.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/070_node_identity.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so a phrase like
+// "no DROP, no DELETE" inside a comment cannot accidentally satisfy or
+// violate a structural assertion.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent
+// or keyword-case drift (uppercase vs lowercase SQL keywords) without
+// weakening the structural contracts themselves.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+test("migration 070 creates the `nodes` table", () => {
+  // The table name is the join key for every later swarm phase. Renaming
+  // it would silently orphan provenance lookups in 1b / 2 / 3.
+  assert.match(SQL, /create table if not exists nodes\b/);
+});
+
+test("nodes.node_id is TEXT PRIMARY KEY", () => {
+  // node_id is the public, stable handle (multihash of the pubkey).
+  // PRIMARY KEY both pins uniqueness and gives downstream FKs a
+  // deterministic target column.
+  assert.match(SQL, /node_id\s+text\s+primary key/);
+});
+
+test("nodes.pubkey is BYTEA NOT NULL", () => {
+  // bytea, not text — Ed25519 public keys are 32 raw bytes. Storing them
+  // as bytea avoids base64 round-trips at every read. NOT NULL because an
+  // identity row without a pubkey is meaningless and breaks signature
+  // verification before it even starts.
+  assert.match(SQL, /pubkey\s+bytea\s+not null/);
+});
+
+test("nodes.display_name is TEXT (nullable, free-form)", () => {
+  // display_name is informational only — not unique, not required. Pin
+  // its presence and type so a future edit doesn't accidentally promote
+  // it to a uniqueness key (which would break peer-list ingestion the
+  // moment two operators choose the same nickname).
+  assert.match(SQL, /display_name\s+text(?!\s+not null)/);
+});
+
+test("nodes.is_self is BOOLEAN NOT NULL DEFAULT FALSE", () => {
+  // Defensive default: any peer we INSERT without spelling out is_self
+  // must NOT take ownership of this database. A nullable column or a
+  // DEFAULT TRUE would let the wrong row claim self-status and would
+  // also break the partial unique index below (NULL is excluded from the
+  // partial predicate, but DEFAULT TRUE would create an immediate
+  // duplicate the moment a second peer is inserted).
+  assert.match(SQL, /is_self\s+boolean\s+not null\s+default\s+false/);
+});
+
+test("nodes.created_at is TIMESTAMPTZ NOT NULL DEFAULT NOW()", () => {
+  // Timezone-aware (timestamptz, not timestamp), server-set. Federation
+  // timestamps must be unambiguous when nodes in different zones compare
+  // signed_at fields against created_at.
+  assert.match(SQL, /created_at\s+timestamptz\s+not null\s+default\s+now\(\)/);
+});
+
+test("partial unique index enforces 'at most one is_self row'", () => {
+  // The partial unique index is THE constraint that prevents two rows
+  // from claiming to be "this node". PostgreSQL has no native
+  // exactly-one-true constraint; a partial unique index on a constant
+  // expression with WHERE is_self does the job.
+  //
+  // Pinning the WHERE clause is essential — without it, the index would
+  // simply forbid duplicate values of the constant `1`, which is a
+  // useless (and silently broken) constraint that would let the second
+  // is_self=true row through.
+  assert.match(SQL, /create unique index if not exists nodes_only_one_self/);
+  assert.match(SQL, /on nodes\s*\(\(1\)\)\s+where is_self/);
+});
+
+test("migration is create-only (no DROP / DELETE statements)", () => {
+  // Hard rule from issue #75: the migration only creates. A stray
+  // DROP TABLE or DELETE FROM in 070 would either pre-empt later schema
+  // work or wipe a peer list that took weeks to accrue. Comments are
+  // already stripped above, so a documentation phrase like "no DROP" in
+  // the file header cannot trigger this guard.
+  assert.doesNotMatch(SQL, /\bdrop\s+(table|index|column|constraint|schema)\b/);
+  assert.doesNotMatch(SQL, /\bdelete\s+from\b/);
+});
+
+test("a second is_self=true row would violate the unique index", () => {
+  // This is the structural-equivalent of the "two rows with is_self=true
+  // fails" runtime assertion from the issue's acceptance criteria. We
+  // can't run the SQL, but we CAN verify the schema-level guarantee
+  // that produces that runtime behaviour:
+  //
+  //   * the index is UNIQUE,
+  //   * indexed on a constant expression `((1))` (so every qualifying
+  //     row collides on the same key),
+  //   * predicated on `WHERE is_self` (so non-self rows are exempt).
+  //
+  // All three together imply: any second row with is_self=true gets
+  // indexed at key=1 alongside the first, hits the UNIQUE violation,
+  // and the INSERT fails. If any of the three drifts, this assertion
+  // fails first and flags the regression at PR review time rather than
+  // after the migration has already shipped.
+  assert.match(
+    SQL,
+    /create unique index if not exists nodes_only_one_self\s+on nodes\s*\(\(1\)\)\s+where is_self/,
+  );
+});

--- a/mcp-server/src/__tests__/node-identity.test.ts
+++ b/mcp-server/src/__tests__/node-identity.test.ts
@@ -1,0 +1,282 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash, generateKeyPairSync, createPrivateKey } from "node:crypto";
+
+import {
+  base58btcEncode,
+  computeNodeId,
+  bootstrapNodeIdentity,
+  type NodeIdentityClient,
+  type NodeIdentitySelf,
+  type BootstrapFs,
+  type BootstrapKeypair,
+} from "../services/node-identity.js";
+
+// ---------------------------------------------------------------------------
+// base58btc — the alphabet and the leading-zero rule. These are the two
+// places a custom encoder typically drifts from canonical bitcoin/IPFS
+// behaviour, so pin both before relying on the result for node_id.
+// ---------------------------------------------------------------------------
+
+test("base58btcEncode of empty buffer is empty string", () => {
+  assert.equal(base58btcEncode(Buffer.alloc(0)), "");
+});
+
+test("base58btcEncode preserves leading zero bytes as '1'", () => {
+  // Bitcoin/IPFS rule: each leading 0x00 byte becomes one leading '1' in
+  // the output. Without this rule, two distinct multihashes with
+  // different leading-zero counts would collide on the same string.
+  assert.equal(base58btcEncode(Buffer.from([0x00])), "1");
+  assert.equal(base58btcEncode(Buffer.from([0x00, 0x00])), "11");
+  assert.equal(base58btcEncode(Buffer.from([0x00, 0x01])), "12");
+});
+
+test("base58btcEncode known vector: 'Hello World!'", () => {
+  // Reference vector from https://en.bitcoin.it/wiki/Base58Check_encoding
+  // (raw base58, no checksum). Independent confirmation that the
+  // alphabet ordering is correct.
+  const encoded = base58btcEncode(Buffer.from("Hello World!", "utf8"));
+  assert.equal(encoded, "2NEpo7TZRRrLZSi2U");
+});
+
+// ---------------------------------------------------------------------------
+// computeNodeId — wire-format contract per docs/SWARM_SPEC.md §3.5
+// ---------------------------------------------------------------------------
+
+test("computeNodeId rejects pubkeys that are not 32 bytes", () => {
+  // Ed25519 raw pubkeys are exactly 32 bytes. Silently accepting wrong
+  // sizes would let a bug in upstream key extraction (e.g. forgetting
+  // to slice the SPKI tail) produce a node_id no peer can verify.
+  assert.throws(() => computeNodeId(Buffer.alloc(31)));
+  assert.throws(() => computeNodeId(Buffer.alloc(33)));
+  assert.throws(() => computeNodeId(Buffer.alloc(0)));
+});
+
+test("computeNodeId is deterministic for a given pubkey", () => {
+  const pub = Buffer.alloc(32, 0x42);
+  assert.equal(computeNodeId(pub), computeNodeId(pub));
+});
+
+test("computeNodeId distinguishes different pubkeys", () => {
+  const a = computeNodeId(Buffer.alloc(32, 0x00));
+  const b = computeNodeId(Buffer.alloc(32, 0x01));
+  assert.notEqual(a, b);
+});
+
+test("computeNodeId produces a 46-char base58btc string starting with 'Qm'", () => {
+  // Standard sha2-256 multihash header (function-code 0x12, length 0x20)
+  // plus 32 bytes of digest = 34 bytes. 34 bytes in base58btc encodes
+  // to a 46-character string whose first two characters are always
+  // 'Qm' — the well-known IPFS CIDv0 silhouette. Any deviation here
+  // means we drifted off the multihash spec and peers will reject us.
+  const id = computeNodeId(Buffer.alloc(32, 0));
+  assert.equal(id.length, 46);
+  assert.match(id, /^Qm/);
+});
+
+test("computeNodeId follows the SWARM_SPEC §3.5 formula exactly", () => {
+  // Independent recomputation: base58btc(0x12 || 0x20 || sha256(pubkey)).
+  // If this assertion ever fails the spec and the implementation have
+  // diverged — that's the moment the swarm trust premise breaks.
+  const pub = Buffer.alloc(32, 0xab);
+  const digest = createHash("sha256").update(pub).digest();
+  const multihash = Buffer.concat([Buffer.from([0x12, 0x20]), digest]);
+  assert.equal(computeNodeId(pub), base58btcEncode(multihash));
+});
+
+// ---------------------------------------------------------------------------
+// bootstrapNodeIdentity — idempotency contract
+// ---------------------------------------------------------------------------
+
+function fakePubkey(byte: number): Buffer {
+  return Buffer.alloc(32, byte);
+}
+
+class FakeFs implements BootstrapFs {
+  private files = new Map<string, string>();
+  private dirs = new Set<string>();
+  writes: Array<{ path: string; pem: string }> = [];
+
+  exists(path: string): boolean {
+    return this.files.has(path);
+  }
+  readPrivkeyPem(path: string): string {
+    const v = this.files.get(path);
+    if (v == null) throw new Error(`fake fs: no such file ${path}`);
+    return v;
+  }
+  writePrivkeyPem(path: string, pem: string): void {
+    this.files.set(path, pem);
+    this.writes.push({ path, pem });
+  }
+  ensureDir(path: string): void {
+    this.dirs.add(path);
+  }
+  // test helpers
+  seedFile(path: string, pem: string): void {
+    this.files.set(path, pem);
+  }
+  hasDir(path: string): boolean {
+    return this.dirs.has(path);
+  }
+}
+
+class FakeClient implements NodeIdentityClient {
+  rows: Array<{
+    node_id: string;
+    pubkey: Buffer;
+    display_name: string | null;
+    created_at: string;
+    is_self: boolean;
+  }> = [];
+  inserts = 0;
+
+  async getSelf(): Promise<NodeIdentitySelf | null> {
+    const r = this.rows.find((x) => x.is_self);
+    if (!r) return null;
+    return {
+      node_id: r.node_id,
+      pubkey_b64: r.pubkey.toString("base64"),
+      display_name: r.display_name,
+      created_at: r.created_at,
+    };
+  }
+  async insertSelf(input: {
+    node_id: string;
+    pubkey: Buffer;
+    display_name?: string | null;
+  }): Promise<void> {
+    this.inserts++;
+    if (this.rows.some((x) => x.is_self)) {
+      // The partial unique index in migration 070 enforces this on a real
+      // DB. Mirror the rejection here so tests catch a logic bug that
+      // would silently double-insert in CI without ever hitting Supabase.
+      throw new Error("duplicate self row");
+    }
+    this.rows.push({
+      node_id: input.node_id,
+      pubkey: input.pubkey,
+      display_name: input.display_name ?? null,
+      created_at: new Date().toISOString(),
+      is_self: true,
+    });
+  }
+}
+
+function realKeypairAdapter(): BootstrapKeypair {
+  return {
+    generate: () => {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const spki = publicKey.export({ type: "spki", format: "der" });
+      const pubkeyRaw = Buffer.from(spki.subarray(spki.length - 32));
+      const privateKeyPem = privateKey.export({
+        type: "pkcs8",
+        format: "pem",
+      }) as string;
+      return { privateKeyPem, pubkeyRaw };
+    },
+    pubkeyFromPem: (pem) => {
+      const pk = createPrivateKey(pem);
+      // The cleanest way to derive the raw 32-byte pubkey from an Ed25519
+      // privkey object is via JWK 'x' (base64url, 32 bytes). SPKI export
+      // doesn't work on private keys.
+      const jwk = pk.export({ format: "jwk" }) as { x?: string };
+      if (!jwk.x) throw new Error("ed25519 jwk missing x");
+      return Buffer.from(jwk.x, "base64url");
+    },
+  };
+}
+
+test("bootstrap: first run creates the self row and writes the privkey", async () => {
+  const fs = new FakeFs();
+  const client = new FakeClient();
+  const keypair = realKeypairAdapter();
+  const r = await bootstrapNodeIdentity({
+    keyFile: "/tmp/fake/.mycelium/node.key",
+    keyDir: "/tmp/fake/.mycelium",
+    fs,
+    keypair,
+    client,
+  });
+  assert.equal(r.status, "created");
+  assert.match(r.node_id, /^Qm/);
+  assert.equal(client.inserts, 1);
+  assert.equal(client.rows.length, 1);
+  assert.equal(fs.writes.length, 1);
+  assert.ok(fs.hasDir("/tmp/fake/.mycelium"));
+});
+
+test("bootstrap: second run is a no-op when the privkey file exists", async () => {
+  const fs = new FakeFs();
+  const client = new FakeClient();
+  const keypair = realKeypairAdapter();
+  // First run: real generation writes the file.
+  const first = await bootstrapNodeIdentity({
+    keyFile: "/tmp/fake/.mycelium/node.key",
+    keyDir: "/tmp/fake/.mycelium",
+    fs,
+    keypair,
+    client,
+  });
+  // Second run: same fs/client, expect no further inserts and the SAME
+  // node_id (re-derived from the persisted privkey).
+  const second = await bootstrapNodeIdentity({
+    keyFile: "/tmp/fake/.mycelium/node.key",
+    keyDir: "/tmp/fake/.mycelium",
+    fs,
+    keypair,
+    client,
+  });
+  assert.equal(second.status, "already-initialized");
+  assert.equal(second.node_id, first.node_id);
+  assert.equal(client.inserts, 1, "second run must not insert");
+  assert.equal(fs.writes.length, 1, "second run must not rewrite the privkey file");
+});
+
+test("bootstrap: refuses to create a key when the DB already has a self row", async () => {
+  // Recovery scenario: privkey file deleted (lost backup) but DB still
+  // claims a self identity. Generating a new keypair would orphan every
+  // signature ever produced — refuse loudly, don't degrade silently.
+  const fs = new FakeFs();
+  const client = new FakeClient();
+  await client.insertSelf({
+    node_id: computeNodeId(fakePubkey(0x01)),
+    pubkey: fakePubkey(0x01),
+  });
+  const keypair = realKeypairAdapter();
+  await assert.rejects(
+    () =>
+      bootstrapNodeIdentity({
+        keyFile: "/tmp/fake/.mycelium/node.key",
+        keyDir: "/tmp/fake/.mycelium",
+        fs,
+        keypair,
+        client,
+      }),
+    /inconsistent state/
+  );
+  assert.equal(client.inserts, 1, "must not double-insert during refusal");
+});
+
+test("bootstrap: re-derives node_id from existing privkey deterministically", async () => {
+  // Pin the load-and-derive path independently from the generate path:
+  // a privkey written in run N must yield the same node_id forever, so
+  // an MCP tool reading the DB row and a CLI rerunning the script see
+  // identical identities.
+  const keypair = realKeypairAdapter();
+  const { privateKeyPem, pubkeyRaw } = keypair.generate();
+  const expected = computeNodeId(pubkeyRaw);
+
+  const fs = new FakeFs();
+  fs.seedFile("/tmp/fake/.mycelium/node.key", privateKeyPem);
+  const client = new FakeClient();
+  const r = await bootstrapNodeIdentity({
+    keyFile: "/tmp/fake/.mycelium/node.key",
+    keyDir: "/tmp/fake/.mycelium",
+    fs,
+    keypair,
+    client,
+  });
+  assert.equal(r.status, "already-initialized");
+  assert.equal(r.node_id, expected);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -150,6 +150,10 @@ import {
   classifyContentSchema, classifyContent,
   guardStatusSchema, guardStatus,
 } from "./tools/guard.js";
+import { NodeIdentityService } from "./services/node-identity.js";
+import {
+  nodeIdentityGetSchema, nodeIdentityGet,
+} from "./tools/node-identity.js";
 import {
   getSelfModelSchema, getSelfModel,
   updateSelfModelSchema, updateSelfModel,
@@ -218,6 +222,7 @@ const guardService = new GuardService(
 );
 const neurochemistryService = new NeurochemistryService(SUPABASE_URL, SUPABASE_KEY);
 const relationsService      = new RelationsService(SUPABASE_URL, SUPABASE_KEY);
+const nodeIdentityService   = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY);
 // DEFERRED 2026-04-26 — federation service parked until federation phase.
 // const federationService = new FederationService(
 //   SUPABASE_URL,
@@ -812,6 +817,19 @@ server.tool(
   "Mark an emergence event resolved with a short explanation of the outcome or decision.",
   resolveEmergenceSchema.shape,
   withErrorHandling((input) => resolveEmergence(identityService, resolveEmergenceSchema.parse(input)))
+);
+
+// --- swarm phase 1b: node identity (issue #76) -----------------------------
+// Read-only handle on the cryptographic identity row produced by
+// scripts/init-node-identity.mjs. Other agents and local tooling can call
+// this to quote `node_id` / pubkey without re-deriving the multihash or
+// touching the privkey file. The wire-format convention is fixed by
+// docs/SWARM_SPEC.md §3.5.
+server.tool(
+  "node_identity_get",
+  "Return THIS node's cryptographic identity row: node_id (multihash of pubkey, base58btc-encoded per docs/SWARM_SPEC.md §3.5), base64 pubkey, optional display_name, created_at. Returns a friendly 'not initialized' message when the bootstrap script hasn't run yet.",
+  nodeIdentityGetSchema.shape,
+  withErrorHandling((input) => nodeIdentityGet(nodeIdentityService, nodeIdentityGetSchema.parse(input)))
 );
 
 /* DEFERRED 2026-04-26 — pairing (tinder) + federation-PKI + federation Phase 2.

--- a/mcp-server/src/services/node-identity.ts
+++ b/mcp-server/src/services/node-identity.ts
@@ -1,0 +1,227 @@
+/**
+ * Node identity service — Swarm Phase 1b (issue #76).
+ *
+ * The cryptographic identity of THIS mycelium node. The wire-format
+ * convention is fixed by docs/SWARM_SPEC.md §3.5:
+ *
+ *   node_id = base58btc( multihash( sha2-256, pubkey_raw_bytes ) )
+ *
+ * The standard sha2-256 multihash is `0x12 0x20 || digest`, which
+ * makes every well-formed node_id 46 base58btc characters and prefixed
+ * with `Qm…` — the classic IPFS CIDv0 silhouette.
+ *
+ * Verfassung pillar 1 (Souveränität): the PRIVATE key never reaches
+ * this layer. Bootstrap reads the raw 32-byte pubkey and forwards it;
+ * the privkey stays in a chmod-600 file outside the database.
+ */
+import { PostgrestClient } from "@supabase/postgrest-js";
+import { createHash } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// node_id derivation — pure, side-effect free
+// ---------------------------------------------------------------------------
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/** base58btc — Bitcoin alphabet, no checksum. Pure. */
+export function base58btcEncode(bytes: Buffer): string {
+  if (bytes.length === 0) return "";
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  let n = 0n;
+  for (const b of bytes) n = (n << 8n) | BigInt(b);
+  let out = "";
+  while (n > 0n) {
+    const r = Number(n % 58n);
+    n = n / 58n;
+    out = BASE58_ALPHABET[r] + out;
+  }
+  return "1".repeat(zeros) + out;
+}
+
+/**
+ * Compute node_id from a raw 32-byte Ed25519 public key.
+ *
+ * Throws on wrong length — a malformed pubkey would otherwise silently
+ * produce a node_id that no peer can verify against.
+ */
+export function computeNodeId(pubkeyRaw: Buffer): string {
+  if (pubkeyRaw.length !== 32) {
+    throw new Error(
+      `computeNodeId: expected 32-byte Ed25519 pubkey, got ${pubkeyRaw.length}`
+    );
+  }
+  const digest = createHash("sha256").update(pubkeyRaw).digest();
+  // multihash header for sha2-256: function-code 0x12, length 0x20.
+  const multihash = Buffer.concat([Buffer.from([0x12, 0x20]), digest]);
+  return base58btcEncode(multihash);
+}
+
+// ---------------------------------------------------------------------------
+// PostgREST adapter
+// ---------------------------------------------------------------------------
+
+function fmtErr(err: unknown): string {
+  if (!err) return "unknown error";
+  if (err instanceof Error) return err.message;
+  const e = err as { message?: string; details?: string; hint?: string; code?: string };
+  return e.message || e.details || e.hint || e.code || JSON.stringify(err);
+}
+
+export interface NodeIdentitySelf {
+  node_id: string;
+  pubkey_b64: string;
+  display_name: string | null;
+  created_at: string;
+}
+
+/**
+ * Minimal PostgREST surface this module needs. Lets tests inject a fake
+ * without booting Supabase.
+ */
+export interface NodeIdentityClient {
+  getSelf(): Promise<NodeIdentitySelf | null>;
+  insertSelf(input: {
+    node_id: string;
+    pubkey: Buffer;
+    display_name?: string | null;
+  }): Promise<void>;
+}
+
+/**
+ * Decode a PostgREST-encoded bytea response. PostgREST returns `bytea`
+ * columns as `\x<hex>` strings by default.
+ */
+function decodeBytea(value: unknown): Buffer {
+  if (typeof value !== "string") {
+    throw new Error(`expected bytea string, got ${typeof value}`);
+  }
+  if (value.startsWith("\\x")) return Buffer.from(value.slice(2), "hex");
+  // Fallback: some PostgREST builds may hand back base64 if the request
+  // negotiated it. Keep the path open but assume hex by default.
+  return Buffer.from(value, "base64");
+}
+
+export class NodeIdentityService implements NodeIdentityClient {
+  private readonly db: PostgrestClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.db = new PostgrestClient(supabaseUrl, {
+      headers: supabaseKey
+        ? { Authorization: `Bearer ${supabaseKey}`, apikey: supabaseKey }
+        : {},
+    });
+  }
+
+  async getSelf(): Promise<NodeIdentitySelf | null> {
+    const { data, error } = await this.db
+      .from("nodes")
+      .select("node_id, pubkey, display_name, created_at")
+      .eq("is_self", true)
+      .maybeSingle();
+    if (error) throw new Error(`getSelf: ${fmtErr(error)}`);
+    if (!data) return null;
+    const pubkey = decodeBytea((data as { pubkey: unknown }).pubkey);
+    return {
+      node_id: (data as { node_id: string }).node_id,
+      pubkey_b64: pubkey.toString("base64"),
+      display_name: (data as { display_name: string | null }).display_name,
+      created_at: (data as { created_at: string }).created_at,
+    };
+  }
+
+  async insertSelf(input: {
+    node_id: string;
+    pubkey: Buffer;
+    display_name?: string | null;
+  }): Promise<void> {
+    if (input.pubkey.length !== 32) {
+      throw new Error(
+        `insertSelf: expected 32-byte pubkey, got ${input.pubkey.length}`
+      );
+    }
+    const { error } = await this.db.from("nodes").insert({
+      node_id: input.node_id,
+      pubkey: "\\x" + input.pubkey.toString("hex"),
+      display_name: input.display_name ?? null,
+      is_self: true,
+    });
+    if (error) throw new Error(`insertSelf: ${fmtErr(error)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap — injectable so tests can mock fs + DB
+// ---------------------------------------------------------------------------
+
+export interface BootstrapFs {
+  exists(path: string): boolean;
+  readPrivkeyPem(path: string): string;
+  writePrivkeyPem(path: string, pem: string): void;
+  ensureDir(path: string): void;
+}
+
+export interface BootstrapKeypair {
+  generate(): { privateKeyPem: string; pubkeyRaw: Buffer };
+  pubkeyFromPem(pem: string): Buffer;
+}
+
+export interface BootstrapResult {
+  status: "already-initialized" | "created";
+  node_id: string;
+  privkey_path: string;
+}
+
+/**
+ * Bootstrap the node identity. Idempotent:
+ *
+ *   - if the privkey file is present, reload it, derive the node_id and
+ *     return without touching the DB,
+ *   - if the DB already has a self row but the privkey file is missing,
+ *     refuse to act — that combination is unrecoverable signing-state
+ *     and a human must intervene,
+ *   - otherwise generate a fresh keypair, write the privkey 0600, and
+ *     INSERT the self row.
+ */
+export async function bootstrapNodeIdentity(deps: {
+  keyFile: string;
+  keyDir: string;
+  fs: BootstrapFs;
+  keypair: BootstrapKeypair;
+  client: NodeIdentityClient;
+  displayName?: string | null;
+}): Promise<BootstrapResult> {
+  const { keyFile, keyDir, fs, keypair, client } = deps;
+
+  if (fs.exists(keyFile)) {
+    const pem = fs.readPrivkeyPem(keyFile);
+    const pubkeyRaw = keypair.pubkeyFromPem(pem);
+    const node_id = computeNodeId(pubkeyRaw);
+    return { status: "already-initialized", node_id, privkey_path: keyFile };
+  }
+
+  // Privkey file missing. Before generating a new one, make sure the DB
+  // doesn't already think it knows who this node is — generating a
+  // second keypair while a self row exists would orphan every signature
+  // ever produced under the original key.
+  const existing = await client.getSelf();
+  if (existing) {
+    throw new Error(
+      `inconsistent state: DB has self row (node_id=${existing.node_id}) but privkey file ${keyFile} is missing. ` +
+        `Refusing to generate a new keypair — that would orphan every signature this node has ever produced. ` +
+        `Restore the privkey from backup, or manually delete the self row before re-running.`
+    );
+  }
+
+  fs.ensureDir(keyDir);
+  const { privateKeyPem, pubkeyRaw } = keypair.generate();
+  fs.writePrivkeyPem(keyFile, privateKeyPem);
+  const node_id = computeNodeId(pubkeyRaw);
+  await client.insertSelf({
+    node_id,
+    pubkey: pubkeyRaw,
+    display_name: deps.displayName ?? null,
+  });
+  return { status: "created", node_id, privkey_path: keyFile };
+}

--- a/mcp-server/src/tools/node-identity.ts
+++ b/mcp-server/src/tools/node-identity.ts
@@ -1,0 +1,37 @@
+/**
+ * MCP tool `node_identity_get` — Swarm Phase 1b (issue #76).
+ *
+ * Read-only. Returns the cryptographic identity row of THIS node so
+ * peers and local tooling can quote it without touching the privkey
+ * file or re-deriving the multihash.
+ */
+import { z } from "zod";
+import type { NodeIdentityService } from "../services/node-identity.js";
+
+export const nodeIdentityGetSchema = z.object({});
+
+export async function nodeIdentityGet(
+  service: NodeIdentityService,
+  _input: unknown
+) {
+  const self = await service.getSelf();
+  if (!self) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text:
+            "No node identity initialized yet. Run `node scripts/init-node-identity.mjs` " +
+            "to generate the keypair and insert the self row.",
+        },
+      ],
+    };
+  }
+  const lines = [
+    `node_id:      ${self.node_id}`,
+    `pubkey_b64:   ${self.pubkey_b64}`,
+    `display_name: ${self.display_name ?? "(unset)"}`,
+    `created_at:   ${self.created_at}`,
+  ];
+  return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+}

--- a/scripts/init-node-identity.mjs
+++ b/scripts/init-node-identity.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * scripts/init-node-identity.mjs — Swarm Phase 1b (issue #76).
+ *
+ * Bootstraps the cryptographic identity of THIS mycelium node:
+ *
+ *   1. Generates an Ed25519 keypair (node:crypto, no extra deps).
+ *   2. Writes the private key PEM to ~/.mycelium/node.key with mode 0600
+ *      inside a 0700 directory. The privkey never enters the database.
+ *   3. Computes node_id = base58btc(multihash(sha2-256, pubkey_raw))
+ *      per docs/SWARM_SPEC.md §3.5.
+ *   4. INSERTs the self-row into `nodes` (migration 070, issue #75).
+ *
+ * Idempotent. Running twice is safe:
+ *   - if ~/.mycelium/node.key already exists, the script reloads it,
+ *     re-derives node_id, prints it and exits 0.
+ *   - if the DB has a self row but the privkey file is missing, the
+ *     script refuses to act — that combination is unrecoverable
+ *     signing-state and a human must intervene.
+ *
+ * Wraps `bootstrapNodeIdentity` from the compiled MCP server. Build the
+ * server first: `cd mcp-server && npm run build`.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  generateKeyPairSync,
+  createPrivateKey,
+} from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const DIST = path.join(ROOT, "mcp-server", "dist");
+
+// Match the existing scripts/breed-agents.mjs and scripts/index-tools.mjs
+// pattern: read SUPABASE_URL/KEY out of .mcp.json so a fresh shell
+// without exported env vars still works.
+function loadEnv() {
+  try {
+    const cfgPath = path.join(ROOT, ".mcp.json");
+    if (!fs.existsSync(cfgPath)) return;
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    const env = cfg.mcpServers?.["vector-memory"]?.env ?? {};
+    for (const [k, v] of Object.entries(env)) process.env[k] ||= v;
+  } catch (e) {
+    console.warn(`! could not parse .mcp.json: ${e?.message ?? e}`);
+  }
+}
+
+loadEnv();
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error(
+    "✗ SUPABASE_URL and SUPABASE_KEY must be set (export them, or add to .mcp.json mcpServers.vector-memory.env)."
+  );
+  process.exit(1);
+}
+
+const distExists = fs.existsSync(path.join(DIST, "services/node-identity.js"));
+if (!distExists) {
+  console.error(
+    "✗ mcp-server/dist/services/node-identity.js not found. Run `cd mcp-server && npm run build` first."
+  );
+  process.exit(1);
+}
+
+const { NodeIdentityService, bootstrapNodeIdentity } = await import(
+  path.join(DIST, "services/node-identity.js")
+);
+
+const KEY_DIR  = path.join(os.homedir(), ".mycelium");
+const KEY_FILE = path.join(KEY_DIR, "node.key");
+
+// Real-fs adapter that mirrors the BootstrapFs interface used by the
+// pure bootstrap function.
+const realFs = {
+  exists: (p) => fs.existsSync(p),
+  readPrivkeyPem: (p) => fs.readFileSync(p, "utf8"),
+  writePrivkeyPem: (p, pem) => {
+    fs.writeFileSync(p, pem, { mode: 0o600 });
+    // chmodSync as a belt-and-suspenders guard — depending on the
+    // operator's umask, the initial mode flag may be masked off.
+    fs.chmodSync(p, 0o600);
+  },
+  ensureDir: (p) => {
+    if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true, mode: 0o700 });
+    fs.chmodSync(p, 0o700);
+  },
+};
+
+const realKeypair = {
+  generate: () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    // Ed25519 raw pubkey: last 32 bytes of the SPKI DER encoding.
+    const spki = publicKey.export({ type: "spki", format: "der" });
+    const pubkeyRaw = Buffer.from(spki.subarray(spki.length - 32));
+    const privateKeyPem = privateKey.export({
+      type: "pkcs8",
+      format: "pem",
+    });
+    return { privateKeyPem, pubkeyRaw };
+  },
+  pubkeyFromPem: (pem) => {
+    const pk = createPrivateKey(pem);
+    // JWK export reveals the raw pubkey under 'x' (base64url, 32 bytes).
+    const jwk = pk.export({ format: "jwk" });
+    if (!jwk.x) throw new Error("ed25519 jwk export missing 'x'");
+    return Buffer.from(jwk.x, "base64url");
+  },
+};
+
+const client = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY);
+
+try {
+  const r = await bootstrapNodeIdentity({
+    keyFile: KEY_FILE,
+    keyDir: KEY_DIR,
+    fs: realFs,
+    keypair: realKeypair,
+    client,
+    displayName: process.env.MYCELIUM_NODE_DISPLAY_NAME ?? null,
+  });
+  if (r.status === "already-initialized") {
+    console.log(`node_id already initialized: ${r.node_id}`);
+    console.log(`privkey:                     ${r.privkey_path}`);
+  } else {
+    console.log(`✓ mycelium node identity bootstrapped`);
+    console.log(`  node_id: ${r.node_id}`);
+    console.log(`  privkey: ${r.privkey_path}  (chmod 0600)`);
+  }
+} catch (e) {
+  console.error(`✗ ${e?.message ?? e}`);
+  process.exit(1);
+}

--- a/supabase/migrations/070_node_identity.sql
+++ b/supabase/migrations/070_node_identity.sql
@@ -1,0 +1,40 @@
+-- 070_node_identity.sql — Swarm Phase 1a (issue #75)
+--
+-- Cryptographic identity of THIS mycelium node, and (later) any peers we
+-- have ever spoken to. Wire format defined by docs/SWARM_SPEC.md
+-- (NodeAdvertisement, landed in PR #78 / phase 0).
+--
+-- Verfassung pillar 1 (Souveränität): the PRIVATE key never lives in this
+-- table. It stays OUTSIDE the database in a chmod-600 file at
+-- ~/.mycelium/node.key. Only the public key and the derived node_id
+-- (multihash of the pubkey) are stored here. A DB compromise alone must
+-- not yield the secret.
+--
+-- This migration ONLY creates structure. No DROP, no DELETE, no data
+-- backfill. The bootstrap row that flips is_self=true is written by a
+-- separate keypair-generation script in phase 1b (different issue) — that
+-- script is the only place the private key is touched, immediately after
+-- which it is written to the chmod-600 file and discarded from memory.
+
+CREATE TABLE IF NOT EXISTS nodes (
+  node_id      TEXT PRIMARY KEY,                  -- multihash(pubkey), e.g. "mc1q..."
+  pubkey       BYTEA NOT NULL,                    -- raw Ed25519 public key (32 bytes)
+  display_name TEXT,                              -- free-form, not unique
+  is_self      BOOLEAN NOT NULL DEFAULT FALSE,    -- exactly one row may have true
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Partial unique index — at most one row may carry is_self=true. PostgreSQL
+-- has no native "exactly-one-true" constraint; a partial unique index on a
+-- constant expression with `WHERE is_self` enforces the "at most one" half.
+-- The "exactly one" half (i.e. presence of a self row at all) is the
+-- responsibility of the phase 1b bootstrap script, not of SQL.
+--
+-- The DEFAULT FALSE on is_self is what makes this safe against accidental
+-- INSERTs of peers without spelling out is_self — they fall outside the
+-- partial index and cannot collide with the self row.
+CREATE UNIQUE INDEX IF NOT EXISTS nodes_only_one_self
+  ON nodes ((1)) WHERE is_self;
+
+COMMENT ON TABLE nodes IS
+  'Mycelium swarm: cryptographic identity of this node and any peers we have ever spoken to. Private keys live OUTSIDE this row (chmod-600 file at ~/.mycelium/node.key). Wire format: docs/SWARM_SPEC.md NodeAdvertisement.';


### PR DESCRIPTION
Closes #76 — Swarm Phase 1b.

## Summary
- New `scripts/init-node-identity.mjs`: idempotent Ed25519 keypair bootstrap. Privkey lands in `~/.mycelium/node.key` (mode 0600, 0700 directory); pubkey + derived `node_id` go into the `nodes` self-row.
- New MCP tool `node_identity_get`: read-only, returns `{ node_id, pubkey_b64, display_name, created_at }`.
- `node_id` follows `docs/SWARM_SPEC.md` §3.5 exactly: `base58btc(multihash(sha2-256, pubkey_raw))` → 46-char `Qm…` string.

## Research summary
- Inspected the existing MCP-tool pattern (`tools/identity.ts`, `tools/soul.ts`) and copied the read-only `getSelfModel` shape for the new tool.
- `node:crypto` already supports Ed25519 (`generateKeyPairSync('ed25519')`); existing `services/crypto.ts` uses the same SPKI-tail pattern to extract the raw 32-byte pubkey, so I reused it.
- The wire-format formula was already pinned in `docs/SWARM_SPEC.md` (merged in `a50444a`); the migration spec from #75 is in `supabase/migrations/070_node_identity.sql` (merged in `3cce198`). PR #79 (which includes the contract test) is still open but the schema needed by this PR is already on `main`.
- Encoded base58btc by hand (no extra dep) with explicit leading-zero handling — pinned by tests against the canonical `2NEpo7TZRRrLZSi2U` 'Hello World!' vector.

## What this does NOT do
- No SQL is executed. Migration 070 must be applied to the database manually before the bootstrap script can live-run; the script will fail with a clear PostgREST error if the `nodes` table is missing.
- No `display_name` heuristic — the bootstrap optionally honours `MYCELIUM_NODE_DISPLAY_NAME`, otherwise leaves the field NULL.
- No automatic call from setup.sh/install.sh — wiring the bootstrap into the installer is a follow-up.
- No use of the new identity by any other tool (advertisements, signed lessons, peer discovery) — those are later swarm phases.

## Constitution affirmation
Touches Pillar 1 (Decentralized) and Pillar 6 (Cyber security). Reinforced, not weakened:
- Pillar 1: identity is generated and owned locally; no central registry consulted.
- Pillar 6: the privkey never reaches the database, lives in a chmod-600 file inside a chmod-700 directory, and bootstrap refuses to regenerate when DB state is inconsistent (would otherwise orphan every signature ever produced under the original key).
- No other pillar weakened — pairing/breeding/swarm-economics surfaces untouched.

## Test plan
- `cd mcp-server && npm test` — 271 tests pass, including 12 new ones in `node-identity.test.ts`:
  - base58btc encoding (empty buffer, leading-zero rule, canonical 'Hello World!' vector)
  - `computeNodeId` rejects non-32-byte input, is deterministic, distinguishes inputs, produces a 46-char `Qm…`, matches the spec formula
  - bootstrap idempotency: first run inserts, second run is a no-op, refusal-on-inconsistent-state, deterministic re-derivation from existing privkey
- Live-test (after migration 070 is applied to a real Supabase): `cd mcp-server && npm run build && node scripts/init-node-identity.mjs` — verify (a) `~/.mycelium/node.key` is created with 0600, (b) `nodes` table has exactly one `is_self=true` row, (c) running again prints `node_id already initialized: …` and inserts nothing, (d) calling `node_identity_get` from any MCP client returns the same `node_id`.