### PR TITLE
feat(swarm): wire-types v1.1 — Lesson PoK fields (#100, sub-phase 4b)

### DIFF
--- a/mcp-server/src/__tests__/wire-types.test.ts
+++ b/mcp-server/src/__tests__/wire-types.test.ts
@@ -70,11 +70,14 @@ const exampleTrustEdge = {
 // WIRE_SPEC_VERSION
 // ---------------------------------------------------------------------------
 
-test("WIRE_SPEC_VERSION is the spec-defined string '1.0' (SWARM_SPEC §1)", () => {
+test("WIRE_SPEC_VERSION is the spec-defined string '1.1' (SWARM_SPEC §1, §3.7)", () => {
   // Pinned literal: a typo or accidental bump here would mis-stamp every
   // record produced by the node, and v1 negotiation is strict-equal on
   // the major component. Catch the mistake at the unit-test boundary.
-  assert.equal(WIRE_SPEC_VERSION, "1.0");
+  // v1.1 (sub-phase 4a, PR #101) added the Proof-of-Knowledge fields on
+  // Lesson; the major component remains "1" so v1.0 nodes stay
+  // negotiation-compatible per SWARM_SPEC §1.
+  assert.equal(WIRE_SPEC_VERSION, "1.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -162,6 +165,97 @@ test("kindOf: returns null on garbage and on partial records", () => {
   const partialLesson = { ...exampleLesson } as Record<string, unknown>;
   delete partialLesson.synthesized_from_cluster_size;
   assert.equal(kindOf(partialLesson), null);
+});
+
+// ---------------------------------------------------------------------------
+// v1.1 Proof-of-Knowledge field shape — SWARM_SPEC §3.1, §3.7
+//
+// These tests pin the type-shape contract for the five new optional fields.
+// They do NOT assert validation rules (those are rules 16–20 in §5, owned
+// by the validator); they only prove that:
+//   (a) a v1.0 Lesson without the new fields still satisfies the interface,
+//   (b) a v1.1 Lesson with all five fields populated also satisfies it,
+//   (c) the discriminator (kindOf) classifies both shapes as "lesson".
+// ---------------------------------------------------------------------------
+
+test("Lesson interface still accepts a v1.0-shaped record (no PoK fields)", () => {
+  // A literal v1.0 Lesson — spec_version "1.0", no evidence_* fields.
+  // SWARM_SPEC §1 says minor bumps are additive, so v1.1 nodes ingest
+  // v1.0 records (with evidence_unverifiable=true marking, per §3.1
+  // compatibility note). At the type-level that means the five v1.1
+  // fields MUST be optional — if they were required, this `satisfies
+  // Lesson` annotation would stop compiling.
+  const v10Lesson = {
+    id: "11111111-2222-3333-4444-555555555555",
+    content: "Pre-PoK lesson, valid under v1.0.",
+    embedding: [0.1, 0.2, 0.3],
+    synthesized_from_cluster_size: 3,
+    origin_node_id: "QmV10Node",
+    signed_at: "2026-04-22T00:00:00.000Z",
+    signature: "AAAA",
+    created_at: "2026-04-20T00:00:00.000Z",
+    spec_version: "1.0",
+  } satisfies Lesson;
+
+  assert.equal(v10Lesson.spec_version, "1.0");
+  assert.ok(!("evidence_root" in v10Lesson));
+  assert.ok(!("evidence_count" in v10Lesson));
+  assert.ok(!("prev_lesson_hash" in v10Lesson));
+  assert.ok(!("maturity_age_days" in v10Lesson));
+  assert.ok(!("useful_count" in v10Lesson));
+  assert.equal(kindOf(v10Lesson), "lesson");
+});
+
+test("Lesson interface accepts a v1.1-shaped record (all PoK fields populated)", () => {
+  // Pin the type shape for every PoK field declared in SWARM_SPEC §3.1
+  // (v1.1+). The `satisfies Lesson` annotation is the compile-time half;
+  // the runtime presence checks are the regression guard.
+  const examplePokLesson = {
+    id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    content: "Lessons in v1.1 carry provenance commitments, not just signatures.",
+    embedding: [0.1, 0.2, 0.3],
+    synthesized_from_cluster_size: 5,
+    origin_node_id: "QmExampleNodeId",
+    signed_at: "2026-04-30T01:00:00.000Z",
+    signature: "AAAA",
+    created_at: "2026-04-23T00:00:00.000Z",
+    tags: ["pok", "swarm-v1.1"],
+    spec_version: WIRE_SPEC_VERSION,
+    evidence_root: "QmEvidenceRootMultihash",
+    evidence_count: 5,
+    prev_lesson_hash: "QmPreviousLessonHash",
+    maturity_age_days: 7,
+    useful_count: 3,
+  } satisfies Lesson;
+
+  assert.equal(examplePokLesson.evidence_count, 5);
+  assert.equal(examplePokLesson.maturity_age_days, 7);
+  assert.equal(examplePokLesson.prev_lesson_hash, "QmPreviousLessonHash");
+  assert.equal(kindOf(examplePokLesson), "lesson");
+});
+
+test("Lesson interface accepts prev_lesson_hash=null (first-published lesson)", () => {
+  // SWARM_SPEC §3.1 v1.1 row: "prev_lesson_hash null only for the very
+  // first lesson a node ever publishes." Pin the null variant so the
+  // type stays `string | null`, not just `string`.
+  const firstEverLesson = {
+    id: "ffffffff-1111-2222-3333-444444444444",
+    content: "First lesson this node ever publishes.",
+    embedding: [0.5, 0.5, 0.5],
+    synthesized_from_cluster_size: 2,
+    origin_node_id: "QmFreshNode",
+    signed_at: "2026-04-30T01:00:00.000Z",
+    signature: "AAAA",
+    created_at: "2026-04-29T00:00:00.000Z",
+    spec_version: WIRE_SPEC_VERSION,
+    evidence_root: "QmEvidenceRootMultihash",
+    evidence_count: 2,
+    prev_lesson_hash: null,
+    maturity_age_days: 1,
+    useful_count: 0,
+  } satisfies Lesson;
+
+  assert.equal(firstEverLesson.prev_lesson_hash, null);
 });
 
 test("kindOf: does not confuse Lesson with HubAnchor (both carry embedding)", () => {

--- a/mcp-server/src/services/wire-types.ts
+++ b/mcp-server/src/services/wire-types.ts
@@ -22,8 +22,14 @@ import { canonicalize } from "./signature.js";
  * (here `"1"`) is the v1 negotiation rule. Producers SHOULD stamp records
  * with this constant rather than a free-form string so a major bump is
  * a single edit, not a search-and-replace.
+ *
+ * v1.1 (sub-phase 4a, merged in PR #101) adds the Proof-of-Knowledge
+ * fields on `Lesson` (`evidence_root`, `evidence_count`,
+ * `prev_lesson_hash`, `maturity_age_days`, `useful_count`). The bump is
+ * additive — minor bumps are reserved for backward-compatible additions
+ * per §1, so v1.0 records remain ingestable on v1.1 nodes.
  */
-export const WIRE_SPEC_VERSION = "1.0";
+export const WIRE_SPEC_VERSION = "1.1";
 
 // ---------------------------------------------------------------------------
 // Wire interfaces — SWARM_SPEC §3
@@ -41,6 +47,21 @@ export const WIRE_SPEC_VERSION = "1.0";
  * Producers MUST satisfy `synthesized_from_cluster_size >= 2` OR document
  * an abstracting synthesis step; on-wire, the cluster-size floor is what
  * the validator (Phase 3b, rule 11) enforces.
+ *
+ * v1.1 fields (Proof-of-Knowledge — SWARM_SPEC §3.7):
+ *   - `evidence_root`     Merkle root over hashed experience IDs (multihash).
+ *   - `evidence_count`    Number of underlying experiences (≥ 1).
+ *   - `prev_lesson_hash`  Multihash of this node's previous lesson, or null
+ *                         for the first lesson a node ever publishes.
+ *   - `maturity_age_days` Whole days between local `created_at` and `signed_at`.
+ *   - `useful_count`      How often this lesson was reinforced before signing.
+ *
+ * The five v1.1 fields are typed `?` (optional) here so a v1.0 record
+ * — which omits them — still satisfies the interface. The validator
+ * (sub-phase 4b runtime, future PR; rules 16–20 in SWARM_SPEC §5) is
+ * the place that enforces "MUST be present when spec_version >= 1.1"
+ * and "MUST be absent when spec_version == 1.0" (cross-version field
+ * smuggling is rule 20).
  */
 export interface Lesson {
   id: string;
@@ -53,6 +74,12 @@ export interface Lesson {
   created_at: string;
   tags?: string[];
   spec_version: string;
+  // v1.1 Proof-of-Knowledge fields (SWARM_SPEC §3.1, §3.7)
+  evidence_root?: string;
+  evidence_count?: number;
+  prev_lesson_hash?: string | null;
+  maturity_age_days?: number;
+  useful_count?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Sub-phase **4b** of issue #100 — the type-layer half. Bumps `WIRE_SPEC_VERSION` from `"1.0"` to `"1.1"` and adds the five Proof-of-Knowledge fields to the `Lesson` interface, matching the v1.1 contract that merged in PR #101 (`docs/SWARM_SPEC.md` §3.1, §3.7).

## Changes

**`mcp-server/src/services/wire-types.ts`** (+27/-2):
- `WIRE_SPEC_VERSION` → `"1.1"` with doc-comment pointer to PR #101
- `Lesson` gains five optional fields:
  - `evidence_root?: string` — multihash of the Merkle root over hashed experience IDs
  - `evidence_count?: number` — count of underlying experiences (≥ 1)
  - `prev_lesson_hash?: string \| null` — multihash of previous lesson, or null for the first-ever
  - `maturity_age_days?: number`
  - `useful_count?: number`
- Optional (`?`) so v1.0 records (which lack them) still satisfy the interface, per SWARM_SPEC §3.1 v1.0→v1.1 compatibility rule.

**`mcp-server/src/__tests__/wire-types.test.ts`** (+97/-1):
- `WIRE_SPEC_VERSION` test pinned to `"1.1"`
- New tests:
  - `Lesson interface still accepts a v1.0-shaped record (no PoK fields)`
  - `Lesson interface accepts a v1.1-shaped record (all PoK fields populated)`
  - `Lesson interface accepts prev_lesson_hash=null (first-published lesson)`

## Test plan

- [x] **383/383 tests pass** (was 380; +3 new v1.1 type-shape tests)
- [x] No runtime behaviour changes — pure type and constant edits
- [x] `satisfies Lesson` annotation in tests is the compile-time contract; if any of the five fields had been typed `required` instead of `?`, the v1.0-shaped test literal would have stopped compiling

## Why optional, not required

The validator (separate PR — sub-phase 4b *runtime*, rules 16–20 in SWARM_SPEC §5) is the right layer to enforce "MUST be present when `spec_version >= "1.1"`" and "MUST be absent when `spec_version == "1.0"`" (cross-version field smuggling, rule 20). At the TypeScript type-layer, optional is the only encoding that keeps both v1.0 and v1.1 records type-compatible.

## Roadmap

This closes the type-layer portion of v1.1 ingestion. Remaining sub-phases tracked in `docs/SWARM_SPEC.md` §9:

| Sub-phase | Scope |
|---|---|
| 4c | Evidence Merkle builder service (RFC 6962 over hashed experience IDs) |
| 4d | `prev_lesson_hash` chain table (migration 074) |
| 4e | `/swarm/lessons/{id}/proof` HTTP endpoint |
| 4f | TrustEdge auto-tuning + quarantine (migration 075) |
| 4g | ConscienceAgent contradicts-trigger |
| 4h | REM self-audit pass |
| 4i | Two-tier pinning + diversity policy (migration 076) |

🤖 Authored under Reed's explicit delegation of architectural decision authority for the swarm layer, 2026-04-30.