### PR TITLE
feat(rem): migration 073 — cluster_diversity gate (#95)

### DIFF
--- a/mcp-server/src/__tests__/migration-073-cluster-diversity.test.ts
+++ b/mcp-server/src/__tests__/migration-073-cluster-diversity.test.ts
@@ -1,0 +1,164 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 073 — cluster diversity gating contract pin (closes part of #95)
+//
+// Why this guard exists: extending find_experience_clusters with two extra
+// parameters AND an extra return column is a foot-gun in PostgreSQL.
+// CREATE OR REPLACE does NOT replace across different parameter counts — it
+// creates an overload — and the new return shape means the prior overloads
+// would even resolve to a DIFFERENT body for the same call site. Without an
+// explicit DROP of every prior overload AND a re-grant of EXECUTE, this
+// migration silently regresses in two ways:
+//
+//   1. The 4-arg overload from migration 016 stays around as a sibling
+//      function with the OLD return shape (no diversity_score). Existing
+//      4-arg callers keep hitting the old body and never see the gate.
+//   2. The DROP wipes the GRANT issued by migration 016 along with the
+//      function; forgetting to re-grant breaks every authenticated client.
+//
+// Same defensive pattern as migration-070-node-identity.test.ts /
+// migration-071-swarm-storage.test.ts / migration-072-lessons-pattern-name.
+// test.ts — read the SQL, normalise it, regex-pin the structural contract.
+// The autonomy loop cannot execute migrations (Reed runs them by hand after
+// merge), so contract tests live at the SQL-text level.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/073_cluster_diversity.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so a phrase like
+// "no DROP" inside a comment cannot accidentally satisfy a structural
+// assertion below.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent or
+// keyword-case drift without weakening the structural contracts.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) Both prior overloads must be dropped before the recreate
+// ---------------------------------------------------------------------------
+
+test("migration 073 drops the 4-arg find_experience_clusters overload (from 016)", () => {
+  // Without this DROP, CREATE OR REPLACE creates a NEW overload sitting
+  // alongside the 4-arg version — every existing 4-arg caller keeps hitting
+  // the old body and never sees the diversity gate.
+  assert.match(
+    SQL,
+    /drop function if exists find_experience_clusters\s*\(\s*float\s*,\s*int\s*,\s*int\s*,\s*float\s*\)/,
+  );
+});
+
+test("migration 073 drops the legacy 3-arg find_experience_clusters overload (from 015)", () => {
+  // Defensive: PG keeps every distinct-arity overload alive. The 3-arg
+  // version was supposed to be dropped by migration 016, but pin the
+  // additional DROP here so a future revert of 016 can't resurrect it.
+  assert.match(
+    SQL,
+    /drop function if exists find_experience_clusters\s*\(\s*float\s*,\s*int\s*,\s*int\s*\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) New 6-arg signature with parameter ORDER pinned
+// ---------------------------------------------------------------------------
+
+test("find_experience_clusters is recreated with 6 parameters in the documented order", () => {
+  // Param order matters — clients call by name via supabase-js rpc(), but
+  // the SQL function's positional grant signature depends on this order.
+  // The two NEW parameters (time_spread_window_hours, min_diversity_score)
+  // MUST be appended at the END so the existing 3-arg TS caller in
+  // services/experiences.ts:findClusters keeps working without code changes.
+  assert.match(
+    SQL,
+    /create or replace function find_experience_clusters\s*\(\s*similarity_threshold\s+float\s+default\s+0\.85\s*,\s*min_cluster_size\s+int\s+default\s+2\s*,\s*max_age_days\s+int\s+default\s+30\s*,\s*lesson_match_threshold\s+float\s+default\s+0\.78\s*,\s*time_spread_window_hours\s+int\s+default\s+72\s*,\s*min_diversity_score\s+float\s+default\s+0\.0\s*\)/,
+  );
+});
+
+test("min_diversity_score defaults to 0.0 — backwards-compatible (no gate)", () => {
+  // Issue #95 / migration header axiom: callers that don't pass the gate
+  // get raw clusters, exactly as before. A non-zero default would silently
+  // change the REM synthesiser's output for every existing caller.
+  assert.match(SQL, /min_diversity_score\s+float\s+default\s+0\.0\b/);
+});
+
+// ---------------------------------------------------------------------------
+// (3) Return shape includes the new diversity_score column
+// ---------------------------------------------------------------------------
+
+test("return table includes diversity_score FLOAT as the new column", () => {
+  // The diversity score MUST surface in the result row so the REM
+  // synthesiser (and dashboards) can show why a cluster was emitted or
+  // suppressed. Without this column the gate is opaque and untestable
+  // from the TS side.
+  assert.match(SQL, /returns table[\s\S]*?diversity_score\s+float[\s\S]*?\)/);
+});
+
+// ---------------------------------------------------------------------------
+// (4) Body actually computes the score with the documented weights
+// ---------------------------------------------------------------------------
+
+test("diversity_score uses the documented 0.50 / 0.25 / 0.25 weighting", () => {
+  // The header axiom pins this weighting:
+  //   0.50 · time_spread_norm + 0.25 · project_diversity + 0.25 · task_type
+  // Drift in the constants would silently change which clusters survive
+  // the gate. Pin the literal expression.
+  assert.match(
+    SQL,
+    /diversity_score\s*:=\s*0\.50\s*\*\s*time_norm\s*\+\s*0\.25\s*\*\s*p_ratio\s*\+\s*0\.25\s*\*\s*t_ratio/,
+  );
+});
+
+test("body honours the gate: clusters with diversity_score < min_diversity_score are skipped", () => {
+  // The gate must be a strict `<` against `min_diversity_score` so a
+  // caller passing min_diversity_score=0 (the default) keeps every cluster
+  // (diversity_score is bounded ≥ 0). Pinning this also guards against
+  // someone "fixing" the comparison to `<=` and accidentally dropping
+  // every zero-diversity cluster even when no gate was requested.
+  assert.match(SQL, /if\s+diversity_score\s*<\s*min_diversity_score\s+then/);
+  // After the gate fires the loop must `continue` — emitting the row would
+  // defeat the purpose. Pin the continue statement after the if-branch.
+  assert.match(
+    SQL,
+    /if\s+diversity_score\s*<\s*min_diversity_score\s+then[\s\S]*?continue\s*;[\s\S]*?end if/,
+  );
+});
+
+test("time_norm clips the elapsed span to [0, 1] using time_spread_window_hours", () => {
+  // The clip is what makes time_spread_norm dimensionless. Without LEAST,
+  // a 30-day cluster would score ~10 on the time axis and dwarf the
+  // project / task axes — the weighted sum would no longer live in [0, 1]
+  // and the gate semantics would silently break.
+  assert.match(
+    SQL,
+    /time_norm\s*:=\s*least\s*\(\s*greatest\s*\(\s*time_span_hours\s*,\s*0\s*\)\s*\/\s*nullif\s*\(\s*time_spread_window_hours\s*,\s*0\s*\)::float\s*,\s*1\.0\s*\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (5) GRANT EXECUTE — DROP wiped the original GRANT from migration 016
+// ---------------------------------------------------------------------------
+
+test("migration 073 re-grants EXECUTE on the new 6-arg signature", () => {
+  // DROP FUNCTION above removed the GRANT issued by migration 016. Without
+  // this re-grant, anon/service_role lose permission to call the RPC and
+  // every authenticated client (including the REM nightly job) breaks at
+  // runtime — exactly the latent bug PR #97 caught in the 072 stash variant.
+  assert.match(
+    SQL,
+    /grant execute on function find_experience_clusters\s*\(\s*float\s*,\s*int\s*,\s*int\s*,\s*float\s*,\s*int\s*,\s*float\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});

--- a/supabase/migrations/073_cluster_diversity.sql
+++ b/supabase/migrations/073_cluster_diversity.sql
@@ -1,0 +1,163 @@
+-- ---------------------------------------------------------------------------
+-- 073_cluster_diversity.sql — closes (last part of) issue #95
+--
+-- A cluster is only a meaningful *pattern* if its members are contextually
+-- diverse — otherwise it's just the same work logged twice. Before this
+-- migration find_experience_clusters had no notion of diversity and would
+-- happily cluster two fragments of the same session, feeding the REM
+-- synthesiser redundant input.
+--
+-- Axiom: "cluster == pattern  ⇔  diversity_score ≥ min_diversity_score".
+--
+-- diversity_score ∈ [0, 1] is a weighted sum of three dimensions:
+--   0.50 · time_spread_norm      — (max_ts − min_ts) clipped to
+--                                  `time_spread_window_hours`
+--   0.25 · project_diversity     — (distinct_projects − 1) / (N − 1),
+--                                  NULLs as own bucket
+--   0.25 · task_type_diversity   — analogous
+--
+-- Time-spread is the dominant axis because same-project + same-task-type can
+-- still be a valid intra-project pattern ("Ich vergesse X beim implement-
+-- Task"), but those must then be spread over time. Same-project + same-task
+-- + < 1 h is redundancy, not pattern.
+--
+-- Default `min_diversity_score = 0.0` keeps the RPC backwards-compatible for
+-- callers that want raw clusters; the REM-sleep caller passes a positive
+-- gate (see scripts/nightly-sleep.mjs, env REM_MIN_DIVERSITY).
+--
+-- Renumbering note (issue #95 triage): this work originally lived in a
+-- stashed 051_cluster_diversity.sql from an interrupted autonomy branch.
+-- Slot 051 on main is now `051_fix_coactivate_memories.sql` (unrelated work
+-- merged in the interim). 072 was just taken by the lessons.pattern_name
+-- migration; 073 is the next free slot. The RPC body is unchanged from the
+-- original stash, modulo:
+--   1. The GRANT EXECUTE for the new 6-arg signature, which the stash
+--      forgot — DROP FUNCTION removes the GRANT issued by migration 016
+--      along with the function, so without re-granting every authenticated
+--      client breaks at runtime.
+--   2. A defensive DROP of both prior overloads (3-arg from 015, 4-arg from
+--      016) before the recreate, so CREATE OR REPLACE can never silently
+--      add a NEW overload on top instead of replacing.
+-- ---------------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS find_experience_clusters(FLOAT, INT, INT, FLOAT);
+DROP FUNCTION IF EXISTS find_experience_clusters(FLOAT, INT, INT);
+
+CREATE OR REPLACE FUNCTION find_experience_clusters(
+  similarity_threshold     FLOAT DEFAULT 0.85,
+  min_cluster_size         INT   DEFAULT 2,
+  max_age_days             INT   DEFAULT 30,
+  lesson_match_threshold   FLOAT DEFAULT 0.78,
+  time_spread_window_hours INT   DEFAULT 72,
+  min_diversity_score      FLOAT DEFAULT 0.0
+)
+RETURNS TABLE (
+  seed_id              UUID,
+  seed_summary         TEXT,
+  member_ids           UUID[],
+  member_count         INT,
+  avg_difficulty       FLOAT,
+  avg_valence          FLOAT,
+  outcomes             TEXT[],
+  matched_lesson_id    UUID,
+  matched_lesson_text  TEXT,
+  matched_similarity   FLOAT,
+  diversity_score      FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  rec              RECORD;
+  used             UUID[] := ARRAY[]::UUID[];
+  match            RECORD;
+  time_span_hours  FLOAT;
+  distinct_proj    INT;
+  distinct_task    INT;
+  p_ratio          FLOAT;
+  t_ratio          FLOAT;
+  time_norm        FLOAT;
+BEGIN
+  FOR rec IN
+    SELECT id, summary, embedding
+      FROM experiences
+     WHERE reflected = FALSE
+       AND embedding IS NOT NULL
+       AND created_at >= NOW() - (max_age_days || ' days')::INTERVAL
+     ORDER BY created_at DESC
+  LOOP
+    IF rec.id = ANY(used) THEN CONTINUE; END IF;
+
+    seed_id      := rec.id;
+    seed_summary := rec.summary;
+
+    SELECT
+      array_agg(e.id),
+      count(*)::INT,
+      avg(e.difficulty)::FLOAT,
+      avg(e.valence)::FLOAT,
+      array_agg(DISTINCT e.outcome)
+      INTO member_ids, member_count, avg_difficulty, avg_valence, outcomes
+    FROM experiences e
+    WHERE e.reflected = FALSE
+      AND e.embedding IS NOT NULL
+      AND e.id <> ALL(used)
+      AND (1 - (e.embedding <=> rec.embedding)) >= similarity_threshold
+      AND e.created_at >= NOW() - (max_age_days || ' days')::INTERVAL;
+
+    IF member_count >= min_cluster_size THEN
+      -- diversity over the member set ----------------------------------------
+      SELECT
+        EXTRACT(epoch FROM (MAX(e.created_at) - MIN(e.created_at))) / 3600.0,
+        COUNT(DISTINCT COALESCE(e.project_id::TEXT, '__null__')),
+        COUNT(DISTINCT COALESCE(e.task_type,        '__null__'))
+        INTO time_span_hours, distinct_proj, distinct_task
+      FROM experiences e
+      WHERE e.id = ANY(member_ids);
+
+      time_norm := LEAST(GREATEST(time_span_hours, 0) / NULLIF(time_spread_window_hours, 0)::FLOAT, 1.0);
+      p_ratio   := CASE WHEN member_count > 1 THEN (distinct_proj - 1)::FLOAT / (member_count - 1) ELSE 0 END;
+      t_ratio   := CASE WHEN member_count > 1 THEN (distinct_task - 1)::FLOAT / (member_count - 1) ELSE 0 END;
+
+      diversity_score := 0.50 * time_norm + 0.25 * p_ratio + 0.25 * t_ratio;
+
+      IF diversity_score < min_diversity_score THEN
+        -- Below diversity gate: mark members as used so we don't reseed the
+        -- same set on the next iteration, but do NOT emit. Treat as noise.
+        used := used || member_ids;
+        CONTINUE;
+      END IF;
+
+      used := used || member_ids;
+
+      -- Lesson-match lookup (unchanged from migration 016 v2) ----------------
+      SELECT l.id, l.lesson, (1 - (l.embedding <=> rec.embedding))::FLOAT AS sim
+        INTO match
+        FROM lessons l
+       WHERE l.embedding IS NOT NULL
+         AND (1 - (l.embedding <=> rec.embedding)) >= lesson_match_threshold
+       ORDER BY l.embedding <=> rec.embedding
+       LIMIT 1;
+
+      IF FOUND THEN
+        matched_lesson_id   := match.id;
+        matched_lesson_text := match.lesson;
+        matched_similarity  := match.sim;
+      ELSE
+        matched_lesson_id   := NULL;
+        matched_lesson_text := NULL;
+        matched_similarity  := NULL;
+      END IF;
+
+      RETURN NEXT;
+    ELSE
+      used := used || ARRAY[rec.id];
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- DROP above removed every grant; re-issue for the new 6-arg signature so
+-- service_role / anon can keep calling the RPC. Mirrors the GRANT in 016.
+GRANT EXECUTE ON FUNCTION find_experience_clusters(
+  FLOAT, INT, INT, FLOAT, INT, FLOAT
+) TO anon, service_role;


### PR DESCRIPTION
## Summary

Closes the last remaining box on #95 (triage of 3 stashed REM/lessons migrations). PR #97 ships migration 072 (`pattern_name` slug); this PR ships migration 073 — the cluster diversity gate for `find_experience_clusters`.

Without the gate the REM synthesiser happily clusters two fragments of the same session and produces redundant lessons. The new `diversity_score ∈ [0, 1]` is a weighted sum:

| Weight | Axis | Source |
|---|---|---|
| 0.50 | `time_spread_norm` | `(max_ts − min_ts)` clipped to `time_spread_window_hours` (default 72 h) |
| 0.25 | `project_diversity` | `(distinct_projects − 1) / (N − 1)` |
| 0.25 | `task_type_diversity` | analogous |

Default `min_diversity_score = 0.0` keeps every existing caller backwards-compatible; the nightly REM job opts into the gate via `REM_MIN_DIVERSITY`.

## Why two PRs and not one

Same rationale as #97 — each migration ships in its own PR so it can be reviewed (and if needed reverted) independently. 073 is otherwise content-independent of 072: it touches `find_experience_clusters` only, no overlap with `lessons.pattern_name`.

## Two latent bugs from the stash variant, fixed here

Same defensive-DROP pattern as PR #97:

1. **GRANT EXECUTE re-issued.** `DROP FUNCTION` removes the GRANT issued by migration 016 along with the function. The stash variant forgot to re-grant — every authenticated client (including `scripts/nightly-sleep.mjs`) would have broken at runtime. Pinned at the SQL-text level by the contract test.
2. **Both prior overloads dropped, not just one.** Stash dropped only the 4-arg overload. Defensive-dropped the 3-arg overload from migration 015 too, so a future revert of 016 cannot resurrect it.

## Backwards-compatibility

The new params (`time_spread_window_hours`, `min_diversity_score`) are appended last with safe defaults. The existing 3-arg TS caller in `services/experiences.ts:findClusters` keeps working without code changes — the SQL function fills in defaults for params 4–6.

## Test plan

- [x] 9 new contract assertions added (`migration-073-cluster-diversity.test.ts`), mirroring the regex-pin pattern from `migration-070`/`-071`/`-072`:
  - both prior overloads dropped
  - 6-arg signature pinned in documented order
  - `min_diversity_score` default = `0.0` (no surprise gate)
  - `diversity_score` present in the new return shape
  - documented `0.50 / 0.25 / 0.25` weighting pinned literally
  - gate uses strict `<` and `continue`s without emitting
  - `time_norm` uses `LEAST(GREATEST(..., 0) / NULLIF(window, 0), 1.0)` clip
  - `GRANT EXECUTE` re-issued for the new 6-arg signature
- [x] Full suite: 374/374 tests pass
- [ ] Reed runs the migration by hand after merge (autonomy loop is forbidden from executing migrations)
- [ ] Once #97 and this PR are merged: `~/mycelium-stash-archive/2026-04-28/` can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)