### PR TITLE
feat(swarm): prev_lesson_hash chain table — sub-phase 4d (#104)

### DIFF
--- a/mcp-server/src/__tests__/migration-074-lesson-chain.test.ts
+++ b/mcp-server/src/__tests__/migration-074-lesson-chain.test.ts
@@ -1,0 +1,202 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 074 — lesson_chain (closes #104, sub-phase 4d)
+//
+// The chain is the substrate §5 rule 19 (broken commitment chain) leans
+// on. Without these structural pins the table can silently regress into
+// shapes that *look* like a chain but no longer enforce one:
+//
+//   1. The append-only invariant has to be SQL-side, not application-trust.
+//      A producer flow that's "carefully not running UPDATE" is one fat
+//      finger away from rewriting history. Trigger-enforced is the floor.
+//   2. The prev_lesson_hash IS NULL ↔ sequence_number = 0 biconditional
+//      is what stops a producer from accidentally publishing lesson #2
+//      with prev=null (silent fork). A loose CHECK (only one direction)
+//      would let one of the two anomalies slip past.
+//   3. UNIQUE (sequence_number) protects the chain from a parallel
+//      double-insert during the read-build-sign-insert producer flow.
+//
+// Contract-test pattern mirrors migration-070..073: the autonomy loop
+// cannot execute migrations (Reed runs them by hand after merge), so
+// we pin shape at the SQL-text level. Stripping comments before keyword
+// matching prevents an explanatory phrase like "no DROP" from satisfying
+// a structural assertion below.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/074_lesson_chain.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) Table shape — every column the issue scope pins
+// ---------------------------------------------------------------------------
+
+test("lesson_chain table is created with the documented column set", () => {
+  // The issue body fixes the column list verbatim — pinning the CREATE
+  // TABLE here means a refactor that drops or renames any column trips
+  // the test BEFORE it reaches a fresh-DB run that would silently
+  // regress the chain semantics.
+  assert.match(SQL, /create table if not exists lesson_chain\b/);
+  assert.match(SQL, /lesson_id\s+uuid\s+primary key/);
+  assert.match(SQL, /signed_at\s+timestamptz\s+not null/);
+  assert.match(SQL, /lesson_hash\s+text\s+not null\s+unique/);
+  assert.match(SQL, /prev_lesson_hash\s+text\b/);
+  assert.match(SQL, /sequence_number\s+int\s+not null/);
+  assert.match(SQL, /created_at\s+timestamptz\s+not null\s+default now\(\)/);
+});
+
+test("sequence_number is non-negative", () => {
+  // CHECK (sequence_number >= 0) — without it, a buggy COALESCE could
+  // emit a negative seed and the UNIQUE constraint would happily accept
+  // it, breaking compute_next_sequence_number's monotone contract.
+  assert.match(SQL, /check\s*\(\s*sequence_number\s*>=\s*0\s*\)/);
+});
+
+test("prev_lesson_hash IS NULL iff sequence_number = 0 (biconditional CHECK)", () => {
+  // §3.7.2: the very first lesson a node publishes has prev_lesson_hash
+  // = null; every subsequent lesson MUST chain. Encoding the
+  // biconditional as a database CHECK turns the "first-lesson" semantics
+  // into an invariant — producer-side bugs that would otherwise quietly
+  // fork the chain (lesson #2 with prev=null, or lesson #1 with a
+  // non-null prev) are rejected at INSERT time.
+  assert.match(
+    SQL,
+    /check\s*\(\s*\(\s*sequence_number\s*=\s*0\s*\)\s*=\s*\(\s*prev_lesson_hash\s+is\s+null\s*\)\s*\)/,
+  );
+});
+
+test("sequence_number is UNIQUE (parallel-double-insert protection)", () => {
+  // The producer flow is read-build-sign-insert. Two flows racing on
+  // step 1 will compute the same `next` value, sign two distinct
+  // lessons against the same prev_hash, then both INSERT. UNIQUE
+  // (sequence_number) makes the second INSERT fail loudly instead of
+  // forking the chain.
+  assert.match(SQL, /unique\s*\(\s*sequence_number\s*\)/);
+});
+
+test("lesson_chain has the signed_at index for replay-by-time", () => {
+  // §3.7.2: receivers MAY reconstruct a producer's chain by ORDER BY
+  // signed_at ASC. The producer's own table benefits from the same
+  // index for any local ops tooling.
+  assert.match(
+    SQL,
+    /create index if not exists lesson_chain_signed_at_idx\s+on lesson_chain\s*\(\s*signed_at\s*\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) Append-only enforcement — UPDATE and DELETE both raise
+// ---------------------------------------------------------------------------
+
+test("append-only trigger function raises on any mutation", () => {
+  // Defense in depth: even an operator with table-owner privileges
+  // shouldn't be able to silently rewrite chain history. A trigger that
+  // RAISES applies to every role that doesn't bypass triggers (none
+  // should — the autonomy loop runs as service_role, which honors
+  // triggers).
+  assert.match(
+    SQL,
+    /create or replace function lesson_chain_no_mutate\(\)\s+returns trigger/,
+  );
+  assert.match(SQL, /raise exception\s+'lesson_chain is append-only/);
+});
+
+test("UPDATE on lesson_chain is blocked by trigger", () => {
+  // The trigger has to be BEFORE UPDATE so the no-op AFTER variant
+  // can't accidentally let the row through with a different value.
+  assert.match(SQL, /drop trigger if exists lesson_chain_no_update on lesson_chain/);
+  assert.match(
+    SQL,
+    /create trigger lesson_chain_no_update\s+before update on lesson_chain\s+for each row execute function lesson_chain_no_mutate\(\)/,
+  );
+});
+
+test("DELETE on lesson_chain is blocked by trigger", () => {
+  // Same shape as UPDATE — without DELETE protection the chain can be
+  // rewritten by deleting + re-inserting the tip with a fresh hash.
+  assert.match(SQL, /drop trigger if exists lesson_chain_no_delete on lesson_chain/);
+  assert.match(
+    SQL,
+    /create trigger lesson_chain_no_delete\s+before delete on lesson_chain\s+for each row execute function lesson_chain_no_mutate\(\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) Producer-side read RPCs
+// ---------------------------------------------------------------------------
+
+test("compute_next_prev_lesson_hash returns the chain tip (or NULL)", () => {
+  // Pin the body — a refactor that swaps ORDER BY sequence_number for
+  // ORDER BY signed_at would silently break the chain on backdated
+  // signed_at clocks. sequence_number is the load-bearing ordering.
+  assert.match(
+    SQL,
+    /create or replace function compute_next_prev_lesson_hash\(\)\s+returns text/,
+  );
+  assert.match(
+    SQL,
+    /select lesson_hash\s+from lesson_chain\s+order by sequence_number desc\s+limit 1/,
+  );
+});
+
+test("compute_next_prev_lesson_hash is GRANTed to anon + service_role", () => {
+  // Same GRANT discipline as migrations 070-073: without an explicit
+  // GRANT every authenticated client (including the autonomy loop)
+  // breaks at runtime when it tries to call the RPC.
+  assert.match(
+    SQL,
+    /grant execute on function compute_next_prev_lesson_hash\(\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+test("compute_next_sequence_number returns 0 on empty chain, monotone otherwise", () => {
+  // COALESCE(MAX(sequence_number) + 1, 0) — pinning the literal so a
+  // refactor that switches to COUNT(*) (off-by-one on partial deletes,
+  // though deletes are forbidden, so this would only bite in restored
+  // backups) is caught here.
+  assert.match(
+    SQL,
+    /create or replace function compute_next_sequence_number\(\)\s+returns int/,
+  );
+  assert.match(
+    SQL,
+    /select coalesce\s*\(\s*max\s*\(\s*sequence_number\s*\)\s*\+\s*1\s*,\s*0\s*\)\s+from lesson_chain/,
+  );
+});
+
+test("compute_next_sequence_number is GRANTed to anon + service_role", () => {
+  assert.match(
+    SQL,
+    /grant execute on function compute_next_sequence_number\(\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) Migration discipline — no destructive ops on prior schema
+// ---------------------------------------------------------------------------
+
+test("migration 074 does not DROP swarm_lessons or any prior table", () => {
+  // 4d adds a sibling table; it must not touch swarm_lessons (071) or
+  // any other prior structure. A silent DROP TABLE in a fresh-DB
+  // migration would still apply cleanly but blow away production data
+  // on an upgrade run.
+  assert.doesNotMatch(SQL, /drop table\s+(?:if exists\s+)?swarm_lessons\b/);
+  assert.doesNotMatch(SQL, /drop table\s+(?:if exists\s+)?lessons\b/);
+  assert.doesNotMatch(SQL, /drop table\s+(?:if exists\s+)?nodes\b/);
+});

--- a/mcp-server/src/__tests__/wire-validator.test.ts
+++ b/mcp-server/src/__tests__/wire-validator.test.ts
@@ -860,3 +860,121 @@ test("validateLessonProof rule 18: wrong evidence_root is rejected", async () =>
   });
   expectErr(result, 18);
 });
+
+// ---------------------------------------------------------------------------
+// Rule 19 — broken commitment chain (SWARM_SPEC §3.7.2 / §5 rule 19)
+//
+// Rule 19 is side-channel: it only fires when the receiver has already
+// cached L_{n-1} for the origin. The validator stays pure and never
+// touches the DB — the cache lookup + multihash recompute live in the
+// injected `getExpectedPrevLessonHashForOrigin` callback.
+// ---------------------------------------------------------------------------
+
+function buildValidV11Lesson(
+  producer: Identity,
+  prevLessonHash: string | null,
+): Record<string, unknown> {
+  const unsigned = {
+    id: "11111111-2222-3333-4444-666666666666",
+    content: "v1.1 lesson with PoK envelope.",
+    embedding: full768Embedding(3),
+    synthesized_from_cluster_size: 4,
+    origin_node_id: producer.nodeId,
+    signed_at: "2026-04-28T11:00:00.000Z",
+    created_at: "2026-04-27T10:00:00.000Z",
+    spec_version: WIRE_SPEC_VERSION,
+    // Five v1.1 fields — present in the signed bytes per §3.7.
+    evidence_root: "QmFakeRootForTest",
+    evidence_count: 4,
+    prev_lesson_hash: prevLessonHash,
+    maturity_age_days: 1,
+    useful_count: 0,
+  };
+  return attachSignature(unsigned, producer.pem);
+}
+
+test("rule 19: prev_lesson_hash matches cached tip → accepted", async () => {
+  const producer = freshIdentity();
+  const expectedTip = "QmExpectedPrevLessonHash";
+  const record = buildValidV11Lesson(producer, expectedTip);
+  const result = await validateWireRecord(record, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]]),
+    ),
+    getExpectedPrevLessonHashForOrigin: () => expectedTip,
+  });
+  assert.equal(result.ok, true);
+});
+
+test("rule 19: prev_lesson_hash mismatch against cached tip is rejected", async () => {
+  const producer = freshIdentity();
+  const record = buildValidV11Lesson(producer, "QmActualPrev");
+  const result = await validateWireRecord(record, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]]),
+    ),
+    // Receiver's cache says the previous tip should have been DIFFERENT
+    // — that's the history-rewrite signal §3.7.2 / §10.2 calls out.
+    getExpectedPrevLessonHashForOrigin: () => "QmDifferentExpectedPrev",
+  });
+  expectErr(result, 19);
+});
+
+test("rule 19: empty receiver cache (callback returns null) skips the check", async () => {
+  // Fresh-peer regime — receiver has no L_{n-1} for this origin, so
+  // there's nothing to chain against. Spec §3.7.2 explicitly allows
+  // this: receivers MAY (but are not required to) reconstruct chains.
+  const producer = freshIdentity();
+  const record = buildValidV11Lesson(producer, "QmAnyPrevTheProducerClaims");
+  const result = await validateWireRecord(record, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]]),
+    ),
+    getExpectedPrevLessonHashForOrigin: () => null,
+  });
+  assert.equal(result.ok, true);
+});
+
+test("rule 19: callback omitted entirely → no enforcement (back-compat)", async () => {
+  // Existing v1.0 callers that have not adopted the new opts field MUST
+  // keep validating without rule-19 checks. This is the back-compat
+  // contract for the validator's optional surface.
+  const producer = freshIdentity();
+  const record = buildValidV11Lesson(producer, "QmWhatever");
+  const result = await validateWireRecord(record, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]]),
+    ),
+  });
+  assert.equal(result.ok, true);
+});
+
+test("rule 19: v1.0 producer escaping the chain (no prev_lesson_hash field) while cache has a tip is rejected", async () => {
+  // A producer that drops back to spec_version="1.0" to escape the chain
+  // — v1.0 records legitimately lack prev_lesson_hash (rule 20 third leg
+  // even forbids them from carrying it), so the rule-2 presence check
+  // does NOT fire. But if the receiver still has L_{n-1} cached for this
+  // origin from earlier v1.1 lessons, the missing field is itself the
+  // chain break: undefined !== expected → rule 19. Validator code:
+  // "the producer cannot escape the chain by claiming to be on the older
+  // spec version" (wire-validator.ts §rule 19).
+  const producer = freshIdentity();
+  const v10 = buildValidV10Lesson(producer);
+  const result = await validateWireRecord(v10, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]]),
+    ),
+    getExpectedPrevLessonHashForOrigin: () => "QmExpectedTip",
+  });
+  expectErr(result, 19);
+});

--- a/mcp-server/src/services/wire-validator.ts
+++ b/mcp-server/src/services/wire-validator.ts
@@ -46,6 +46,26 @@ export interface ValidateOptions {
    * is not consulted for that kind.
    */
   getPubkeyForNode: (nodeId: string) => Uint8Array | null;
+  /**
+   * Optional. Lookup the lesson_hash this receiver expects to see in
+   * `prev_lesson_hash` for the next Lesson from `originId`, given the
+   * receiver's local cache of that origin's chain. Returns null when the
+   * receiver holds no prior lesson from this origin (the fresh-peer
+   * case — rule 19 cannot fire because there is no L_{n-1} to chain
+   * against).
+   *
+   * Typical implementation: query the most recent cached lesson for
+   * `originId` from `swarm_lessons` (migration 071) and recompute
+   * `multihash(sha2-256, JCS(signed_lesson))`. The recompute MUST run
+   * inside the callback — the validator stays pure and never reads the
+   * DB. SWARM_SPEC §5 rule 19, §3.7.2.
+   *
+   * Omit (or return null) and rule 19 is silently skipped — that's the
+   * v1.0 / fresh-peer regime. Rule 19 is intentionally side-channel
+   * because the prev-hash invariant only holds when the receiver has
+   * actually cached the predecessor.
+   */
+  getExpectedPrevLessonHashForOrigin?: (originId: string) => string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -487,6 +507,34 @@ export async function validateWireRecord(
   const sig = record.signature as string;
   if (!verify(record, sig, verifierPubkey)) {
     return fail(5, `Ed25519 signature verification failed`);
+  }
+
+  // Rule 19: broken commitment chain. SWARM_SPEC §3.7.2 / §5 rule 19.
+  // Only meaningful for Lesson, and only when the receiver actually has
+  // L_{n-1} cached (callback returns non-null). The callback is the
+  // receiver's responsibility — typically it queries the most recent
+  // cached lesson for `origin_node_id` from swarm_lessons and recomputes
+  // multihash(JCS(L_{n-1})). A mismatch is treated as a history-rewrite
+  // signal — the issue body and §10.2 mark this as a single-strike
+  // quarantine trigger, but quarantine bookkeeping is the receiver's
+  // job (4f) — here we only emit the rule-19 rejection.
+  if (kind === "lesson" && opts.getExpectedPrevLessonHashForOrigin) {
+    const originId = record.origin_node_id as string;
+    const expected = opts.getExpectedPrevLessonHashForOrigin(originId);
+    if (expected !== null && expected !== undefined) {
+      // `prev_lesson_hash` is a v1.1+ Lesson field. A v1.0 record that
+      // omits it AND chains against a cached predecessor is also a
+      // chain break (the producer cannot escape the chain by claiming
+      // to be on the older spec version). `record.prev_lesson_hash`
+      // being undefined OR not equal to expected both fail.
+      const actual = record.prev_lesson_hash;
+      if (actual !== expected) {
+        return fail(
+          19,
+          `prev_lesson_hash ${JSON.stringify(actual)} does not match cached chain tip ${expected} for origin ${originId}`,
+        );
+      }
+    }
   }
 
   return { ok: true };

--- a/supabase/migrations/074_lesson_chain.sql
+++ b/supabase/migrations/074_lesson_chain.sql
@@ -1,0 +1,122 @@
+-- 074_lesson_chain.sql — Swarm Phase 4d (issue #104)
+--
+-- Per-node commitment chain for SELF-published Lessons. Spec §3.7.2.
+-- The integrity guarantee §5 rule 19 leans on lives in this table:
+-- a strictly-ordered, append-only sequence of lesson hashes whose
+-- prev_lesson_hash links back to the previous tip. Rewriting any past
+-- entry invalidates every subsequent hash this node has ever signed.
+--
+-- Append-only is enforced by trigger (UPDATE / DELETE raise) — defense
+-- in depth so an operator with table-owner privileges still can't
+-- silently rewrite chain history. RLS would also work but a trigger is
+-- simpler to reason about and applies to every role that doesn't
+-- bypass triggers (none should — the autonomy loop runs as service_role
+-- which honors triggers).
+--
+-- Scope discipline:
+--   * This table holds OUR locally-published lessons only. Remote-chain
+--     caching for §5 rule 19 enforcement uses `swarm_lessons` (migration
+--     071) as the source of truth — no per-origin dimension here.
+--   * `sequence_number` is monotone-from-COALESCE (not SERIAL) so a
+--     restore-from-backup keeps the chain intact: SERIAL sequences are
+--     not part of pg_dump --data-only output and would diverge from the
+--     backed-up sequence_numbers, breaking every prev_lesson_hash linkage.
+--
+-- Producer flow (TS-side, lands in a later phase — this migration only
+-- supplies the SQL substrate):
+--   1. prev := SELECT compute_next_prev_lesson_hash()    (NULL for first ever)
+--   2. seq  := SELECT compute_next_sequence_number()      (0 for first ever)
+--   3. build the lesson body with prev_lesson_hash = prev, sign
+--   4. lesson_hash := multihash(sha2-256, JCS(signed_lesson))
+--   5. INSERT INTO lesson_chain (lesson_id, signed_at, lesson_hash,
+--                                prev_lesson_hash, sequence_number)
+--                         VALUES (id, signed_at, hash, prev, seq);
+-- Race protection: UNIQUE (sequence_number) makes a parallel double-insert
+-- fail loudly rather than corrupting the chain.
+--
+-- Receiver-side rule 19 (TS-side, this migration ships nothing for it):
+-- the wire-validator uses an injected `getExpectedPrevLessonHashForOrigin`
+-- callback. The callback is the receiver's responsibility — typical
+-- implementation queries `swarm_lessons WHERE origin_node_id = ?`
+-- ORDER BY signed_at DESC LIMIT 1 and recomputes the multihash. This
+-- migration intentionally does NOT cache remote chains: receivers MAY
+-- (per §3.7.2) reconstruct producer chains from `swarm_lessons` rather
+-- than maintaining a parallel cache table.
+--
+-- Reed runs the migration manually after merge — the autonomy loop is
+-- forbidden from executing it (migration discipline from 070-073).
+
+-- ---------------------------------------------------------------------------
+-- (1) lesson_chain table
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lesson_chain (
+  lesson_id        UUID        PRIMARY KEY,
+  signed_at        TIMESTAMPTZ NOT NULL,
+  lesson_hash      TEXT        NOT NULL UNIQUE,
+  prev_lesson_hash TEXT,
+  sequence_number  INT         NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (sequence_number >= 0),
+  -- §3.7.2: prev_lesson_hash IS NULL iff this is the very first lesson.
+  -- Encoding the biconditional as a CHECK turns "first-lesson" semantics
+  -- into a database invariant — a producer that forgets to set
+  -- prev_lesson_hash on lesson #2 cannot quietly publish a broken chain.
+  CHECK ((sequence_number = 0) = (prev_lesson_hash IS NULL)),
+  UNIQUE (sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS lesson_chain_signed_at_idx
+  ON lesson_chain (signed_at);
+
+COMMENT ON TABLE lesson_chain IS
+  'Mycelium swarm: per-node commitment chain over self-published lessons. SWARM_SPEC §3.7.2. Append-only by trigger; UPDATE and DELETE raise.';
+
+-- ---------------------------------------------------------------------------
+-- (2) Append-only enforcement
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION lesson_chain_no_mutate() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION
+    'lesson_chain is append-only — rows cannot be % (SWARM_SPEC §3.7.2)',
+    TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS lesson_chain_no_update ON lesson_chain;
+CREATE TRIGGER lesson_chain_no_update
+  BEFORE UPDATE ON lesson_chain
+  FOR EACH ROW EXECUTE FUNCTION lesson_chain_no_mutate();
+
+DROP TRIGGER IF EXISTS lesson_chain_no_delete ON lesson_chain;
+CREATE TRIGGER lesson_chain_no_delete
+  BEFORE DELETE ON lesson_chain
+  FOR EACH ROW EXECUTE FUNCTION lesson_chain_no_mutate();
+
+-- ---------------------------------------------------------------------------
+-- (3) Producer-side read helpers
+--
+-- compute_next_prev_lesson_hash() returns the tip of the current chain.
+-- The producer feeds this into the NEXT lesson's prev_lesson_hash field
+-- BEFORE signing — the field has to be inside the canonical signed bytes
+-- per §3.7.2. NULL when the chain is empty (the very first lesson this
+-- node ever publishes has prev_lesson_hash = null).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION compute_next_prev_lesson_hash() RETURNS TEXT AS $$
+  SELECT lesson_hash
+  FROM lesson_chain
+  ORDER BY sequence_number DESC
+  LIMIT 1;
+$$ LANGUAGE sql STABLE;
+
+GRANT EXECUTE ON FUNCTION compute_next_prev_lesson_hash() TO anon, service_role;
+
+-- compute_next_sequence_number() — companion helper. Returns 0 for the
+-- first-ever lesson, monotone-increasing thereafter. Producer calls this
+-- at INSERT time. Two-call convention (read prev_hash + read seq) is
+-- intentional: the producer needs the prev_hash BEFORE signing, and the
+-- sequence_number AFTER signing (it's not part of the signed bytes).
+CREATE OR REPLACE FUNCTION compute_next_sequence_number() RETURNS INT AS $$
+  SELECT COALESCE(MAX(sequence_number) + 1, 0) FROM lesson_chain;
+$$ LANGUAGE sql STABLE;
+
+GRANT EXECUTE ON FUNCTION compute_next_sequence_number() TO anon, service_role;


### PR DESCRIPTION
## Summary

- Migration 074 — append-only `lesson_chain` table for self-published lessons (SWARM_SPEC §3.7.2).
- Producer-side helpers `compute_next_prev_lesson_hash()` + `compute_next_sequence_number()` (GRANTed per 070-073 discipline).
- Wire-validator §5 rule 19 with an injected `getExpectedPrevLessonHashForOrigin` callback so the validator stays pure and the receiver does its own cache lookup + multihash recompute.
- 13 SQL contract pins + 5 rule-19 validator tests. 419/419 green.

## Why a separate chain table (and not a column on swarm_lessons)?

`swarm_lessons` (071) holds remote-cached lessons; `lesson_chain` holds *our* commitment chain. Mixing the two would force a per-origin dimension on `sequence_number` that's only meaningful for self. Receivers that want to reconstruct a producer's chain do it from `swarm_lessons` ordered by `signed_at ASC` per §3.7.2 — no parallel cache table required, and the validator callback keeps that flexibility.

## Why `monotone-from-COALESCE` and not `SERIAL`?

`SERIAL` sequences are **not** included in `pg_dump --data-only` output. After a restore-from-backup, a `SERIAL`-based `sequence_number` would diverge from the backed-up values — every `prev_lesson_hash` linkage would still be valid against the restored hashes, but new lesson #N+1 would get the wrong sequence and the UNIQUE constraint would either crash or silently re-use a sequence number. `COALESCE(MAX(...) + 1, 0)` recovers cleanly.

## Why a trigger (and not RLS) for append-only?

Trigger reads cleaner (no role policy negotiation), applies to every role that doesn't bypass triggers (none should — the autonomy loop runs as `service_role` which honors them), and the `RAISE EXCEPTION` message points the operator straight at the spec section. RLS would also work; trigger is the simpler floor.

## Out of scope for 4d

- Producer-side TS code that *calls* the RPCs and inserts into `lesson_chain` — no v1.1 publishing flow exists yet. The SQL substrate ships now; the producer wires up when the publishing path lands. The acceptance criterion *"Producer never publishes a v1.1 lesson without a chain entry"* is structurally satisfied (the only path to insert a chain entry IS the producer flow; there is no other writer).
- Quarantine bookkeeping for rule 19 hits — 4f's territory (#107).
- Remote-chain cache table — receivers reconstruct from `swarm_lessons` per §3.7.2.

## Test plan

- [x] `npm run build` clean (mcp-server)
- [x] `npm test` — 419 / 419 pass
- [x] 13 new SQL contract pins on migration 074 (table shape, biconditional CHECK, UNIQUE, append-only triggers UPDATE+DELETE, RPC bodies + GRANTs, no-DROP guard)
- [x] 5 new rule-19 validator tests (match, mismatch, null cache, omitted callback, stripped prev-hash)
- [ ] Reed runs `bash scripts/migrate.sh` after merge

Closes part of #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)