### PR TITLE
feat(swarm): evidence Merkle builder — sub-phase 4c (#103)

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -620,8 +620,8 @@ swarm-labelled phase merges to `main`.
 | 3c — `GET /.well-known/mycelium-node` advertisement | §3.2 | [#87](https://github.com/Dewinator/mycelium/issues/87) | `be59267` | ✅ on `main` |
 | 3d — Peer + signed-record storage (migration 071) | §6 | [#88](https://github.com/Dewinator/mycelium/issues/88) | `b0eca59` | ✅ on `main` |
 | 4a — PoK + self-healing spec (v1.1) | §3.1, §3.7, §4.6, §5 (16–20), §10 | [#100](https://github.com/Dewinator/mycelium/issues/100) | `3292bd6` | ✅ on `main` |
-| 4b — `wire-types.ts` v1.1 fields + JCS validator update | §3.1 | [#102](https://github.com/Dewinator/mycelium/issues/102) | — | ⏳ spec-only |
-| 4c — Evidence Merkle builder service | §3.7.1 | [#103](https://github.com/Dewinator/mycelium/issues/103) | — | ⏳ spec-only |
+| 4b — `wire-types.ts` v1.1 fields + JCS validator update | §3.1 | [#102](https://github.com/Dewinator/mycelium/issues/102) | `a33a5e5` | ✅ on `main` |
+| 4c — Evidence Merkle builder service | §3.7.1 | [#103](https://github.com/Dewinator/mycelium/issues/103) | _PR pending_ | 🟡 implemented |
 | 4d — `prev_lesson_hash` chain table (migration 074) | §3.7.2 | [#104](https://github.com/Dewinator/mycelium/issues/104) | — | ⏳ spec-only |
 | 4e — `/swarm/lessons/{id}/proof` endpoint | §4.6 | [#105](https://github.com/Dewinator/mycelium/issues/105) | — | ⏳ spec-only |
 | 4f — TrustEdge auto-tuning + quarantine (migration 075) | §10.1, §10.2 | [#107](https://github.com/Dewinator/mycelium/issues/107) | — | ⏳ spec-only |

--- a/mcp-server/src/__tests__/evidence-merkle.test.ts
+++ b/mcp-server/src/__tests__/evidence-merkle.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for `services/evidence-merkle.ts` — Swarm sub-phase 4c (issue #103).
+ *
+ * Coverage matrix (issue #103 acceptance):
+ *
+ *   1. All four exported functions have at least one happy-path test.
+ *   2. Hand-recomputed (test-side, independent of the module) root matches
+ *      the module's output for 4-leaf and 7-leaf trees. The 7-leaf case
+ *      exercises the odd-level trailing-leaf duplication path twice (once
+ *      at level-0 with 7 leaves, once at level-1 with 4 leaves).
+ *   3. Round-trip: build → proof → verify holds for *every* leaf for
+ *      tree sizes 1, 2, 3, 4, 5, 7, 8.
+ *   4. Privacy invariant: builder rejects strings that obviously look
+ *      like raw experience content (whitespace, multi-line, oversized).
+ *      Output of every public function is a hash, not raw content.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import {
+  hashExperienceId,
+  buildEvidenceRoot,
+  buildInclusionProof,
+  verifyInclusionProof,
+  __internal,
+} from "../services/evidence-merkle.js";
+
+// ---------------------------------------------------------------------------
+// Independent re-implementation of §3.7.1 hashing — the test-side oracle.
+//
+// This MUST be byte-identical to the module's behaviour, but written from
+// scratch from the spec text alone. If the module ever drifts (e.g. wrong
+// domain-separation byte, wrong multihash header), the oracle catches it.
+// ---------------------------------------------------------------------------
+
+const SHA256_MULTIHASH_HEADER = Buffer.from([0x12, 0x20]);
+const BASE58_ALPHA =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function oracleBase58Encode(bytes: Buffer): string {
+  if (bytes.length === 0) return "";
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  let n = 0n;
+  for (const b of bytes) n = (n << 8n) | BigInt(b);
+  let out = "";
+  while (n > 0n) {
+    const r = Number(n % 58n);
+    n = n / 58n;
+    out = BASE58_ALPHA[r] + out;
+  }
+  return "1".repeat(zeros) + out;
+}
+
+function oracleBase58Decode(s: string): Buffer {
+  if (s.length === 0) return Buffer.alloc(0);
+  let zeros = 0;
+  while (zeros < s.length && s[zeros] === "1") zeros++;
+  let n = 0n;
+  for (let i = zeros; i < s.length; i++) {
+    const v = BASE58_ALPHA.indexOf(s[i]);
+    if (v < 0) throw new Error(`oracle: bad base58 char ${s[i]}`);
+    n = n * 58n + BigInt(v);
+  }
+  const bytes: number[] = [];
+  while (n > 0n) {
+    bytes.unshift(Number(n & 0xffn));
+    n >>= 8n;
+  }
+  return Buffer.concat([Buffer.alloc(zeros, 0), Buffer.from(bytes)]);
+}
+
+function oracleHashExperienceId(id: string): string {
+  const digest = createHash("sha256").update(Buffer.from(id, "utf8")).digest();
+  return oracleBase58Encode(Buffer.concat([SHA256_MULTIHASH_HEADER, digest]));
+}
+
+function oracleLeafDigest(leafMultihashB58: string): Buffer {
+  const mh = oracleBase58Decode(leafMultihashB58);
+  return createHash("sha256")
+    .update(Buffer.concat([Buffer.from([0x00]), mh]))
+    .digest();
+}
+
+function oracleInnerDigest(left: Buffer, right: Buffer): Buffer {
+  // Sorted pair — matches module's inner-hash convention.
+  const [a, b] =
+    Buffer.compare(left, right) <= 0 ? [left, right] : [right, left];
+  return createHash("sha256")
+    .update(Buffer.concat([Buffer.from([0x01]), a, b]))
+    .digest();
+}
+
+function oracleBuildRoot(experience_ids: string[]): string {
+  const leaves = experience_ids.map(oracleHashExperienceId).sort();
+  let layer: Buffer[] = leaves.map(oracleLeafDigest);
+  while (layer.length > 1) {
+    const next: Buffer[] = [];
+    for (let i = 0; i < layer.length; i += 2) {
+      const left = layer[i];
+      const right = i + 1 < layer.length ? layer[i + 1] : layer[i];
+      next.push(oracleInnerDigest(left, right));
+    }
+    layer = next;
+  }
+  return oracleBase58Encode(
+    Buffer.concat([SHA256_MULTIHASH_HEADER, layer[0]])
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function fakeUuids(n: number): string[] {
+  // Deterministic UUID-shaped IDs — keeps test output reproducible.
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const hex = i.toString(16).padStart(32, "0");
+    out.push(
+      `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(
+        16,
+        20
+      )}-${hex.slice(20, 32)}`
+    );
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("hashExperienceId produces a 46-char base58btc sha2-256 multihash", () => {
+  const h = hashExperienceId("00000000-0000-0000-0000-000000000000");
+  assert.equal(h.length, 46, "sha2-256 multihash must be 46 base58btc chars");
+  assert.ok(h.startsWith("Qm"), "sha2-256 multihash MUST be Qm-prefixed");
+  // Independent recomputation
+  assert.equal(
+    h,
+    oracleHashExperienceId("00000000-0000-0000-0000-000000000000")
+  );
+});
+
+test("hashExperienceId is deterministic and collision-distinguishes near-duplicates", () => {
+  assert.equal(hashExperienceId("alpha"), hashExperienceId("alpha"));
+  assert.notEqual(hashExperienceId("alpha"), hashExperienceId("alphA"));
+});
+
+test("buildEvidenceRoot rejects empty input (evidence_count must be >= 1)", () => {
+  assert.throws(() => buildEvidenceRoot([]), /at least one experience id/);
+});
+
+test("buildEvidenceRoot single-leaf root = leafHash(multihash) as a multihash", () => {
+  const ids = fakeUuids(1);
+  const { root, leaves } = buildEvidenceRoot(ids);
+  assert.equal(leaves.length, 1);
+  // Independent recomputation: a 1-leaf tree has root == leafHash, no inner hashing happens.
+  const expected = oracleBase58Encode(
+    Buffer.concat([SHA256_MULTIHASH_HEADER, oracleLeafDigest(leaves[0])])
+  );
+  assert.equal(root, expected);
+});
+
+test("buildEvidenceRoot 4-leaf root matches independent oracle computation", () => {
+  const ids = fakeUuids(4);
+  const { root, leaves } = buildEvidenceRoot(ids);
+  assert.equal(leaves.length, 4);
+  // Leaves must be sorted ascending — §3.7.1 invariant.
+  for (let i = 1; i < leaves.length; i++) {
+    assert.ok(leaves[i - 1] <= leaves[i], "leaves must be sorted ascending");
+  }
+  assert.equal(root, oracleBuildRoot(ids));
+});
+
+test("buildEvidenceRoot 7-leaf root matches oracle (odd-level duplication path)", () => {
+  // 7 leaves → level-0 has 7 (odd, last duplicates) → level-1 has 4 → level-2 has 2 → root.
+  // Two duplications happen; oracle MUST agree.
+  const ids = fakeUuids(7);
+  const { root, leaves } = buildEvidenceRoot(ids);
+  assert.equal(leaves.length, 7);
+  assert.equal(root, oracleBuildRoot(ids));
+});
+
+test("buildEvidenceRoot is order-independent (leaves get sorted)", () => {
+  const ids = fakeUuids(5);
+  const a = buildEvidenceRoot(ids).root;
+  const b = buildEvidenceRoot([...ids].reverse()).root;
+  assert.equal(a, b, "input order must not affect root — leaves are pre-sorted");
+});
+
+test("round-trip: build → proof → verify holds for every leaf at sizes {1,2,3,4,5,7,8}", () => {
+  for (const n of [1, 2, 3, 4, 5, 7, 8]) {
+    const ids = fakeUuids(n);
+    const { root, leaves } = buildEvidenceRoot(ids);
+    for (const id of ids) {
+      const proof = buildInclusionProof(ids, id);
+      assert.ok(
+        verifyInclusionProof(root, proof.hashed_experience_id, proof.merkle_path),
+        `n=${n} id=${id} round-trip failed`
+      );
+      // The proof's leaf MUST be one of the tree's sorted leaves.
+      assert.ok(leaves.includes(proof.hashed_experience_id));
+    }
+  }
+});
+
+test("buildInclusionProof accepts already-hashed leaf as target", () => {
+  const ids = fakeUuids(5);
+  const { root } = buildEvidenceRoot(ids);
+  const targetHashed = hashExperienceId(ids[2]);
+  const proof = buildInclusionProof(ids, targetHashed);
+  assert.equal(proof.hashed_experience_id, targetHashed);
+  assert.ok(verifyInclusionProof(root, proof.hashed_experience_id, proof.merkle_path));
+});
+
+test("buildInclusionProof throws when target is not in the leaf set", () => {
+  const ids = fakeUuids(3);
+  assert.throws(
+    () => buildInclusionProof(ids, "ffffffff-ffff-ffff-ffff-ffffffffffff"),
+    /target leaf not found/
+  );
+});
+
+test("verifyInclusionProof rejects a tampered merkle_path", () => {
+  const ids = fakeUuids(4);
+  const { root } = buildEvidenceRoot(ids);
+  const proof = buildInclusionProof(ids, ids[1]);
+  assert.ok(verifyInclusionProof(root, proof.hashed_experience_id, proof.merkle_path));
+  // Replace one sibling with a hash of "garbage"
+  const bad = [...proof.merkle_path];
+  bad[0] = hashExperienceId("garbage-leaf");
+  assert.equal(
+    verifyInclusionProof(root, proof.hashed_experience_id, bad),
+    false
+  );
+});
+
+test("verifyInclusionProof rejects malformed root / path strings without throwing", () => {
+  const ids = fakeUuids(4);
+  const proof = buildInclusionProof(ids, ids[0]);
+  // Bad root — wrong length
+  assert.equal(verifyInclusionProof("not-a-multihash", proof.hashed_experience_id, proof.merkle_path), false);
+  // Bad path entry — empty string
+  assert.equal(verifyInclusionProof(buildEvidenceRoot(ids).root, proof.hashed_experience_id, [""]), false);
+  // Bad leaf — invalid base58 char (0 is not in the bitcoin alphabet)
+  assert.equal(verifyInclusionProof(buildEvidenceRoot(ids).root, "0", proof.merkle_path), false);
+});
+
+test("verifyInclusionProof rejects a proof against the wrong root", () => {
+  const idsA = fakeUuids(4);
+  const idsB = fakeUuids(4).map((s) => s.replace(/0/g, "1")); // disjoint set
+  const rootB = buildEvidenceRoot(idsB).root;
+  const proofA = buildInclusionProof(idsA, idsA[0]);
+  assert.equal(
+    verifyInclusionProof(rootB, proofA.hashed_experience_id, proofA.merkle_path),
+    false
+  );
+});
+
+test("privacy invariant: builder rejects whitespace in IDs (looks like raw content)", () => {
+  assert.throws(
+    () => hashExperienceId("hello world this is content not an id"),
+    /whitespace or structural characters/
+  );
+  assert.throws(
+    () => buildEvidenceRoot(["aaa-bbb", "id with space"]),
+    /whitespace or structural characters/
+  );
+});
+
+test("privacy invariant: builder rejects oversized inputs (likely raw content)", () => {
+  const tooLong = "a".repeat(200);
+  assert.throws(() => hashExperienceId(tooLong), />128/);
+  assert.throws(() => buildEvidenceRoot([tooLong]), />128/);
+});
+
+test("privacy invariant: builder rejects multi-line + JSON-shaped inputs", () => {
+  assert.throws(
+    () => hashExperienceId('{"id": "abc", "content": "secret"}'),
+    /whitespace or structural characters/
+  );
+  assert.throws(() => hashExperienceId("line1\nline2"), /whitespace or structural characters/);
+});
+
+test("privacy invariant: outputs of all public functions are hashes, not raw IDs", () => {
+  const rawIds = fakeUuids(3);
+  const { root, leaves } = buildEvidenceRoot(rawIds);
+  // Output must not contain any raw id substring.
+  for (const raw of rawIds) {
+    assert.ok(!root.includes(raw), `root must not leak raw id ${raw}`);
+    for (const leaf of leaves) {
+      assert.ok(!leaf.includes(raw), `leaf must not leak raw id ${raw}`);
+    }
+  }
+  const proof = buildInclusionProof(rawIds, rawIds[1]);
+  assert.ok(!proof.hashed_experience_id.includes(rawIds[1]));
+  for (const sib of proof.merkle_path) {
+    for (const raw of rawIds) {
+      assert.ok(!sib.includes(raw), `merkle_path must not leak raw id ${raw}`);
+    }
+  }
+});
+
+test("__internal helpers are consistent with the public API", () => {
+  // The leaf digest of an id, computed via __internal, equals what
+  // verifyInclusionProof's first step would compute. Tightens the
+  // contract between the public API and the verification primitive.
+  const id = "abc-123";
+  const hashedId = hashExperienceId(id);
+  const leafD = __internal.leafDigest(hashedId);
+  assert.equal(leafD.length, 32);
+
+  // A 1-leaf tree's root is exactly multihash(leafDigest) and verify
+  // accepts an empty merkle_path against it.
+  const { root } = buildEvidenceRoot([id]);
+  assert.equal(verifyInclusionProof(root, hashedId, []), true);
+});

--- a/mcp-server/src/services/evidence-merkle.ts
+++ b/mcp-server/src/services/evidence-merkle.ts
@@ -1,0 +1,368 @@
+/**
+ * Evidence-Merkle service — Swarm sub-phase 4c (issue #103, RFC #100).
+ *
+ * Pure, dependency-free producer-side Merkle tree that anchors a Lesson's
+ * `evidence_root` to the experience IDs that produced it, per
+ * docs/SWARM_SPEC.md §3.7.1 and §4.6.
+ *
+ * Hashing rules (RFC 6962, Bitcoin trailing-leaf duplication):
+ *   - Leaf hash:  H(0x00 || hashed_experience_id_bytes)
+ *   - Inner hash: H(0x01 || min(L, R) || max(L, R))     (see §design notes below)
+ *   - Odd levels: trailing leaf duplicated
+ *
+ * § design notes — sorted-pair inner-hash convention:
+ *
+ *   The 4c API contract (issue #103) is `verifyInclusionProof(root, leaf,
+ *   path) → bool`. There is no leaf-index parameter, so the verifier
+ *   cannot recover left/right placement at each level the way classical
+ *   RFC 6962 audit-path verification does. Sorted-pair concatenation
+ *   `H(0x01 || min(L,R) || max(L,R))` is the position-less normal form
+ *   compatible with that signature; it is the same construction used by
+ *   OpenZeppelin's MerkleProof.sol and most on-chain verifiers. The
+ *   collision-resistance argument is unchanged from RFC 6962 because
+ *   inner-domain (0x01) is disjoint from leaf-domain (0x00).
+ *
+ *   Trade-off: an attacker who can choose which two of N leaves are
+ *   adjacent-siblings at level 0 can cause the tree to swap the
+ *   left/right of those two; sorted-pair hashing collapses both
+ *   orderings to the same hash. Because v1.1 lessons sort leaves
+ *   ascending before tree construction (spec §3.7.1) the attacker
+ *   cannot control adjacency without controlling the experience-id
+ *   hashes themselves — which they cannot, because the canonical
+ *   experience id space is enforced by the producer node and the
+ *   verifier never sees raw IDs.
+ *
+ * Privacy invariant (Designprinzip 2):
+ *
+ *   Only **hashes** of experience IDs ever leave this module. The
+ *   evidence-root and merkle-paths are sha2-256 multihashes; the
+ *   `hashed_experience_id` exposed in inclusion proofs is itself a
+ *   hash. Raw experience IDs are accepted at the input boundary
+ *   (because the producer needs them to compute hashes), but they
+ *   never appear in the output of any exported function. A defensive
+ *   shape check rejects anything that obviously isn't an ID (whitespace,
+ *   structural delimiters, suspicious length).
+ */
+import { createHash } from "node:crypto";
+import { base58btcEncode } from "./node-identity.js";
+
+// ---------------------------------------------------------------------------
+// Multihash + base58btc helpers (sha2-256 only, the single hash this swarm
+// commits to per SWARM_SPEC §3.7.1).
+// ---------------------------------------------------------------------------
+
+const MULTIHASH_SHA256_HEADER = Buffer.from([0x12, 0x20]); // sha2-256, 32-byte digest
+const MULTIHASH_TOTAL_BYTES = 34; // 2-byte header + 32-byte digest
+const LEAF_PREFIX = Buffer.from([0x00]);
+const INNER_PREFIX = Buffer.from([0x01]);
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+const BASE58_INDEX = (() => {
+  const idx = new Int8Array(128).fill(-1);
+  for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+    idx[BASE58_ALPHABET.charCodeAt(i)] = i;
+  }
+  return idx;
+})();
+
+function base58btcDecode(s: string): Buffer {
+  if (s.length === 0) return Buffer.alloc(0);
+  let zeros = 0;
+  while (zeros < s.length && s[zeros] === "1") zeros++;
+  let n = 0n;
+  for (let i = zeros; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    const v = code < 128 ? BASE58_INDEX[code] : -1;
+    if (v < 0) {
+      throw new Error(
+        `base58btcDecode: invalid base58btc character '${s[i]}' at index ${i}`
+      );
+    }
+    n = n * 58n + BigInt(v);
+  }
+  const out: number[] = [];
+  while (n > 0n) {
+    out.unshift(Number(n & 0xffn));
+    n >>= 8n;
+  }
+  return Buffer.concat([Buffer.alloc(zeros, 0), Buffer.from(out)]);
+}
+
+function multihashFromDigest(digest: Buffer): string {
+  if (digest.length !== 32) {
+    throw new Error(`multihashFromDigest: expected 32-byte digest, got ${digest.length}`);
+  }
+  return base58btcEncode(Buffer.concat([MULTIHASH_SHA256_HEADER, digest]));
+}
+
+function digestFromMultihash(multihashB58: string): Buffer {
+  const decoded = base58btcDecode(multihashB58);
+  if (decoded.length !== MULTIHASH_TOTAL_BYTES) {
+    throw new Error(
+      `digestFromMultihash: expected ${MULTIHASH_TOTAL_BYTES}-byte sha2-256 multihash, got ${decoded.length} bytes`
+    );
+  }
+  if (decoded[0] !== 0x12 || decoded[1] !== 0x20) {
+    throw new Error(
+      `digestFromMultihash: prefix 0x${decoded[0].toString(16)} 0x${decoded[1].toString(16)} is not sha2-256 (expected 0x12 0x20)`
+    );
+  }
+  return decoded.subarray(2);
+}
+
+// ---------------------------------------------------------------------------
+// Privacy guard — defensive check that rejects obviously-not-an-ID input.
+//
+// This is not a security boundary (a 36-char alphanumeric blob would slip
+// through). The guard exists to fail loud on accidental misuse — e.g. a
+// caller mistakenly passing experience.content instead of experience.id.
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_ID_CHARS = /[\s{}\[\]"<>]/;
+const MAX_REASONABLE_ID_LENGTH = 128;
+
+function assertExperienceIdShape(value: unknown, ctx: string): asserts value is string {
+  if (typeof value !== "string") {
+    throw new Error(`${ctx}: experience_id must be a string, got ${typeof value}`);
+  }
+  if (value.length === 0) {
+    throw new Error(`${ctx}: experience_id must not be empty`);
+  }
+  if (value.length > MAX_REASONABLE_ID_LENGTH) {
+    throw new Error(
+      `${ctx}: experience_id is ${value.length} chars (>${MAX_REASONABLE_ID_LENGTH}); refusing to accept what looks like raw content. Pass an ID, not an experience body.`
+    );
+  }
+  if (FORBIDDEN_ID_CHARS.test(value)) {
+    throw new Error(
+      `${ctx}: experience_id contains whitespace or structural characters; refusing to accept what looks like raw content. Pass an ID, not an experience body.`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Hash a producer-local experience ID into the leaf form that goes onto
+ * the wire: `multihash(sha2-256, utf8-bytes-of-experience-id)` encoded in
+ * base58btc. Output is a 46-character `Qm…`-prefixed string (same shape as
+ * `node_id` from §3.5).
+ *
+ * Inputs are required to look like IDs (no whitespace, ≤ 128 chars). The
+ * canonical byte-encoding for an experience id is its UTF-8 representation;
+ * §3.7.1 phrases this as `experience_id_canonical_bytes`.
+ */
+export function hashExperienceId(experience_id: string): string {
+  assertExperienceIdShape(experience_id, "hashExperienceId");
+  const digest = createHash("sha256")
+    .update(Buffer.from(experience_id, "utf8"))
+    .digest();
+  return multihashFromDigest(digest);
+}
+
+export interface EvidenceRoot {
+  /** base58btc multihash of the Merkle root (sha2-256). */
+  root: string;
+  /**
+   * The full set of `hashed_experience_id` leaves, sorted ascending —
+   * the same order in which they were folded into the tree. Producers
+   * persist this so they can later answer a §4.6 inclusion-proof
+   * challenge without re-deriving the hashes from raw IDs.
+   */
+  leaves: string[];
+}
+
+/**
+ * Build the `evidence_root` Merkle commitment over a producer-local set
+ * of experience IDs. Leaves are hashed, sorted ascending (lex order on the
+ * base58btc strings), then folded with RFC 6962 / Bitcoin conventions
+ * documented at module top.
+ *
+ * Empty input is rejected — a v1.1 Lesson MUST satisfy `evidence_count ≥ 1`
+ * (§3.1). Single-leaf trees are valid; the root is `H(0x00 || multihash)`.
+ */
+export function buildEvidenceRoot(experience_ids: string[]): EvidenceRoot {
+  if (!Array.isArray(experience_ids)) {
+    throw new Error("buildEvidenceRoot: experience_ids must be an array");
+  }
+  if (experience_ids.length === 0) {
+    throw new Error(
+      "buildEvidenceRoot: at least one experience id is required (evidence_count must be >= 1 per SWARM_SPEC §3.1)"
+    );
+  }
+  experience_ids.forEach((id, i) =>
+    assertExperienceIdShape(id, `buildEvidenceRoot[${i}]`)
+  );
+  const leaves = experience_ids.map(hashExperienceId).sort();
+  const root = computeRoot(leaves);
+  return { root, leaves };
+}
+
+export interface InclusionProof {
+  /** The leaf this proof attests to. base58btc sha2-256 multihash. */
+  hashed_experience_id: string;
+  /**
+   * Bottom-up sibling hashes (each a base58btc sha2-256 multihash of an
+   * intermediate node). Combined with `hashed_experience_id` per §3.7.1
+   * leaf-then-inner hashing, reconstructs `evidence_root`.
+   */
+  merkle_path: string[];
+}
+
+/**
+ * Build an inclusion proof for `target` over `experience_ids`.
+ *
+ * `target` may be either the raw experience id (will be hashed
+ * internally) or an already-hashed leaf (`hashExperienceId(...)` output).
+ * Both forms resolve to the same on-tree leaf — accepting either lets the
+ * §4.6 endpoint hand the function the value it already has, without
+ * requiring re-derivation.
+ *
+ * Throws if the target is not present in the leaf set; that is a
+ * producer-side invariant violation, not a quietly-empty proof.
+ */
+export function buildInclusionProof(
+  experience_ids: string[],
+  target: string
+): InclusionProof {
+  if (!Array.isArray(experience_ids) || experience_ids.length === 0) {
+    throw new Error(
+      "buildInclusionProof: experience_ids must be a non-empty array"
+    );
+  }
+  experience_ids.forEach((id, i) =>
+    assertExperienceIdShape(id, `buildInclusionProof[${i}]`)
+  );
+  // Resolve target to its leaf form. A 46-char Qm-prefixed string is a
+  // hashed leaf; anything else is treated as a raw id and hashed.
+  const leafTarget = looksLikeMultihashLeaf(target)
+    ? target
+    : hashExperienceId(target);
+
+  const leaves = experience_ids.map(hashExperienceId).sort();
+  const idx = leaves.indexOf(leafTarget);
+  if (idx < 0) {
+    throw new Error(
+      `buildInclusionProof: target leaf not found among ${leaves.length} hashed experience ids`
+    );
+  }
+
+  const path = collectAuditPath(leaves, idx);
+  return {
+    hashed_experience_id: leafTarget,
+    merkle_path: path.map(multihashFromDigest),
+  };
+}
+
+/**
+ * Verify an inclusion proof against `root`. Stateless and position-less:
+ * sorted-pair inner hashing means the proof reconstructs the root without
+ * any leaf-index argument (see module-top design notes).
+ *
+ * Returns false on any structural error — invalid multihash, non-base58btc
+ * input, wrong digest length. Never throws on bad data; that lets a
+ * receiver safely call this on adversarial peer input.
+ */
+export function verifyInclusionProof(
+  root: string,
+  hashed_experience_id: string,
+  merkle_path: string[]
+): boolean {
+  try {
+    const rootDigest = digestFromMultihash(root);
+    let h = sha256(Buffer.concat([LEAF_PREFIX, base58btcDecode(hashed_experience_id)]));
+    for (const sib of merkle_path) {
+      const sibDigest = digestFromMultihash(sib);
+      h = innerHash(h, sibDigest);
+    }
+    return h.equals(rootDigest);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal tree builder + audit-path collector
+// ---------------------------------------------------------------------------
+
+function sha256(data: Buffer): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+function leafDigest(leafMultihashB58: string): Buffer {
+  // Leaf hash domain-separation byte 0x00 prefixed to the FULL multihash
+  // bytes (header + digest). Per §3.7.1 the leaf hash is over the
+  // hashed_experience_id, which is the multihash form on the wire.
+  return sha256(Buffer.concat([LEAF_PREFIX, base58btcDecode(leafMultihashB58)]));
+}
+
+function innerHash(left: Buffer, right: Buffer): Buffer {
+  // Sorted-pair: see module-top design note. Equivalent to RFC 6962
+  // H(0x01 || L || R) when leaves are pre-sorted at the bottom level
+  // and we propagate that order up by always taking min/max at each
+  // pairing.
+  const [a, b] = Buffer.compare(left, right) <= 0 ? [left, right] : [right, left];
+  return sha256(Buffer.concat([INNER_PREFIX, a, b]));
+}
+
+function computeRoot(sortedLeaves: string[]): string {
+  let layer: Buffer[] = sortedLeaves.map(leafDigest);
+  while (layer.length > 1) {
+    const next: Buffer[] = [];
+    for (let i = 0; i < layer.length; i += 2) {
+      const left = layer[i];
+      // Bitcoin convention: trailing odd leaf is duplicated.
+      const right = i + 1 < layer.length ? layer[i + 1] : layer[i];
+      next.push(innerHash(left, right));
+    }
+    layer = next;
+  }
+  return multihashFromDigest(layer[0]);
+}
+
+function collectAuditPath(sortedLeaves: string[], targetIdx: number): Buffer[] {
+  const path: Buffer[] = [];
+  let layer: Buffer[] = sortedLeaves.map(leafDigest);
+  let cursor = targetIdx;
+  while (layer.length > 1) {
+    const sibIdx = cursor % 2 === 0 ? cursor + 1 : cursor - 1;
+    // Odd-leaf duplication: when our level has an odd count and we are
+    // the last node, our "sibling" is ourselves.
+    const sib = sibIdx < layer.length ? layer[sibIdx] : layer[cursor];
+    path.push(sib);
+    const next: Buffer[] = [];
+    for (let i = 0; i < layer.length; i += 2) {
+      const left = layer[i];
+      const right = i + 1 < layer.length ? layer[i + 1] : layer[i];
+      next.push(innerHash(left, right));
+    }
+    layer = next;
+    cursor = Math.floor(cursor / 2);
+  }
+  return path;
+}
+
+function looksLikeMultihashLeaf(s: string): boolean {
+  // sha2-256 multihash in base58btc is a deterministic 46-char Qm... string.
+  return s.length === 46 && s.startsWith("Qm");
+}
+
+// ---------------------------------------------------------------------------
+// Test-only exports — stable surface for the unit suite to recompute
+// hashes independently. Not part of the public swarm API.
+// ---------------------------------------------------------------------------
+
+export const __internal = {
+  sha256,
+  leafDigest,
+  innerHash,
+  multihashFromDigest,
+  digestFromMultihash,
+  base58btcDecode,
+  LEAF_PREFIX,
+  INNER_PREFIX,
+};


### PR DESCRIPTION
## Summary

- New pure module `mcp-server/src/services/evidence-merkle.ts` implementing the v1.1 `Lesson.evidence_root` commitment per [SWARM_SPEC §3.7.1](../blob/main/docs/SWARM_SPEC.md#371-evidence-merkle-tree).
- 18 new unit tests in `mcp-server/src/__tests__/evidence-merkle.test.ts`.
- SWARM_SPEC §9 status table: 4b → ✅ on main (`a33a5e5`), 4c → 🟡 implemented.

Closes #103.

## Design choices (documented in module-top comments)

- **Sorted-pair inner hashing.** Issue #103's API is `verifyInclusionProof(root, leaf, path) → bool` with no leaf-index parameter, so position-less verification is required. `H(0x01 || min(L,R) || max(L,R))` collapses both adjacency orderings to one hash; the collision-resistance argument is unchanged from RFC 6962 because inner-domain (`0x01`) is disjoint from leaf-domain (`0x00`). Same construction as OpenZeppelin's `MerkleProof.sol`.
- **Privacy invariant defensive guard.** Inputs that contain whitespace, structural delimiters, or are >128 chars are rejected at the boundary — fails loud on accidental misuse like passing `experience.content` instead of `experience.id`. Not a security boundary, but catches the obvious bug.
- **Reuses `base58btcEncode` from `services/node-identity.ts`** — keeps a single canonical multihash codec in the codebase.

## Acceptance (issue #103)

- [x] All four functions exported and unit-tested
- [x] Hand-recomputed root for a 4-leaf tree matches; same for 7-leaf (odd-level duplication path)
- [x] Round-trip: build → proof → verify holds for every leaf (sizes {1,2,3,4,5,7,8})
- [x] No raw experience content can leak through the API surface (privacy-invariant test)

## Test plan

- [x] `cd mcp-server && npm test` → 401 → **419 passing**, 0 failing
- [x] Tampered-path / wrong-root / malformed-multihash all return `false` instead of throwing
- [x] Reverse-order input produces the same root (leaves are pre-sorted)

## Out of scope for 4c (deferred to later sub-phases)

- Wiring the builder into the Lesson signing path → **4d** (#104) / **4e** (#105)
- Caching the root across `useful_count` increments — noted as a perf TODO
- The `/swarm/lessons/{id}/proof` HTTP endpoint → **4e** (#105)

🤖 Filed by autonomous tick 2026-04-30 per RFC #100 acceptance.

Generated with [Claude Code](https://claude.com/claude-code)