### PR TITLE
feat(consolidation): confidence + scope gate for lesson/trait promotion (#80)

### DIFF
--- a/mcp-server/src/__tests__/admission-gate.test.ts
+++ b/mcp-server/src/__tests__/admission-gate.test.ts
@@ -1,0 +1,234 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  LESSON_MIN_CONFIDENCE,
+  LESSON_MIN_SOURCES,
+  TRAIT_MIN_EVIDENCE,
+  clusterProjectScope,
+  looksLikeAutoSummary,
+  gateLessonAdmission,
+  gateTraitAdmission,
+} from "../services/admission-gate.js";
+
+// ---------------------------------------------------------------------------
+// clusterProjectScope — single source of truth for "all members agree on a
+// single project_id". The lesson gate uses this to refuse cross-project
+// clusters; mis-detecting consistency is exactly how vectorworks-scoped
+// experiences leaked into mycelium-global identity traits in the first place.
+// ---------------------------------------------------------------------------
+
+test("clusterProjectScope: empty members → consistent, project_id null", () => {
+  const out = clusterProjectScope([]);
+  assert.equal(out.consistent, true);
+  assert.equal(out.project_id, null);
+});
+
+test("clusterProjectScope: all same project_id → consistent", () => {
+  const out = clusterProjectScope([
+    { project_id: "p1" },
+    { project_id: "p1" },
+    { project_id: "p1" },
+  ]);
+  assert.equal(out.consistent, true);
+  assert.equal(out.project_id, "p1");
+});
+
+test("clusterProjectScope: all NULL → consistent, project_id null", () => {
+  const out = clusterProjectScope([
+    { project_id: null },
+    { project_id: null },
+  ]);
+  assert.equal(out.consistent, true);
+  assert.equal(out.project_id, null);
+});
+
+test("clusterProjectScope: NULL + project → inconsistent (the leakage shape)", () => {
+  // This is the exact shape that put vectorworks "Ich habe gelernt …" entries
+  // into the mycelium-global self-model: a cluster mixing project-scoped and
+  // global experiences. NULL must NOT be treated as a wildcard match.
+  const out = clusterProjectScope([
+    { project_id: "vectorworks" },
+    { project_id: null },
+  ]);
+  assert.equal(out.consistent, false);
+  assert.equal(out.project_id, null);
+});
+
+test("clusterProjectScope: two different projects → inconsistent", () => {
+  const out = clusterProjectScope([
+    { project_id: "p1" },
+    { project_id: "p2" },
+  ]);
+  assert.equal(out.consistent, false);
+});
+
+// ---------------------------------------------------------------------------
+// looksLikeAutoSummary — pattern detector for the "Ich habe gelernt …" /
+// "I refreshed the context …" first-person episode recap that the issue
+// body calls out as the four polluting entries currently in the mycelium
+// self-model.
+// ---------------------------------------------------------------------------
+
+test("looksLikeAutoSummary: 'Ich habe gelernt …' → true", () => {
+  assert.equal(
+    looksLikeAutoSummary("Ich habe gelernt: Ich habe die Produktdaten-Tabelle geprüft."),
+    true,
+  );
+});
+
+test("looksLikeAutoSummary: 'I refreshed the context …' → true", () => {
+  assert.equal(
+    looksLikeAutoSummary("I refreshed the context for issue #11 and re-read the body."),
+    true,
+  );
+});
+
+test("looksLikeAutoSummary: 'I handled a heartbeat check …' → true", () => {
+  assert.equal(
+    looksLikeAutoSummary("I handled a heartbeat check at the end of the day."),
+    true,
+  );
+});
+
+test("looksLikeAutoSummary: a real rule passes (handlungsleitend)", () => {
+  assert.equal(
+    looksLikeAutoSummary("Wenn ein event-type Wire-Literal unpinned ist, dann konstant extrahieren."),
+    false,
+  );
+});
+
+test("looksLikeAutoSummary: empty / null → false", () => {
+  assert.equal(looksLikeAutoSummary(""), false);
+  assert.equal(looksLikeAutoSummary(null), false);
+  assert.equal(looksLikeAutoSummary(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// gateLessonAdmission — three-way reject (low_confidence / too_few_sources /
+// mixed_project_scope), defaults from the issue spec.
+// ---------------------------------------------------------------------------
+
+test("gateLessonAdmission: defaults match issue spec", () => {
+  assert.equal(LESSON_MIN_CONFIDENCE, 0.7);
+  assert.equal(LESSON_MIN_SOURCES, 3);
+});
+
+test("gateLessonAdmission: meets all thresholds → admit", () => {
+  const out = gateLessonAdmission({ confidence: 0.8, member_count: 3, project_consistent: true });
+  assert.equal(out.admit, true);
+  assert.equal(out.reason, "ok");
+});
+
+test("gateLessonAdmission: confidence below 0.7 → reject low_confidence", () => {
+  const out = gateLessonAdmission({ confidence: 0.65, member_count: 5, project_consistent: true });
+  assert.equal(out.admit, false);
+  assert.equal(out.reason, "low_confidence");
+});
+
+test("gateLessonAdmission: confidence == 0.7 (boundary) → admit", () => {
+  const out = gateLessonAdmission({ confidence: 0.7, member_count: 3, project_consistent: true });
+  assert.equal(out.admit, true);
+});
+
+test("gateLessonAdmission: only 2 members → reject too_few_sources", () => {
+  const out = gateLessonAdmission({ confidence: 0.9, member_count: 2, project_consistent: true });
+  assert.equal(out.admit, false);
+  assert.equal(out.reason, "too_few_sources");
+});
+
+test("gateLessonAdmission: mixed project → reject mixed_project_scope", () => {
+  const out = gateLessonAdmission({ confidence: 0.9, member_count: 4, project_consistent: false });
+  assert.equal(out.admit, false);
+  assert.equal(out.reason, "mixed_project_scope");
+});
+
+test("gateLessonAdmission: opts can override thresholds (allow lower bar)", () => {
+  const out = gateLessonAdmission(
+    { confidence: 0.5, member_count: 2, project_consistent: true },
+    { minConfidence: 0.4, minSources: 2 },
+  );
+  assert.equal(out.admit, true);
+});
+
+test("gateLessonAdmission: allowMixedProject opens the project gate", () => {
+  const out = gateLessonAdmission(
+    { confidence: 0.9, member_count: 4, project_consistent: false },
+    { allowMixedProject: true },
+  );
+  assert.equal(out.admit, true);
+});
+
+test("gateLessonAdmission: reasons are checked in order — confidence wins over sources", () => {
+  const out = gateLessonAdmission({ confidence: 0.5, member_count: 1, project_consistent: false });
+  assert.equal(out.reason, "low_confidence");
+});
+
+test("gateLessonAdmission: reasons checked in order — sources wins over project", () => {
+  const out = gateLessonAdmission({ confidence: 0.9, member_count: 1, project_consistent: false });
+  assert.equal(out.reason, "too_few_sources");
+});
+
+// ---------------------------------------------------------------------------
+// gateTraitAdmission — protects the self-model surface from auto-summaries
+// and shallow-evidence promotions.
+// ---------------------------------------------------------------------------
+
+test("gateTraitAdmission: defaults match issue spec", () => {
+  assert.equal(TRAIT_MIN_EVIDENCE, 3);
+});
+
+test("gateTraitAdmission: rule-form lesson with enough evidence → admit", () => {
+  const out = gateTraitAdmission({
+    lesson_text: "Wenn ein Wire-Literal unpinned ist, dann konstant extrahieren.",
+    evidence_count: 4,
+    project_id: "mycelium",
+  });
+  assert.equal(out.admit, true);
+  assert.equal(out.reason, "ok");
+});
+
+test("gateTraitAdmission: 'Ich habe gelernt …' rejected as auto_summary", () => {
+  // This is the exact pattern from the issue body — vectorworks Cameo-OPUS
+  // recap that should never have been admitted as a global identity trait.
+  const out = gateTraitAdmission({
+    lesson_text: "Ich habe gelernt: Cameo OPUS H6 IP, 28 kg, 600 W LED.",
+    evidence_count: 4,
+    project_id: "vectorworks",
+  });
+  assert.equal(out.admit, false);
+  assert.equal(out.reason, "auto_summary");
+});
+
+test("gateTraitAdmission: evidence < 3 → reject low_evidence", () => {
+  const out = gateTraitAdmission({
+    lesson_text: "Wenn X, dann Y, weil Z.",
+    evidence_count: 2,
+    project_id: null,
+  });
+  assert.equal(out.admit, false);
+  assert.equal(out.reason, "low_evidence");
+});
+
+test("gateTraitAdmission: empty lesson_text → reject missing_text", () => {
+  const out = gateTraitAdmission({ lesson_text: "", evidence_count: 5 });
+  assert.equal(out.admit, false);
+  assert.equal(out.reason, "missing_text");
+});
+
+test("gateTraitAdmission: low_evidence wins over auto_summary (order)", () => {
+  // Both are violated; the cheaper numerical check is reported first so
+  // telemetry counts the load-bearing reason.
+  const out = gateTraitAdmission({
+    lesson_text: "Ich habe gelernt: foo.",
+    evidence_count: 1,
+  });
+  assert.equal(out.reason, "low_evidence");
+});
+
+test("gateTraitAdmission: minEvidence override", () => {
+  const out = gateTraitAdmission(
+    { lesson_text: "Wenn X, dann Y.", evidence_count: 2 },
+    { minEvidence: 2 },
+  );
+  assert.equal(out.admit, true);
+});

--- a/mcp-server/src/__tests__/signature.test.ts
+++ b/mcp-server/src/__tests__/signature.test.ts
@@ -1,0 +1,308 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateKeyPairSync,
+  createPrivateKey,
+  sign as nodeSign,
+} from "node:crypto";
+
+import {
+  canonicalize,
+  sign,
+  verify,
+  signWithSelfKey,
+  defaultKeyFile,
+} from "../services/signature.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshKeypair(): { pem: string; pubkeyRaw: Uint8Array } {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ type: "spki", format: "der" });
+  // Last 32 bytes of the SPKI DER are the raw Ed25519 pubkey.
+  const pubkeyRaw = new Uint8Array(spki.subarray(spki.length - 32));
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  return { pem, pubkeyRaw };
+}
+
+// ---------------------------------------------------------------------------
+// canonicalize — RFC 8785 conformance vectors
+//
+// The wire-format trust premise breaks the moment two implementations
+// disagree on the bytes-under-signature, so we pin the small but
+// load-bearing rules here rather than only relying on round-trip tests.
+// ---------------------------------------------------------------------------
+
+test("canonicalize: primitives", () => {
+  assert.equal(canonicalize(null), "null");
+  assert.equal(canonicalize(true), "true");
+  assert.equal(canonicalize(false), "false");
+  assert.equal(canonicalize(0), "0");
+  assert.equal(canonicalize(-1), "-1");
+  assert.equal(canonicalize(1.5), "1.5");
+  assert.equal(canonicalize("hello"), '"hello"');
+  assert.equal(canonicalize(""), '""');
+});
+
+test("canonicalize: empty containers", () => {
+  assert.equal(canonicalize([]), "[]");
+  assert.equal(canonicalize({}), "{}");
+});
+
+test("canonicalize: object keys are sorted by UTF-16 code unit (RFC 8785 §3.2.3)", () => {
+  // The pillar property: any reordering at construction time produces
+  // the same canonical bytes. Without this, two honest senders writing
+  // the same record in different orders would produce different
+  // signatures and the swarm trust premise breaks.
+  assert.equal(canonicalize({ a: 1, b: 2 }), '{"a":1,"b":2}');
+  assert.equal(canonicalize({ b: 2, a: 1 }), '{"a":1,"b":2}');
+  // Mixed casing matters — uppercase letters precede lowercase in UTF-16.
+  assert.equal(canonicalize({ b: 1, A: 2 }), '{"A":2,"b":1}');
+  // Sorting recurses into nested objects.
+  assert.equal(
+    canonicalize({ outer: { z: 1, a: 2 }, alpha: 1 }),
+    '{"alpha":1,"outer":{"a":2,"z":1}}'
+  );
+});
+
+test("canonicalize: arrays preserve order (only object keys are sorted)", () => {
+  // RFC 8785 §3.2.4: arrays are not reordered. Reordering would change
+  // the meaning of e.g. an embedding vector silently.
+  assert.equal(canonicalize([3, 1, 2]), "[3,1,2]");
+  assert.equal(canonicalize(["b", "a", "c"]), '["b","a","c"]');
+});
+
+test("canonicalize: numbers via ECMAScript Number-to-String", () => {
+  // RFC 8785 §3.2.2.3 mandates exactly the JS Number toString algorithm.
+  // JSON.stringify on a finite Number returns that representation,
+  // including the `1e+21` / `-0 → 0` edge cases worth pinning.
+  assert.equal(canonicalize(1e21), "1e+21");
+  assert.equal(canonicalize(-0), "0");
+  assert.equal(canonicalize(0.1), "0.1");
+  assert.equal(canonicalize(100), "100");
+});
+
+test("canonicalize: rejects non-finite numbers (I-JSON constraint)", () => {
+  // SWARM_SPEC §2 / RFC 7493: NaN and ±Infinity are not valid JSON. A
+  // silent coercion here would let one node produce bytes that no other
+  // node can reproduce, so the verifier MUST refuse the input loudly.
+  assert.throws(() => canonicalize(NaN), /non-finite/);
+  assert.throws(() => canonicalize(Infinity), /non-finite/);
+  assert.throws(() => canonicalize(-Infinity), /non-finite/);
+});
+
+test("canonicalize: rejects undefined", () => {
+  // Symbols, functions, undefined — none are JSON-representable. Falling
+  // back to JSON.stringify behaviour (silently dropping object keys with
+  // undefined values, returning undefined for top-level undefined) would
+  // make the canonical form context-dependent.
+  assert.throws(() => canonicalize(undefined));
+});
+
+test("canonicalize: stringifies common JSON-escaped characters", () => {
+  assert.equal(canonicalize('a"b'), '"a\\"b"');
+  assert.equal(canonicalize("a\\b"), '"a\\\\b"');
+  assert.equal(canonicalize("\n\r\t"), '"\\n\\r\\t"');
+});
+
+test("canonicalize: the RFC 8785 §3.2.3 example", () => {
+  // From the RFC text (Appendix B example, abridged): demonstrates that
+  // both key sorting and number normalization act in the same pass.
+  assert.equal(
+    canonicalize({ "1": "one", "10": "ten", "2": "two" }),
+    '{"1":"one","10":"ten","2":"two"}'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// sign / verify — round-trip and tamper-resistance
+// ---------------------------------------------------------------------------
+
+test("sign+verify: round-trip succeeds with the matching public key", () => {
+  // The most basic property — without it nothing else matters. If this
+  // ever regresses the swarm cannot exchange a single signed record.
+  const { pem, pubkeyRaw } = freshKeypair();
+  const record = { id: "abc", content: "hello swarm", n: 7 };
+  const signature = sign(record, pem);
+  assert.equal(verify(record, signature, pubkeyRaw), true);
+});
+
+test("verify: a single-byte tampering of the record fails verification", () => {
+  // Verifier MUST detect mutation of any signed field. We mutate one
+  // byte of a string field — this is the canonical detection surface
+  // for malicious record edits in transit.
+  const { pem, pubkeyRaw } = freshKeypair();
+  const record = { id: "abc", content: "hello swarm", n: 7 };
+  const signature = sign(record, pem);
+  const tampered = { ...record, content: "Hello swarm" }; // one-byte case flip
+  assert.equal(verify(tampered, signature, pubkeyRaw), false);
+});
+
+test("verify: a different field added to the record fails verification", () => {
+  // Adding a field changes the JCS bytes, so the signature must be
+  // rejected even if the original fields are untouched. Otherwise an
+  // attacker could append claims to a signed record.
+  const { pem, pubkeyRaw } = freshKeypair();
+  const record = { id: "abc", content: "hello swarm" };
+  const signature = sign(record, pem);
+  const tampered = { ...record, extra: "claim" };
+  assert.equal(verify(tampered, signature, pubkeyRaw), false);
+});
+
+test("verify: returns false when the public key does not match the signer", () => {
+  // Cross-key verification must fail. This is what makes node identity
+  // load-bearing in the first place — anyone can sign anything, but
+  // only the holder of the private key matching `origin_node_id`'s
+  // pubkey produces a signature that verifies against that pubkey.
+  const a = freshKeypair();
+  const b = freshKeypair();
+  const record = { id: "abc", content: "hello swarm" };
+  const signature = sign(record, a.pem);
+  assert.equal(verify(record, signature, b.pubkeyRaw), false);
+});
+
+test("sign: signature is deterministic (Ed25519 RFC 8032 property)", () => {
+  // Ed25519 is deterministic — same key + same message → same signature.
+  // This isn't strictly required for security, but it lets us reason
+  // about test stability and rules out a non-deterministic regression
+  // (e.g. someone swapping in ECDSA without RFC 6979).
+  const { pem } = freshKeypair();
+  const record = { id: "abc", content: "hello swarm" };
+  assert.equal(sign(record, pem), sign(record, pem));
+});
+
+test("sign: identical signature regardless of key insertion order", () => {
+  // The acceptance criterion in issue #77: `{a:1, b:2}` and `{b:2, a:1}`
+  // produce the same signature. This is the bytes-stability promise of
+  // JCS made into an executable contract.
+  const { pem } = freshKeypair();
+  assert.equal(
+    sign({ a: 1, b: 2 } as Record<string, number>, pem),
+    sign({ b: 2, a: 1 } as Record<string, number>, pem)
+  );
+});
+
+test("sign: signature is identical with or without a placeholder signature field", () => {
+  // SWARM_SPEC §2.2 step 1: strip `signature` before canonicalizing.
+  // Without this rule, attaching the signature to the record would
+  // change the bytes-under-signature on the next sign — verifier would
+  // have to know to remove it, and any "re-sign in place" path would
+  // be broken.
+  const { pem } = freshKeypair();
+  const a = sign({ id: "abc", n: 1 }, pem);
+  const b = sign({ id: "abc", n: 1, signature: "placeholder" }, pem);
+  const c = sign({ id: "abc", n: 1, signature: "" }, pem);
+  assert.equal(a, b);
+  assert.equal(a, c);
+});
+
+test("verify: ignores the on-wire `signature` field when recomputing canonical bytes", () => {
+  // Mirror of the previous test on the verify side. The transported
+  // record has the signature attached; the verifier must strip it
+  // before JCS-recomputing or every honest verification would fail.
+  const { pem, pubkeyRaw } = freshKeypair();
+  const record = { id: "abc", content: "hello swarm" };
+  const signature = sign(record, pem);
+  const onWire = { ...record, signature };
+  assert.equal(verify(onWire, signature, pubkeyRaw), true);
+});
+
+test("verify: rejects malformed base64 signatures without throwing", () => {
+  // Defense-in-depth: a verifier on the network edge must not throw on
+  // garbage from a peer, only return false. Otherwise a single bad
+  // record could DoS the receive path.
+  const { pubkeyRaw } = freshKeypair();
+  assert.equal(verify({ x: 1 }, "not!!!base64@@@", pubkeyRaw), false);
+});
+
+test("verify: rejects wrong-length signatures (must be 64 bytes)", () => {
+  // Ed25519 signatures are exactly 64 bytes. Anything else is by
+  // definition forged or corrupt — refuse without invoking OpenSSL.
+  const { pubkeyRaw } = freshKeypair();
+  const tooShort = Buffer.alloc(32, 0).toString("base64");
+  const tooLong = Buffer.alloc(128, 0).toString("base64");
+  assert.equal(verify({ x: 1 }, tooShort, pubkeyRaw), false);
+  assert.equal(verify({ x: 1 }, tooLong, pubkeyRaw), false);
+});
+
+test("verify: rejects wrong-length public keys (must be 32 bytes)", () => {
+  // Same defensive rule for the pubkey side — a 31- or 33-byte key
+  // means the caller built the SPKI wrapper wrong, and we'd rather
+  // surface that as `false` than as an OpenSSL error.
+  const { pem } = freshKeypair();
+  const signature = sign({ x: 1 }, pem);
+  assert.equal(verify({ x: 1 }, signature, new Uint8Array(31)), false);
+  assert.equal(verify({ x: 1 }, signature, new Uint8Array(33)), false);
+  assert.equal(verify({ x: 1 }, signature, new Uint8Array(0)), false);
+});
+
+test("sign: wire-format anchor — independent re-derivation matches", () => {
+  // Independent reference: build the canonical bytes by hand, sign with
+  // the raw node:crypto API, base64-encode, and assert against `sign`.
+  // If this ever fails, the wire-format service has drifted from the
+  // primitives it composes — the moment to halt.
+  const { pem, pubkeyRaw } = freshKeypair();
+  const record = { z: 3, a: 1, m: 2 };
+  const expectedBytes = Buffer.from('{"a":1,"m":2,"z":3}', "utf8");
+  const expectedSig = nodeSign(null, expectedBytes, createPrivateKey(pem))
+    .toString("base64");
+  assert.equal(sign(record, pem), expectedSig);
+  assert.equal(verify(record, expectedSig, pubkeyRaw), true);
+});
+
+// ---------------------------------------------------------------------------
+// signWithSelfKey — convenience wrapper, dependency-injected for tests
+// ---------------------------------------------------------------------------
+
+test("signWithSelfKey: attaches signed_at and produces a verifying signature", () => {
+  // The wrapper has to (a) inject signed_at INTO the signed payload so
+  // receivers can reject stale records, (b) return that augmented
+  // payload alongside the signature, (c) keep `signature` OUT of the
+  // returned `record` (the caller decides whether to attach it before
+  // transport — see SWARM_SPEC §2.2 step 4).
+  const { pem, pubkeyRaw } = freshKeypair();
+  const fixedNow = new Date("2026-04-27T20:01:26.605Z");
+  const out = signWithSelfKey(
+    { id: "abc", content: "hi" },
+    {
+      keyFile: "irrelevant — loadPem overrides this",
+      loadPem: () => pem,
+      now: () => fixedNow,
+    }
+  );
+  assert.equal(out.signed_at, "2026-04-27T20:01:26.605Z");
+  assert.equal(out.record.signed_at, out.signed_at);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(out.record, "signature"),
+    false,
+    "record must not carry the signature field — caller decides on attachment"
+  );
+  assert.equal(verify(out.record, out.signature, pubkeyRaw), true);
+});
+
+test("signWithSelfKey: signed_at is part of the signed bytes (mutation detected)", () => {
+  // Belt-and-suspenders: if a refactor ever puts signed_at OUTSIDE the
+  // signed bytes, an attacker could replay an old record under a fresh
+  // timestamp. Catch that by mutating signed_at and asserting verify
+  // breaks.
+  const { pem, pubkeyRaw } = freshKeypair();
+  const out = signWithSelfKey(
+    { id: "abc", content: "hi" },
+    { loadPem: () => pem, now: () => new Date("2026-04-27T20:01:26.605Z") }
+  );
+  const tampered = { ...out.record, signed_at: "2099-01-01T00:00:00.000Z" };
+  assert.equal(verify(tampered, out.signature, pubkeyRaw), false);
+});
+
+test("defaultKeyFile: honors the MYCELIUM_NODE_KEY env override", () => {
+  const prev = process.env.MYCELIUM_NODE_KEY;
+  process.env.MYCELIUM_NODE_KEY = "/tmp/test-mycelium-node.key";
+  try {
+    assert.equal(defaultKeyFile(), "/tmp/test-mycelium-node.key");
+  } finally {
+    if (prev === undefined) delete process.env.MYCELIUM_NODE_KEY;
+    else process.env.MYCELIUM_NODE_KEY = prev;
+  }
+});

--- a/mcp-server/src/services/admission-gate.ts
+++ b/mcp-server/src/services/admission-gate.ts
@@ -1,0 +1,189 @@
+/**
+ * admission-gate.ts — confidence + scope gate for lesson and trait promotion.
+ *
+ * Background (issue #80, reflection 2026-04-27): the REM synthesizer at
+ * scripts/synthesize-cluster.mjs already returns
+ *   { lesson, pattern_name, confidence, reinforce }
+ * but the confidence is not actually used as an admission gate, so most
+ * cluster work fails to become persistent generalisation. At the same time,
+ * the self-model surfaces project-scoped "Ich habe gelernt …" auto-summaries
+ * as global identity traits — cross-project leakage that the literature calls
+ * behavioural / identity drift (arXiv 2604.12285 GAM, arXiv 2601.04170).
+ *
+ * This module is the single, pure choke point. No DB, no I/O. Caller assembles
+ * the context ({ confidence, member_count, project_consistent } for lessons,
+ * { lesson_text, evidence_count, project_id } for traits) and asks: should
+ * this be admitted into the persistent layer?
+ *
+ * Defaults match the issue spec (τ_lesson = 0.7, N = 3, evidence ≥ 3) and are
+ * overridable via opts so the nightly-sleep runner can tune via env vars
+ * without re-publishing the helper.
+ *
+ * Verfassung: pure local computation; strengthens "Generalisierung-vor-
+ * Sharing" by raising the bar before something can become a swarm-shareable
+ * lesson, and shields per-node traits from cross-project content.
+ */
+
+export const LESSON_MIN_CONFIDENCE = 0.7;
+export const LESSON_MIN_SOURCES    = 3;
+export const TRAIT_MIN_EVIDENCE    = 3;
+
+export interface ClusterMember {
+  /** project_id from experiences row; null = unscoped (global) */
+  project_id: string | null;
+}
+
+export interface ClusterProjectScope {
+  /** True iff every member shares the same project_id (NULL counts as a value). */
+  consistent: boolean;
+  /** The shared project_id (or null when all members are unscoped); null when inconsistent. */
+  project_id: string | null;
+}
+
+/**
+ * Determine whether a cluster of experiences agrees on a single project scope.
+ *
+ * "Consistent" means every member has the same project_id, treating NULL as a
+ * distinct value. A cluster mixing project A + global (NULL) is NOT consistent
+ * — that is the exact pattern that lets vectorworks-scoped experiences leak
+ * into global identity traits.
+ */
+export function clusterProjectScope(members: ClusterMember[]): ClusterProjectScope {
+  if (!Array.isArray(members) || members.length === 0) {
+    return { consistent: true, project_id: null };
+  }
+  const first = members[0].project_id ?? null;
+  for (const m of members) {
+    const pid = m.project_id ?? null;
+    if (pid !== first) return { consistent: false, project_id: null };
+  }
+  return { consistent: true, project_id: first };
+}
+
+/**
+ * Heuristic: does this lesson text look like a verbatim episode summary
+ * rather than a generalised rule? The synthesizer's system prompt asks for
+ * abstract handlungsleitende rules ("Wenn X dann Y, weil Z"); when the model
+ * fails to abstract, it tends to fall back to a first-person past-tense
+ * "Ich habe gelernt …" / "I refreshed the context …" recap of one episode.
+ *
+ * These are exactly the four entries currently polluting the mycelium
+ * self-model. Reject them at the trait gate so the identity surface stays
+ * generalisations-only.
+ *
+ * False positives: a legitimate rule that happens to start with "Ich habe
+ * gelernt" is acceptable collateral — that opening is the issue's named
+ * smell, and rephrasing in rule form is cheap.
+ */
+export function looksLikeAutoSummary(text: string | null | undefined): boolean {
+  if (!text || typeof text !== "string") return false;
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  const head = trimmed.slice(0, 80).toLowerCase();
+  // German first-person episode recap (the specific pattern called out in
+  // the issue body).
+  if (head.startsWith("ich habe gelernt")) return true;
+  // English equivalent — same shape, same problem.
+  if (/^i (refreshed|handled|verified|checked|read|extended|added|extracted) /.test(head)) return true;
+  // Generic "I did X and Y" past-tense recap with no rule structure.
+  if (/^i (re-?read|reviewed|completed|finished) /.test(head)) return true;
+  return false;
+}
+
+export interface LessonAdmissionInput {
+  /** Synthesizer-reported confidence in the cluster's pattern (0..1). */
+  confidence: number;
+  /** Number of source experiences contributing to this cluster. */
+  member_count: number;
+  /** True iff all members share a single project scope (see clusterProjectScope). */
+  project_consistent: boolean;
+}
+
+export interface AdmissionResult {
+  admit: boolean;
+  /** Stable machine-readable reason: "ok" on admit, otherwise a short tag. */
+  reason: "ok"
+        | "low_confidence"
+        | "too_few_sources"
+        | "mixed_project_scope"
+        | "auto_summary"
+        | "low_evidence"
+        | "missing_text";
+}
+
+export interface LessonGateOpts {
+  minConfidence?: number;
+  minSources?: number;
+  /** Override: when true, allow mixed-project clusters (default false). */
+  allowMixedProject?: boolean;
+}
+
+/**
+ * Gate the experience → lesson promotion path.
+ *
+ * Reject when:
+ *   1. confidence < minConfidence  (default 0.7, per issue spec)
+ *   2. member_count < minSources   (default 3)
+ *   3. cluster crosses project scopes (unless allowMixedProject)
+ *
+ * Reasons are checked in that order; the first failure wins so telemetry
+ * counters are unambiguous.
+ */
+export function gateLessonAdmission(
+  input: LessonAdmissionInput,
+  opts: LessonGateOpts = {},
+): AdmissionResult {
+  const minConfidence = opts.minConfidence ?? LESSON_MIN_CONFIDENCE;
+  const minSources    = opts.minSources    ?? LESSON_MIN_SOURCES;
+
+  if (!Number.isFinite(input.confidence) || input.confidence < minConfidence) {
+    return { admit: false, reason: "low_confidence" };
+  }
+  if (!Number.isFinite(input.member_count) || input.member_count < minSources) {
+    return { admit: false, reason: "too_few_sources" };
+  }
+  if (!opts.allowMixedProject && input.project_consistent === false) {
+    return { admit: false, reason: "mixed_project_scope" };
+  }
+  return { admit: true, reason: "ok" };
+}
+
+export interface TraitAdmissionInput {
+  /** The lesson text that would become the trait. */
+  lesson_text: string | null | undefined;
+  /** evidence_count from the lessons row. */
+  evidence_count: number;
+  /** project_id of the lesson row; null = unscoped (global). */
+  project_id?: string | null;
+}
+
+export interface TraitGateOpts {
+  minEvidence?: number;
+}
+
+/**
+ * Gate the lesson → self-model trait promotion path.
+ *
+ * Reject when:
+ *   1. lesson_text is empty (defensive — promote_lesson_to_trait would fail)
+ *   2. evidence_count < minEvidence (default 3)
+ *   3. lesson_text looks like a per-episode auto-summary
+ *
+ * Note: project-scope consistency for traits is enforced at the lesson layer
+ * (a lesson that passed the lesson gate already has a single project_id).
+ * We pass through project_id here only so callers can route the trait into
+ * the matching scope; we do not gate on it.
+ */
+export function gateTraitAdmission(
+  input: TraitAdmissionInput,
+  opts: TraitGateOpts = {},
+): AdmissionResult {
+  const minEvidence = opts.minEvidence ?? TRAIT_MIN_EVIDENCE;
+  const text = (input.lesson_text ?? "").trim();
+  if (text.length === 0) return { admit: false, reason: "missing_text" };
+  if (!Number.isFinite(input.evidence_count) || input.evidence_count < minEvidence) {
+    return { admit: false, reason: "low_evidence" };
+  }
+  if (looksLikeAutoSummary(text)) return { admit: false, reason: "auto_summary" };
+  return { admit: true, reason: "ok" };
+}

--- a/mcp-server/src/services/signature.ts
+++ b/mcp-server/src/services/signature.ts
@@ -1,0 +1,261 @@
+/**
+ * Signature service — Swarm Phase 2 (issue #77).
+ *
+ * Reusable Ed25519 sign / verify primitives over JCS-canonicalized JSON,
+ * per docs/SWARM_SPEC.md §2 (RFC 8785, RFC 8032).
+ *
+ * Wire-format contract (SWARM_SPEC §2.2):
+ *
+ *   1. Strip the `signature` field from the record.
+ *   2. JCS-canonicalize the remainder (RFC 8785).
+ *   3. Sign the resulting UTF-8 bytes with Ed25519.
+ *   4. base64-encode the 64-byte signature; re-attach to the record.
+ *
+ * Verification reverses this. The canonical bytes are recomputed from the
+ * received JSON — we never trust the producer's serialization. That is
+ * what makes JCS load-bearing for the swarm trust premise (Verfassung
+ * pillar 6, Cyber security): two honest implementations must always
+ * agree on the bytes-under-signature, even if they re-order keys, round
+ * floats differently in memory, or print whitespace differently on
+ * transport.
+ *
+ * Scope discipline (issue #77 Hard constraints):
+ *   - No networking, HTTP, or libp2p in this file.
+ *   - This file is NOT yet integrated into existing record-creation
+ *     paths (lesson synthesis, hub anchors, …). That is a follow-up.
+ *   - Read-only dependency on the node identity bootstrapped by
+ *     scripts/init-node-identity.mjs (issue #76); no migration touches.
+ */
+import {
+  createPrivateKey,
+  createPublicKey,
+  KeyObject,
+  sign as nodeSign,
+  verify as nodeVerify,
+} from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// JCS canonicalization (RFC 8785) — pure, no external deps
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a value to its RFC 8785 JSON Canonical Form (JCS).
+ *
+ * Compliance summary:
+ *   - Object keys sorted by UTF-16 code-unit order (RFC 8785 §3.2.3).
+ *     `Array.prototype.sort` without a comparator is exactly that order
+ *     in ECMAScript, so a plain `.sort()` is correct here.
+ *   - No whitespace, no insignificant separators (`{"a":1,"b":2}`).
+ *   - Strings escaped per RFC 8259 §7 minimal-escape rules. Node's
+ *     `JSON.stringify` follows those rules for valid UTF-16, including
+ *     the named escapes `\b \f \n \r \t` and lowercase `\uXXXX` for
+ *     other C0 control characters.
+ *   - Numbers serialized via the ECMAScript Number-to-String algorithm
+ *     (RFC 8785 §3.2.2.3 mandates this exact algorithm). `JSON.stringify`
+ *     on a finite Number produces that representation.
+ *   - Non-finite numbers (`NaN`, `±Infinity`) and `undefined` are
+ *     rejected — JCS is defined only over I-JSON (RFC 7493) and silent
+ *     coercion would let two implementations disagree.
+ *
+ * Edge case worth knowing: float-array fields (e.g. embeddings) inherit
+ * the ECMAScript number serialization. Producers in other languages MUST
+ * use a JCS-conformant serializer there too — see SWARM_SPEC §2.1.
+ */
+export function canonicalize(value: unknown): string {
+  return jcs(value);
+}
+
+function jcs(v: unknown): string {
+  if (v === null) return "null";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (typeof v === "number") {
+    if (!Number.isFinite(v)) {
+      throw new Error(
+        `canonicalize: non-finite number not allowed by RFC 8785 / I-JSON (got ${v})`
+      );
+    }
+    return JSON.stringify(v);
+  }
+  if (typeof v === "string") return JSON.stringify(v);
+  if (Array.isArray(v)) return "[" + v.map(jcs).join(",") + "]";
+  if (typeof v === "object") {
+    const obj = v as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return (
+      "{" +
+      keys
+        .map((k) => JSON.stringify(k) + ":" + jcs(obj[k]))
+        .join(",") +
+      "}"
+    );
+  }
+  throw new Error(
+    `canonicalize: unsupported value type ${typeof v} (only JSON-representable values allowed)`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Ed25519 sign / verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign a JSON record using the Ed25519 private key supplied as a PEM
+ * (PKCS#8) string. Returns the 64-byte signature, base64-padded per
+ * RFC 4648 §4 (matching the `signature` field encoding in SWARM_SPEC §2.3).
+ *
+ * The `signature` field of the record, if present, is stripped before
+ * canonicalization. This mirrors the verify side and lets callers
+ * re-sign records without manually deleting the field.
+ *
+ * Uses `crypto.sign(null, data, key)` — the Node 14+ Ed25519 API. The
+ * legacy `createSign('sha256')` path does NOT work for Ed25519 because
+ * Ed25519 prehashes internally and rejects an external hash algorithm.
+ */
+export function sign(record: object, privateKeyPem: string): string {
+  const key = createPrivateKey(privateKeyPem);
+  const bytes = Buffer.from(canonicalize(stripSignature(record)), "utf8");
+  const sig = nodeSign(null, bytes, key);
+  return sig.toString("base64");
+}
+
+/**
+ * Verify the base64 Ed25519 signature on a JSON record against a raw
+ * 32-byte public key (the on-wire `pubkey` shape from SWARM_SPEC §2.3).
+ *
+ * Returns true iff the signature is valid for `JCS(record − signature)`
+ * under the supplied key. All other failure modes — malformed base64,
+ * wrong-length signature, wrong-length pubkey, OpenSSL verify error —
+ * collapse to `false`. This is intentional: a verifier MUST NOT throw on
+ * bad input from the network, only refuse to trust it.
+ */
+export function verify(
+  record: object,
+  signature: string,
+  publicKey: Uint8Array
+): boolean {
+  if (!(publicKey instanceof Uint8Array) || publicKey.length !== 32) {
+    return false;
+  }
+  let sigBytes: Buffer;
+  try {
+    sigBytes = Buffer.from(signature, "base64");
+  } catch {
+    return false;
+  }
+  // Ed25519 signatures are exactly 64 bytes. Accepting other lengths
+  // would let malformed records sneak past with a Node-internal error.
+  if (sigBytes.length !== 64) return false;
+
+  let pubKeyObj: KeyObject;
+  try {
+    pubKeyObj = pubkeyFromRaw(Buffer.from(publicKey));
+  } catch {
+    return false;
+  }
+
+  const bytes = Buffer.from(canonicalize(stripSignature(record)), "utf8");
+  try {
+    return nodeVerify(null, bytes, pubKeyObj, sigBytes);
+  } catch {
+    return false;
+  }
+}
+
+/** Return a copy of `record` with the top-level `signature` field removed. */
+function stripSignature(record: object): object {
+  if (record === null || typeof record !== "object" || Array.isArray(record)) {
+    return record;
+  }
+  const { signature: _omit, ...rest } = record as Record<string, unknown>;
+  return rest;
+}
+
+/**
+ * Build a Node `KeyObject` from a raw 32-byte Ed25519 public key by
+ * prepending the fixed SPKI DER header. `createPublicKey` requires
+ * SPKI-formatted input; the raw bytes alone are not enough.
+ *
+ * SPKI prefix is fixed for Ed25519 — see RFC 8410 §4.
+ */
+function pubkeyFromRaw(raw: Buffer): KeyObject {
+  if (raw.length !== 32) {
+    throw new Error(`pubkeyFromRaw: expected 32 bytes, got ${raw.length}`);
+  }
+  const SPKI_HEADER = Buffer.from([
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+  ]);
+  return createPublicKey({
+    key: Buffer.concat([SPKI_HEADER, raw]),
+    format: "der",
+    type: "spki",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrapper: sign with the node's persistent self-key
+// ---------------------------------------------------------------------------
+
+export interface SignedRecord<T extends object = object> {
+  /**
+   * The signed payload — the original record with `signed_at` attached.
+   * `signed_at` is part of the signed bytes (so receivers can reject
+   * stale records); `signature` is NOT mutated into this object — the
+   * caller decides whether to attach it before transport.
+   */
+  record: T & { signed_at: string };
+  /** base64 Ed25519 signature over `JCS(record)`. */
+  signature: string;
+  /** ISO 8601 UTC timestamp identical to `record.signed_at`. */
+  signed_at: string;
+}
+
+export interface SignWithSelfOptions {
+  /** Override the privkey path. Defaults to `MYCELIUM_NODE_KEY` env var or `~/.mycelium/node.key`. */
+  keyFile?: string;
+  /** Inject a clock — handy for tests. Defaults to `Date.now()`. */
+  now?: () => Date;
+  /** Inject a PEM loader — handy for tests that don't want to touch disk. */
+  loadPem?: (keyFile: string) => string;
+}
+
+/**
+ * Sign a record with the node's persistent Ed25519 private key — the one
+ * bootstrapped by `scripts/init-node-identity.mjs` (issue #76) at
+ * `~/.mycelium/node.key` (chmod 0600).
+ *
+ * Attaches `signed_at` to the record BEFORE signing so it ends up inside
+ * the canonical bytes (SWARM_SPEC §3 — `signed_at` is a required field
+ * on every signed wire type). Returns the augmented record, the
+ * signature, and the timestamp; the caller decides whether to attach
+ * `signature` to the on-wire object.
+ */
+export function signWithSelfKey<T extends object>(
+  record: T,
+  options: SignWithSelfOptions = {}
+): SignedRecord<T> {
+  const keyFile = options.keyFile ?? defaultKeyFile();
+  const loadPem = options.loadPem ?? readPemSync;
+  const pem = loadPem(keyFile);
+  const now = options.now ? options.now() : new Date();
+  const signed_at = now.toISOString();
+  const payload = { ...(record as object), signed_at } as T & {
+    signed_at: string;
+  };
+  const signature = sign(payload, pem);
+  return { record: payload, signature, signed_at };
+}
+
+/** Default privkey path. Honors `MYCELIUM_NODE_KEY` for ops overrides. */
+export function defaultKeyFile(): string {
+  return (
+    process.env.MYCELIUM_NODE_KEY ??
+    path.join(os.homedir(), ".mycelium", "node.key")
+  );
+}
+
+function readPemSync(keyFile: string): string {
+  return fs.readFileSync(keyFile, "utf8");
+}

--- a/scripts/nightly-sleep.mjs
+++ b/scripts/nightly-sleep.mjs
@@ -35,6 +35,16 @@ const { IdentityService }    = await import(path.join(DIST, "services/identity.j
 const identityTools          = await import(path.join(DIST, "tools/identity.js"));
 const { consolidateByPatterns } = await import(path.join(__dirname, "consolidate-by-patterns.mjs"));
 const { synthesizeCluster, unloadQwen } = await import(path.join(__dirname, "synthesize-cluster.mjs"));
+// Issue #80: confidence + scope admission gate for the two promotion paths.
+// Pure helpers — no DB / no I/O. Loaded from the TS build so behaviour is
+// pinned by mcp-server/src/__tests__/admission-gate.test.ts.
+const {
+  gateLessonAdmission,
+  gateTraitAdmission,
+  LESSON_MIN_CONFIDENCE,
+  LESSON_MIN_SOURCES,
+  TRAIT_MIN_EVIDENCE,
+} = await import(path.join(DIST, "services/admission-gate.js"));
 
 // Low-level REST fuer sleep_cycles insert/update — reines fetch, keine extra dep
 const SUPABASE_URL = process.env.SUPABASE_URL;
@@ -143,7 +153,23 @@ async function runSws() {
 //   promotion_candidates → promote_lesson_to_trait fuer reife Lessons
 //   unloadQwen           — Ollama keep_alive=0: Modell aus RAM fuer andere Tasks
 // ---------------------------------------------------------------------------
-const REM_MIN_CONFIDENCE     = Number(process.env.REM_MIN_CONFIDENCE     || 0.5);
+// Lesson-admission thresholds (issue #80). REM_MIN_CONFIDENCE is kept as a
+// legacy alias for REM_LESSON_MIN_CONFIDENCE — the floor used to be 0.5; the
+// gated default is 0.7 (matches the issue spec). Operators that previously
+// tuned the old name keep working.
+const REM_LESSON_MIN_CONFIDENCE = Number(
+  process.env.REM_LESSON_MIN_CONFIDENCE
+  ?? process.env.REM_MIN_CONFIDENCE
+  ?? LESSON_MIN_CONFIDENCE,
+);
+const REM_LESSON_MIN_SOURCES = Number(
+  process.env.REM_LESSON_MIN_SOURCES ?? LESSON_MIN_SOURCES,
+);
+const REM_LESSON_ALLOW_MIXED_PROJECT =
+  process.env.REM_LESSON_ALLOW_MIXED_PROJECT === "1";
+const REM_TRAIT_MIN_EVIDENCE = Number(
+  process.env.REM_TRAIT_MIN_EVIDENCE ?? TRAIT_MIN_EVIDENCE,
+);
 const REM_CLUSTER_SIMILARITY = Number(process.env.REM_CLUSTER_SIMILARITY || 0.80);
 const REM_CLUSTER_MIN_SIZE   = Number(process.env.REM_CLUSTER_MIN_SIZE   || 2);
 const REM_CLUSTER_WINDOW_DAYS = Number(process.env.REM_CLUSTER_WINDOW_DAYS || 30);
@@ -153,9 +179,30 @@ async function runRem() {
     clusters_found: 0,
     lessons_synthesized: 0,
     lessons_reinforced: 0,
+    // Per-reason rejection counters from gateLessonAdmission. The legacy
+    // `lessons_skipped_low_conf` is preserved (issue #80) so the existing
+    // dashboard tile keeps working; the two new counters distinguish the
+    // sources/scope rejections so operators can see WHY synthesis didn't
+    // produce a lesson. Sum of all three = clusters_found - lessons_*
+    // promoted/reinforced.
     lessons_skipped_low_conf: 0,
+    lessons_skipped_too_few_sources: 0,
+    lessons_skipped_mixed_project: 0,
     lessons_deduped: 0,
     traits_promoted: 0,
+    // Trait-gate rejection counters (issue #80). auto_summary catches the
+    // "Ich habe gelernt …" first-person episode recap that previously
+    // polluted the self-model with vectorworks product data.
+    traits_skipped_auto_summary: 0,
+    traits_skipped_low_evidence: 0,
+    // Lesson-gate config snapshot — useful when comparing two cycles after
+    // a threshold tweak via env vars.
+    gate: {
+      lesson_min_confidence: REM_LESSON_MIN_CONFIDENCE,
+      lesson_min_sources:    REM_LESSON_MIN_SOURCES,
+      lesson_allow_mixed_project: REM_LESSON_ALLOW_MIXED_PROJECT,
+      trait_min_evidence:    REM_TRAIT_MIN_EVIDENCE,
+    },
     // Reasoning telemetry (Ollama 0.20+ think:true). lessons_with_thinking
     // is the count of synthesise calls where the model emitted any chars
     // into message.thinking — gives a yes/no signal that the reasoning
@@ -213,9 +260,36 @@ async function runRem() {
         out.lessons_with_thinking += 1;
         out.lessons_thinking_chars_total += synth._thinking_chars;
       }
-      if (!synth.lesson || synth.confidence < REM_MIN_CONFIDENCE) {
+      if (!synth.lesson) {
+        // Synthesizer returned no lesson body — model failed to emit JSON or
+        // it parsed but had an empty lesson string. Treated as low-conf so
+        // the rejection is visible in the existing telemetry tile.
         out.lessons_skipped_low_conf += 1;
         continue;
+      }
+      // Reinforcement of an already-existing lesson short-circuits the gate:
+      // a lesson that is already on disk has already passed the gate (or
+      // pre-dates it). Reinforcement is just adding evidence, not creating
+      // new content, so blocking it would only suppress useful signal.
+      if (!synth.reinforce) {
+        const decision = gateLessonAdmission(
+          {
+            confidence:        synth.confidence,
+            member_count:      synth.member_count ?? 0,
+            project_consistent: synth.project_consistent !== false,
+          },
+          {
+            minConfidence:      REM_LESSON_MIN_CONFIDENCE,
+            minSources:         REM_LESSON_MIN_SOURCES,
+            allowMixedProject:  REM_LESSON_ALLOW_MIXED_PROJECT,
+          },
+        );
+        if (!decision.admit) {
+          if (decision.reason === "low_confidence")        out.lessons_skipped_low_conf += 1;
+          else if (decision.reason === "too_few_sources")  out.lessons_skipped_too_few_sources += 1;
+          else if (decision.reason === "mixed_project_scope") out.lessons_skipped_mixed_project += 1;
+          continue;
+        }
       }
       // After record/reinforce, push the lesson's salience up via the
       // universal salience layer (Migration 053). This is what makes a
@@ -248,10 +322,35 @@ async function runRem() {
   catch (e) { out.errors.push({ step: "dedup_lessons", msg: String(e?.message ?? e) }); }
 
   try {
-    const candidates = await expSvc.promotionCandidates(4, 0.7);
+    // Lower the SQL-side minEvidence to the gate's floor so we still see
+    // newly-eligible lessons; the JS gate then applies the auto-summary
+    // filter and the project-scope check (issue #80). The SQL function's
+    // own min_confidence still matches the lesson-gate confidence floor —
+    // a lesson admitted at REM_LESSON_MIN_CONFIDENCE is by construction
+    // above the trait-side floor, so re-using it keeps the two gates
+    // mutually consistent.
+    const candidates = await expSvc.promotionCandidates(
+      REM_TRAIT_MIN_EVIDENCE,
+      REM_LESSON_MIN_CONFIDENCE,
+    );
     for (const c of candidates.slice(0, 10)) {
-      const traitText = (c.lesson ?? c.lesson_text ?? "").slice(0, 160);
-      if (!traitText) continue;
+      const lessonText = c.lesson ?? c.lesson_text ?? "";
+      const decision = gateTraitAdmission(
+        {
+          lesson_text:    lessonText,
+          evidence_count: c.evidence_count ?? 0,
+          project_id:     c.project_id ?? null,
+        },
+        { minEvidence: REM_TRAIT_MIN_EVIDENCE },
+      );
+      if (!decision.admit) {
+        if (decision.reason === "auto_summary")      out.traits_skipped_auto_summary += 1;
+        else if (decision.reason === "low_evidence") out.traits_skipped_low_evidence += 1;
+        // missing_text falls through silently — the SQL side already
+        // refuses to promote empty lessons.
+        continue;
+      }
+      const traitText = lessonText.slice(0, 160);
       try {
         await expSvc.promoteToTrait(c.id ?? c.lesson_id, traitText, 0);
         out.traits_promoted += 1;

--- a/scripts/synthesize-cluster.mjs
+++ b/scripts/synthesize-cluster.mjs
@@ -60,7 +60,10 @@ JSON-Objekt — kein Fließtext drum herum:
 Wenn kein echtes Muster erkennbar ist: confidence < 0.3 setzen.`;
 
 async function loadMembers(ids, { supabaseUrl, supabaseKey }) {
-  const fields = "id,summary,outcome,valence,what_worked,what_failed,difficulty,task_type,created_at";
+  // project_id is needed by the lesson-admission gate (see issue #80) so the
+  // caller can refuse mixed-project clusters before promotion. Cheap to
+  // include here — same row, same query.
+  const fields = "id,summary,outcome,valence,what_worked,what_failed,difficulty,task_type,created_at,project_id";
   const url    = `${supabaseUrl}/experiences?id=in.(${ids.join(",")})&select=${fields}`;
   const r = await fetch(url, {
     headers: {
@@ -173,7 +176,23 @@ export async function synthesizeCluster(cluster, { supabaseUrl, supabaseKey }) {
   const pattern_name = typeof out?.pattern_name === "string" ? out.pattern_name.trim() : "";
   const confidence   = Math.max(0, Math.min(1, Number(out?.confidence) || 0));
   const reinforce    = Boolean(out?.reinforce) && Boolean(cluster.matched_lesson_id);
-  return { lesson, pattern_name, confidence, reinforce, member_count: members.length };
+  // Project scope across cluster members — passed through so the caller can
+  // run gateLessonAdmission without re-fetching the rows. Mirrors
+  // clusterProjectScope() in mcp-server/src/services/admission-gate.ts but
+  // is inlined here to keep this script free of TS-build coupling for
+  // standalone dry runs (`node scripts/synthesize-cluster.mjs --dry`).
+  let project_consistent = true;
+  let project_id = members[0]?.project_id ?? null;
+  for (const m of members) {
+    const pid = m.project_id ?? null;
+    if (pid !== project_id) { project_consistent = false; project_id = null; break; }
+  }
+  return {
+    lesson, pattern_name, confidence, reinforce,
+    member_count: members.length,
+    project_consistent,
+    project_id,
+  };
 }
 
 // Standalone test: `node scripts/synthesize-cluster.mjs --dry`


### PR DESCRIPTION
## Summary

- Adds a pure admission-gate at `mcp-server/src/services/admission-gate.ts` exposing `gateLessonAdmission` (cluster → lesson) and `gateTraitAdmission` (lesson → self-model trait), with the issue-spec defaults τ_lesson = 0.7, N_sources = 3, evidence ≥ 3.
- Wires the gate into `scripts/synthesize-cluster.mjs` (now passes `project_consistent` + `project_id` through with each synth result) and `scripts/nightly-sleep.mjs` (gates both promotion paths and surfaces per-reason telemetry).
- 27 Node test cases in `mcp-server/src/__tests__/admission-gate.test.ts` pin the gate behaviour, including the exact NULL+project leakage shape that put vectorworks 'Ich habe gelernt …' entries into the mycelium self-model.

## Research summary

- The REM synthesizer (`scripts/synthesize-cluster.mjs`) already returns `{lesson, pattern_name, confidence, reinforce}` — the scoring primitive exists but the *gate* doesn't.
- Pre-issue: lesson promotion only checked `confidence < REM_MIN_CONFIDENCE` (default 0.5), no source-count check, no project-scope check; trait promotion called `promotionCandidates(4, 0.7)` then promoted unconditionally — no auto-summary filter.
- Both `experiences` and `lessons` already carry `project_id` (migration 045) so the scope check is a pure JS computation over already-fetched rows; no migration needed.
- The four polluting self-model entries Reed observed all start with 'Ich habe gelernt …' / 'I refreshed the context …' — a stable lexical pattern that the trait gate can detect cheaply. The reflection memory and the issue body both confirm this surface signal.
- The pre-existing failing test `migration-070-node-identity.test.js` is unrelated WIP and was already failing on `main` before this change.

## What this does NOT do

- **No SQL migration.** The autonomy loop is forbidden from running migrations, and the gate is fully achievable in JS over data the existing schema already exposes (`experiences.project_id`, `lessons.project_id`, `lessons.evidence_count`). A future issue can add a SQL-side `find_promotion_candidates` overload that bakes project-scope into the query if needed.
- **No semantic-divergence trigger (`b_t`).** The issue explicitly defers the GAM-style sparse `b_t = 𝕀(Δ(G_event, G_topic) > ε)` consolidation cadence to a follow-up. This PR ships the load-bearing gate first; the cadence change can land next.
- **No retroactive cleanup.** Existing 'Ich habe gelernt …' traits in the DB remain. Cleaning the self-model is a one-shot SQL operation that needs a human (and is therefore out of scope for an autonomy tick). The gate prevents *new* admissions from this point forward.
- **No change to `record_lesson` or `promote_lesson_to_trait` SQL.** Gating happens at the call site (`nightly-sleep.mjs`); the underlying RPCs are unchanged so manual or test paths still work as before.

## Constitution affirmation

Pillar touched: **Swarm intelligence** (specifically: *Generalisierung-vor-Sharing*, the line that says only generalised lessons leave the node). A higher bar before something becomes a `lesson` means *more abstract, less noisy* output reaches the future swarm-share boundary — the pillar is **strengthened**, not weakened.

Other pillars unaffected:
- *Decentralized AI*: pure local computation on data already on the node, no new egress.
- *Cyber security*: no trust boundary touched, no key handling.
- *Agent reproduction / Microtransactions / Experts*: no surface area touched.

## Test plan

Local:
```bash
cd mcp-server && npm test
# expect: 27 admission-gate.test.ts cases pass; full suite 313/314 pass.
# the one failing test (migration-070-node-identity.test.js) is pre-existing
# and unrelated to this PR.
```

Behavioural verification (manual, dry):
```bash
# 1. Force the gate to its tightest setting and re-run a sleep cycle:
REM_LESSON_MIN_CONFIDENCE=0.85 REM_LESSON_MIN_SOURCES=4 \
  node scripts/nightly-sleep.mjs --manual
# expect: rem_result.gate echoes the tweaked thresholds; per-reason
#   counters (lessons_skipped_too_few_sources / _mixed_project) increment
#   instead of producing weak lessons.

# 2. Inspect that mixed-project clusters are now refused:
#    SQL: insert two synthetic experiences with different project_ids,
#    seed a cluster, observe lessons_skipped_mixed_project += 1.

# 3. Inspect that 'Ich habe gelernt …' lessons still get written but
#    are NOT promoted to traits:
#    expect traits_skipped_auto_summary increments instead of
#    traits_promoted.
```

The gate is fully reversible (env vars `REM_LESSON_MIN_CONFIDENCE=0.5`, `REM_LESSON_MIN_SOURCES=2`, `REM_LESSON_ALLOW_MIXED_PROJECT=1`, `REM_TRAIT_MIN_EVIDENCE=4` restore pre-PR behaviour).