### PR TITLE
feat(swarm): TrustEdge dynamics + quarantine substrate — sub-phase 4f (#107)

### DIFF
--- a/mcp-server/src/__tests__/migration-075-trust-edge-dynamics.test.ts
+++ b/mcp-server/src/__tests__/migration-075-trust-edge-dynamics.test.ts
@@ -1,0 +1,462 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 075 — TrustEdge dynamics + quarantine state machine (#107, 4f)
+//
+// Same defensive contract-pin pattern as migration-070 / -071 / -072 / -073 /
+// -074: read the SQL, normalise it, regex-pin every load-bearing structural
+// invariant. The autonomy loop cannot execute migrations (Reed runs them by
+// hand after merge), so contract tests live at the SQL-text level. Tight
+// pins here are deliberately worth their drift cost: reputation arithmetic
+// and quarantine semantics are the swarm's anti-adversarial substrate.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/075_trust_edge_dynamics.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so any phrasing
+// inside a comment cannot accidentally satisfy a structural assertion.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent or
+// keyword-case drift without weakening the structural contracts.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) `nodes` is extended with the §10.1 + §10.2 bookkeeping columns
+// ---------------------------------------------------------------------------
+
+test("nodes gets successful_inclusion_proof_rate_30d (REAL, nullable)", () => {
+  // §10.1 input signal. Nullable so a fresh peer with no proof history
+  // doesn't violate NOT NULL on insert; the formula collapses NULL → 1.0
+  // (no decay applied).
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists successful_inclusion_proof_rate_30d\s+real\s*;/,
+  );
+});
+
+test("nodes gets avg_local_useful_count (REAL, nullable)", () => {
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists avg_local_useful_count\s+real\s*;/,
+  );
+});
+
+test("nodes gets age_factor (REAL, NOT NULL, default 1.0)", () => {
+  // Default 1.0 means "fully aged-in" so existing rows aren't penalised
+  // until the REM cycle computes a real value.
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists age_factor\s+real\s+not null\s+default\s+1\.0\s*;/,
+  );
+});
+
+test("nodes gets quarantined_until (TIMESTAMPTZ, nullable)", () => {
+  // NULL == not quarantined. is_quarantined() depends on this nullability
+  // semantic — a NOT NULL default would force every row into "quarantined
+  // until 1970-01-01" land and break the polling-side filter.
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists quarantined_until\s+timestamptz\s*;/,
+  );
+});
+
+test("nodes gets last_decay_at (TIMESTAMPTZ, nullable)", () => {
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists last_decay_at\s+timestamptz\s*;/,
+  );
+});
+
+test("nodes gets decay_reason (TEXT, nullable)", () => {
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists decay_reason\s+text\s*;/,
+  );
+});
+
+test("nodes gets consecutive_rejections (INT, NOT NULL, default 0)", () => {
+  // §10.2 N-counter. Default 0 + NOT NULL is the only sane invariant —
+  // a NULL counter in the rejection state machine would be a foot-gun
+  // (NULL > 5 is NULL, the threshold check would silently fail open).
+  assert.match(
+    SQL,
+    /alter table nodes add column if not exists consecutive_rejections\s+int\s+not null\s+default\s+0\s*;/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) Range constraints — proof rate ∈ [0, 1], age_factor ∈ [0, 1], counts ≥ 0
+// ---------------------------------------------------------------------------
+
+test("proof rate is constrained to [0, 1] when not NULL", () => {
+  // The formula multiplies by this factor; values outside [0, 1] would
+  // either overflow the [0, 1] clamp on the upper side (no harm) or push
+  // the product negative on the lower side (the GREATEST clamps it back
+  // to 0, but a negative input is a bug not a normal state). Pin the
+  // CHECK so a future migration can't drop it silently.
+  assert.match(
+    SQL,
+    /constraint nodes_proof_rate_range\s+check\s*\(\s*successful_inclusion_proof_rate_30d is null\s+or\s*\(\s*successful_inclusion_proof_rate_30d\s*>=\s*0\s+and\s+successful_inclusion_proof_rate_30d\s*<=\s*1\s*\)\s*\)/,
+  );
+});
+
+test("age_factor is constrained to [0, 1]", () => {
+  assert.match(
+    SQL,
+    /constraint nodes_age_factor_range\s+check\s*\(\s*age_factor\s*>=\s*0\s+and\s+age_factor\s*<=\s*1\s*\)/,
+  );
+});
+
+test("avg_local_useful_count is constrained to >= 0", () => {
+  assert.match(
+    SQL,
+    /constraint nodes_useful_count_nonneg\s+check\s*\(\s*avg_local_useful_count is null\s+or\s+avg_local_useful_count\s*>=\s*0\s*\)/,
+  );
+});
+
+test("consecutive_rejections is constrained to >= 0", () => {
+  assert.match(
+    SQL,
+    /constraint nodes_consecutive_rejections_nonneg\s+check\s*\(\s*consecutive_rejections\s*>=\s*0\s*\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) trust_edge_log — append-only audit table
+// ---------------------------------------------------------------------------
+
+test("trust_edge_log table exists with the audit columns", () => {
+  assert.match(
+    SQL,
+    /create table if not exists trust_edge_log[\s\S]*?node_id\s+text\s+not null references nodes\s*\(\s*node_id\s*\)/,
+  );
+  assert.match(SQL, /weight_before\s+real\s+not null/);
+  assert.match(SQL, /weight_after\s+real\s+not null/);
+  assert.match(SQL, /reason\s+text\s+not null/);
+  assert.match(SQL, /at\s+timestamptz\s+not null\s+default now\(\)/);
+});
+
+test("trust_edge_log weight_before / weight_after are clamped to [0, 1]", () => {
+  // The audit log mirrors the trust_weight column's [0, 1] domain; a row
+  // with a value outside the domain would either be a producer bug or a
+  // direct INSERT bypass and is worth rejecting at the DB level.
+  assert.match(
+    SQL,
+    /check\s*\(\s*weight_before\s*>=\s*0\s+and\s+weight_before\s*<=\s*1\s*\)/,
+  );
+  assert.match(
+    SQL,
+    /check\s*\(\s*weight_after\s*>=\s*0\s+and\s+weight_after\s*<=\s*1\s*\)/,
+  );
+});
+
+test("trust_edge_log has a (node_id, at DESC) index for operator queries", () => {
+  assert.match(
+    SQL,
+    /create index if not exists trust_edge_log_node_at_idx\s+on trust_edge_log\s*\(\s*node_id\s*,\s*at desc\s*\)/,
+  );
+});
+
+test("trust_edge_log is append-only (UPDATE and DELETE triggers)", () => {
+  // Defense in depth — even an operator with table-owner privileges
+  // shouldn't be able to silently rewrite reputation history. Same
+  // pattern as lesson_chain (074).
+  assert.match(SQL, /create or replace function trust_edge_log_no_mutate\s*\(\s*\)\s+returns trigger/);
+  assert.match(SQL, /raise exception\s+'trust_edge_log is append-only/);
+  assert.match(
+    SQL,
+    /create trigger trust_edge_log_no_update\s+before update on trust_edge_log/,
+  );
+  assert.match(
+    SQL,
+    /create trigger trust_edge_log_no_delete\s+before delete on trust_edge_log/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) compute_trust_weight — the §10.1 formula, pure SQL, IMMUTABLE
+// ---------------------------------------------------------------------------
+
+test("compute_trust_weight has the documented 5-arg signature", () => {
+  // Signature drift would silently break the REM-cycle caller. Pin the
+  // parameter ORDER explicitly because the GRANT EXECUTE below references
+  // the positional signature.
+  assert.match(
+    SQL,
+    /create or replace function compute_trust_weight\s*\(\s*base_weight\s+real\s*,\s*proof_rate_30d\s+real\s*,\s*avg_useful_count\s+real\s*,\s*useful_count_threshold\s+real\s*,\s*age_factor\s+real\s*\)\s+returns real/,
+  );
+});
+
+test("compute_trust_weight is IMMUTABLE (cacheable, deterministic)", () => {
+  // Must be IMMUTABLE so the planner can fold constant calls and so the
+  // function passes contract-test assertions about determinism. Marking it
+  // STABLE or VOLATILE would silently change query plans and re-run the
+  // formula on every row when used as a generated-column expression.
+  assert.match(SQL, /language sql immutable/);
+});
+
+test("compute_trust_weight clamps the product to [0, 1]", () => {
+  // The clamp is the §10.1 "weight ∈ [0, 1]" guarantee. Without it, a
+  // base_weight of 1.0 (operator-pinned origin) combined with a proof
+  // rate near 1 and a high useful_count could produce > 1 and unbalance
+  // every downstream weighting calculation.
+  assert.match(
+    SQL,
+    /greatest\s*\(\s*0\.0::real\s*,\s*least\s*\(\s*1\.0::real\s*,/,
+  );
+});
+
+test("compute_trust_weight uses NULLIF on threshold to avoid div-by-zero", () => {
+  // useful_count_threshold = 0 is a config-time mistake but should not
+  // crash the nightly REM job. NULLIF(threshold, 0) makes the division
+  // produce NULL, which COALESCE folds to 1.0 (no decay). Surprising
+  // behaviour, but the safer of the two — pin it.
+  assert.match(SQL, /nullif\s*\(\s*useful_count_threshold\s*,\s*0\s*\)/);
+});
+
+test("compute_trust_weight has GRANT EXECUTE to anon and service_role", () => {
+  assert.match(
+    SQL,
+    /grant execute on function compute_trust_weight\s*\(\s*real\s*,\s*real\s*,\s*real\s*,\s*real\s*,\s*real\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (5) record_trust_edge_change — atomic weight update + audit log
+// ---------------------------------------------------------------------------
+
+test("record_trust_edge_change requires a non-empty reason", () => {
+  // §10.1 says weight changes MUST be recorded with a reason. A NULL or
+  // empty reason would defeat the audit surface — fail loud at the DB.
+  assert.match(
+    SQL,
+    /raise exception 'record_trust_edge_change: reason is required/,
+  );
+});
+
+test("record_trust_edge_change rejects out-of-range weights", () => {
+  assert.match(
+    SQL,
+    /raise exception 'record_trust_edge_change: weight must be in \[0, 1\], got %'/,
+  );
+});
+
+test("record_trust_edge_change short-circuits on no-op weight changes", () => {
+  // If the new weight equals the existing one, no log row is written.
+  // This keeps the audit log signal-to-noise high — only real changes
+  // appear. Pin the comparison so a future "always log" refactor can't
+  // silently flood the log.
+  assert.match(SQL, /if v_before = p_new_weight then\s+return\s*;/);
+});
+
+test("record_trust_edge_change writes the log row BEFORE updating nodes", () => {
+  // Order matters for audit invariants: if the UPDATE went first and the
+  // INSERT crashed, the audit log would lose the {before, after} pair
+  // forever. Doing INSERT first means a crash leaves the system with a
+  // log entry but no nodes update — recoverable. Pin the order.
+  assert.match(
+    SQL,
+    /insert into trust_edge_log[\s\S]*?values\s*\([\s\S]*?\)\s*;\s*update nodes/,
+  );
+});
+
+test("record_trust_edge_change updates last_decay_at, decay_reason, trust_reason", () => {
+  // All three columns get touched in the same UPDATE so the operator's
+  // "what changed and when" view is consistent.
+  assert.match(
+    SQL,
+    /update nodes\s+set\s+trust_weight\s*=\s*p_new_weight\s*,\s*trust_reason\s*=\s*p_reason\s*,\s*last_decay_at\s*=\s*now\(\)\s*,\s*decay_reason\s*=\s*p_reason/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (6) is_quarantined — single-column read used by /swarm/lessons polling
+// ---------------------------------------------------------------------------
+
+test("is_quarantined returns FALSE for unknown or non-quarantined nodes", () => {
+  // COALESCE pattern: SELECT returns NULL for unknown id, AND
+  // (NULL > NOW()) is NULL — wrap in COALESCE(..., FALSE) so callers get
+  // a definite boolean. Pin this because changing the default to TRUE
+  // would silently quarantine every unknown peer (foot-gun: silent
+  // denial of /swarm/lessons polling for fresh peers).
+  assert.match(
+    SQL,
+    /create or replace function is_quarantined\s*\(\s*p_node_id\s+text\s*\)\s+returns boolean[\s\S]*?coalesce\s*\(\s*\(\s*select quarantined_until from nodes where node_id = p_node_id\s*\)\s*>\s*now\(\)\s*,\s*false\s*\)/,
+  );
+});
+
+test("is_quarantined is STABLE (depends on now() but no writes)", () => {
+  assert.match(
+    SQL,
+    /create or replace function is_quarantined[\s\S]*?language sql stable/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (7) quarantine_origin — set §10.2 hold for K days
+// ---------------------------------------------------------------------------
+
+test("quarantine_origin rejects days <= 0", () => {
+  assert.match(
+    SQL,
+    /raise exception 'quarantine_origin: days must be > 0, got %'/,
+  );
+});
+
+test("quarantine_origin requires a non-empty reason", () => {
+  assert.match(SQL, /raise exception 'quarantine_origin: reason is required'/);
+});
+
+test("quarantine_origin sets quarantined_until = NOW() + p_days days", () => {
+  // Pin the interval-construction form — string concatenation is the
+  // only portable way to build a parametrised INTERVAL in plpgsql, but
+  // it's also a SQL-injection attractor. Cast to INT happens at call
+  // sites; the parameter is typed INT here so concat is safe.
+  assert.match(
+    SQL,
+    /quarantined_until\s*=\s*now\(\)\s*\+\s*\(\s*p_days\s*\|\|\s*' days'\s*\)::interval/,
+  );
+});
+
+test("quarantine_origin resets consecutive_rejections to 0", () => {
+  // The streak has been consumed by the quarantine. If the origin
+  // re-offends after the hold expires, the count starts fresh. Without
+  // this reset, the very next rejection (post-thaw) would fire another
+  // quarantine — the origin would be permanently locked out by a single
+  // late-arriving rejection.
+  assert.match(SQL, /consecutive_rejections\s*=\s*0/);
+});
+
+test("quarantine_origin raises on unknown node_id", () => {
+  assert.match(SQL, /raise exception 'quarantine_origin: unknown node_id %'/);
+});
+
+// ---------------------------------------------------------------------------
+// (8) record_origin_rejection — encodes the §10.2 state machine
+// ---------------------------------------------------------------------------
+
+test("record_origin_rejection has defaults N=5, K=30 per SWARM_SPEC §10.2", () => {
+  assert.match(
+    SQL,
+    /create or replace function record_origin_rejection\s*\(\s*p_node_id\s+text\s*,\s*p_rule_number\s+int\s*,\s*p_n_threshold\s+int\s+default\s+5\s*,\s*p_k_days\s+int\s+default\s+30\s*\)\s+returns boolean/,
+  );
+});
+
+test("record_origin_rejection rejects rule_number outside [1, 20]", () => {
+  // §5 has rules 1–20 in v1.1. A rule_number outside this range is a
+  // caller bug; fail loud rather than silently increment the counter.
+  assert.match(
+    SQL,
+    /raise exception 'record_origin_rejection: rule_number must be in \[1, 20\], got %'/,
+  );
+});
+
+test("rule 19 is single-strike — immediate quarantine regardless of N", () => {
+  // Per §10.2: chain rewriting is a definitionally adversarial act. The
+  // single-strike branch must short-circuit BEFORE the cumulative
+  // counter increments — pin the if-block placement.
+  assert.match(
+    SQL,
+    /if p_rule_number = 19 then\s+perform quarantine_origin\s*\(\s*p_node_id\s*,\s*p_k_days\s*,\s*'single-strike: rule 19[^']*'\s*\)\s*;\s*return true\s*;\s*end if\s*;/,
+  );
+});
+
+test("cumulative branch increments and quarantines at N", () => {
+  // Pin the >= comparison (not >) so the very Nth rejection triggers
+  // quarantine, not the (N+1)th. Off-by-one here would let the origin
+  // get away with one extra rejection per cycle — exactly the kind of
+  // drift §10.2 is meant to prevent.
+  assert.match(
+    SQL,
+    /update nodes\s+set\s+consecutive_rejections\s*=\s*consecutive_rejections\s*\+\s*1\s+where\s+node_id\s*=\s*p_node_id\s+returning consecutive_rejections into v_new_count/,
+  );
+  assert.match(SQL, /if v_new_count\s*>=\s*p_n_threshold then/);
+});
+
+test("record_origin_rejection raises on unknown node_id", () => {
+  assert.match(
+    SQL,
+    /raise exception 'record_origin_rejection: unknown node_id %'/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (9) reset_origin_rejection_streak — break the §10.2 streak on clean ingest
+// ---------------------------------------------------------------------------
+
+test("reset_origin_rejection_streak only writes when the counter is > 0", () => {
+  // Common path is a clean ingest from a peer with counter already 0;
+  // the conditional WHERE avoids producing a needless WAL entry every
+  // poll cycle. Pin it because without the AND-clause the function
+  // becomes a hot-path UPDATE on every successful ingest.
+  assert.match(
+    SQL,
+    /update nodes\s+set\s+consecutive_rejections\s*=\s*0\s+where\s+node_id\s*=\s*p_node_id\s+and\s+consecutive_rejections\s*>\s*0/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (10) GRANT EXECUTE — every helper is callable by anon + service_role
+// ---------------------------------------------------------------------------
+
+test("record_trust_edge_change has GRANT EXECUTE", () => {
+  assert.match(
+    SQL,
+    /grant execute on function record_trust_edge_change\s*\(\s*text\s*,\s*real\s*,\s*text\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+test("is_quarantined has GRANT EXECUTE", () => {
+  assert.match(
+    SQL,
+    /grant execute on function is_quarantined\s*\(\s*text\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+test("quarantine_origin has GRANT EXECUTE", () => {
+  assert.match(
+    SQL,
+    /grant execute on function quarantine_origin\s*\(\s*text\s*,\s*int\s*,\s*text\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+test("record_origin_rejection has GRANT EXECUTE", () => {
+  assert.match(
+    SQL,
+    /grant execute on function record_origin_rejection\s*\(\s*text\s*,\s*int\s*,\s*int\s*,\s*int\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+test("reset_origin_rejection_streak has GRANT EXECUTE", () => {
+  assert.match(
+    SQL,
+    /grant execute on function reset_origin_rejection_streak\s*\(\s*text\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (11) No DROP / DELETE / TRUNCATE on existing data — substrate migration
+// ---------------------------------------------------------------------------
+
+test("migration 075 contains no DROP TABLE / DELETE / TRUNCATE", () => {
+  // Substrate-only — same discipline as 070-074. The autonomy loop is
+  // forbidden from running migrations; even so, a stray DROP would be a
+  // foot-gun if Reed runs the migration on a populated DB.
+  assert.doesNotMatch(SQL, /\bdrop table\b/);
+  assert.doesNotMatch(SQL, /\bdelete from\b/);
+  assert.doesNotMatch(SQL, /\btruncate\b/);
+});

--- a/supabase/migrations/075_trust_edge_dynamics.sql
+++ b/supabase/migrations/075_trust_edge_dynamics.sql
@@ -1,0 +1,378 @@
+-- 075_trust_edge_dynamics.sql — Swarm Phase 4f (issue #107)
+--
+-- Substrate for §10.1 reputation decay (TrustEdge auto-tuning) and §10.2
+-- quarantine state machine. SWARM_SPEC v1.1.
+--
+-- Scope discipline (mirrors migration 074): this migration ships ONLY the
+-- DB-level structure plus the small set of helper functions that need to
+-- be transactional. The runtime that drives them — REM-cycle reputation
+-- recompute, polling-side quarantine filter — lands in a follow-up TS PR.
+-- Splitting the work this way keeps each PR small enough to review and
+-- avoids a giant cross-cutting diff.
+--
+-- TrustEdge is stored as flat columns on `nodes` (see header of migration
+-- 071 for the rationale: §3.4 explicitly forbids exposing trust across
+-- the wire, and a one-row-per-peer view in `nodes` removes the temptation
+-- to ever JOIN it into a /swarm/* response). This migration extends that
+-- row with six bookkeeping columns plus a `consecutive_rejections` counter
+-- for the §10.2 state machine, and adds an append-only audit log for
+-- weight changes so an operator can review §10.1 decay decisions.
+--
+-- §10.1 formula recap:
+--   weight = base_weight
+--          × successful_inclusion_proof_rate(origin, last_30d)
+--          × clamp(0, 1, avg_local_useful_count(origin) / threshold)
+--          × age_factor(origin)
+--   clamped to [0, 1].
+-- `compute_trust_weight()` below is the pure-SQL implementation. The REM
+-- cycle is responsible for sourcing the four input signals (proof-rate
+-- comes from §4.6 handler success/failure events, useful_count from
+-- existing experience.useful_count aggregates, age_factor from
+-- nodes.last_seen_at - nodes.created_at). Keeping the formula DB-side
+-- means we get one source of truth for the arithmetic and contract-pin
+-- tests can verify the constants without booting Postgres.
+--
+-- §10.2 state machine recap:
+--   * N consecutive rule 1–20 rejections → quarantine for K days
+--   * Rule 19 (broken commitment chain) is single-strike — quarantine
+--     immediately regardless of N (chain rewriting is a definitionally
+--     adversarial act, §3.7.2)
+--   * Defaults: N = 5, K = 30. Both are function-parameter-overridable
+--     so an operator can tune per peer without altering schema.
+--
+-- Append-only audit log:
+-- `trust_edge_log` is the operator's audit surface for §10.1. Every
+-- weight change MUST be accompanied by a `reason`. UPDATE/DELETE are
+-- forbidden via trigger — same pattern as `lesson_chain` (074), defense
+-- in depth so an operator with table-owner privileges still cannot
+-- silently rewrite reputation history.
+--
+-- Reed runs the migration manually after merge — the autonomy loop is
+-- forbidden from executing it (migration discipline from 070-074).
+
+-- ---------------------------------------------------------------------------
+-- (1) Extend `nodes` with the §10.1 + §10.2 bookkeeping fields
+--
+-- All new columns are nullable or carry safe defaults so the existing
+-- `is_self` row from phase 1b and any peer rows from migration 071 keep
+-- working without backfill. NULL on a signal column means "no data yet";
+-- the formula treats NULL inputs as "no decay applied this cycle".
+-- ---------------------------------------------------------------------------
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS successful_inclusion_proof_rate_30d REAL;
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS avg_local_useful_count REAL;
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS age_factor REAL NOT NULL DEFAULT 1.0;
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS quarantined_until TIMESTAMPTZ;
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS last_decay_at TIMESTAMPTZ;
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS decay_reason TEXT;
+-- The §10.2 N-counter. Resets on quarantine (the streak is consumed) and
+-- on the first non-rejection ingest from the same origin (the streak is
+-- broken). Stored on the row rather than computed from a rejection log
+-- so the polling-side check is a single column read.
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS consecutive_rejections INT NOT NULL DEFAULT 0;
+
+-- Range guards. Rates are bounded probabilities; counts are non-negative.
+-- ALTER TABLE ... ADD CONSTRAINT IF NOT EXISTS is not portable across
+-- PostgreSQL versions; the DO-block pattern is the established workaround.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'nodes_proof_rate_range'
+  ) THEN
+    ALTER TABLE nodes
+      ADD CONSTRAINT nodes_proof_rate_range
+      CHECK (successful_inclusion_proof_rate_30d IS NULL
+             OR (successful_inclusion_proof_rate_30d >= 0
+                 AND successful_inclusion_proof_rate_30d <= 1));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'nodes_age_factor_range'
+  ) THEN
+    ALTER TABLE nodes
+      ADD CONSTRAINT nodes_age_factor_range
+      CHECK (age_factor >= 0 AND age_factor <= 1);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'nodes_useful_count_nonneg'
+  ) THEN
+    ALTER TABLE nodes
+      ADD CONSTRAINT nodes_useful_count_nonneg
+      CHECK (avg_local_useful_count IS NULL OR avg_local_useful_count >= 0);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'nodes_consecutive_rejections_nonneg'
+  ) THEN
+    ALTER TABLE nodes
+      ADD CONSTRAINT nodes_consecutive_rejections_nonneg
+      CHECK (consecutive_rejections >= 0);
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- (2) trust_edge_log — append-only audit surface for §10.1
+--
+-- Operator-facing. Every weight change records {before, after, reason, at}
+-- so the operator can ask "why did peer X's trust drop overnight?" and
+-- get a single-query answer.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS trust_edge_log (
+  id            BIGSERIAL    PRIMARY KEY,
+  node_id       TEXT         NOT NULL REFERENCES nodes(node_id),
+  weight_before REAL         NOT NULL,
+  weight_after  REAL         NOT NULL,
+  reason        TEXT         NOT NULL,
+  at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  CHECK (weight_before >= 0 AND weight_before <= 1),
+  CHECK (weight_after  >= 0 AND weight_after  <= 1)
+);
+
+CREATE INDEX IF NOT EXISTS trust_edge_log_node_at_idx
+  ON trust_edge_log (node_id, at DESC);
+
+COMMENT ON TABLE trust_edge_log IS
+  'Mycelium swarm: append-only audit log of TrustEdge weight changes (SWARM_SPEC §10.1). Operator-facing. UPDATE/DELETE forbidden by trigger.';
+
+-- Append-only enforcement — same pattern as lesson_chain (074).
+CREATE OR REPLACE FUNCTION trust_edge_log_no_mutate() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION
+    'trust_edge_log is append-only — rows cannot be % (SWARM_SPEC §10.1)',
+    TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trust_edge_log_no_update ON trust_edge_log;
+CREATE TRIGGER trust_edge_log_no_update
+  BEFORE UPDATE ON trust_edge_log
+  FOR EACH ROW EXECUTE FUNCTION trust_edge_log_no_mutate();
+
+DROP TRIGGER IF EXISTS trust_edge_log_no_delete ON trust_edge_log;
+CREATE TRIGGER trust_edge_log_no_delete
+  BEFORE DELETE ON trust_edge_log
+  FOR EACH ROW EXECUTE FUNCTION trust_edge_log_no_mutate();
+
+-- ---------------------------------------------------------------------------
+-- (3) compute_trust_weight — the §10.1 formula as a pure SQL function
+--
+-- Inputs are passed in by the caller (the REM-cycle TS code aggregates the
+-- four signals from existing tables — proof success/failure log, experience
+-- useful_count, last_seen_at, etc.). This function is the single source of
+-- truth for the arithmetic, including the [0, 1] clamp.
+--
+-- NULL handling: any NULL input collapses the whole product to base_weight
+-- alone (treating NULL as "no signal yet, don't decay"). This is the
+-- conservative default — a fresh peer with no proof history shouldn't be
+-- driven to 0 just because the rolling window hasn't accumulated data.
+-- The REM cycle only writes the result back via record_trust_edge_change
+-- if it represents a *real* change, so NULL-only inputs don't pollute the
+-- audit log.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION compute_trust_weight(
+  base_weight              REAL,
+  proof_rate_30d           REAL,
+  avg_useful_count         REAL,
+  useful_count_threshold   REAL,
+  age_factor               REAL
+) RETURNS REAL AS $$
+  SELECT GREATEST(0.0::REAL, LEAST(1.0::REAL,
+    base_weight
+    * COALESCE(proof_rate_30d, 1.0)
+    * COALESCE(
+        LEAST(1.0::REAL, avg_useful_count / NULLIF(useful_count_threshold, 0)),
+        1.0
+      )
+    * COALESCE(age_factor, 1.0)
+  ));
+$$ LANGUAGE sql IMMUTABLE;
+
+GRANT EXECUTE ON FUNCTION compute_trust_weight(REAL, REAL, REAL, REAL, REAL)
+  TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (4) record_trust_edge_change — atomic update + audit
+--
+-- The REM cycle calls this with the new weight produced by
+-- compute_trust_weight(). The function reads the current weight, writes a
+-- log row capturing {before, after, reason, at}, and updates nodes
+-- accordingly — all in a single statement so a crash between the read and
+-- the write cannot produce a row in `nodes` whose value diverges from the
+-- audit log.
+--
+-- No-op behaviour: if `p_new_weight` equals the current `trust_weight`,
+-- no log row is written (the audit log shows real changes only).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION record_trust_edge_change(
+  p_node_id    TEXT,
+  p_new_weight REAL,
+  p_reason     TEXT
+) RETURNS VOID AS $$
+DECLARE
+  v_before REAL;
+BEGIN
+  IF p_reason IS NULL OR length(trim(p_reason)) = 0 THEN
+    RAISE EXCEPTION 'record_trust_edge_change: reason is required (SWARM_SPEC §10.1)';
+  END IF;
+  IF p_new_weight < 0 OR p_new_weight > 1 THEN
+    RAISE EXCEPTION 'record_trust_edge_change: weight must be in [0, 1], got %', p_new_weight;
+  END IF;
+
+  SELECT trust_weight INTO v_before FROM nodes WHERE node_id = p_node_id;
+  IF v_before IS NULL THEN
+    RAISE EXCEPTION 'record_trust_edge_change: unknown node_id %', p_node_id;
+  END IF;
+
+  -- No-op short-circuit: identical weight, no audit row, no UPDATE.
+  IF v_before = p_new_weight THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO trust_edge_log (node_id, weight_before, weight_after, reason)
+  VALUES (p_node_id, v_before, p_new_weight, p_reason);
+
+  UPDATE nodes
+  SET    trust_weight  = p_new_weight,
+         trust_reason  = p_reason,
+         last_decay_at = NOW(),
+         decay_reason  = p_reason
+  WHERE  node_id = p_node_id;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION record_trust_edge_change(TEXT, REAL, TEXT)
+  TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (5) is_quarantined — single-column read used by the polling client
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION is_quarantined(p_node_id TEXT) RETURNS BOOLEAN AS $$
+  SELECT COALESCE(
+    (SELECT quarantined_until FROM nodes WHERE node_id = p_node_id) > NOW(),
+    FALSE
+  );
+$$ LANGUAGE sql STABLE;
+
+GRANT EXECUTE ON FUNCTION is_quarantined(TEXT) TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (6) quarantine_origin — set the §10.2 hold for K days
+--
+-- Resets `consecutive_rejections` to 0 because the streak has been
+-- consumed by the quarantine action; if the origin re-offends after
+-- coming back, the count starts fresh.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION quarantine_origin(
+  p_node_id TEXT,
+  p_days    INT,
+  p_reason  TEXT
+) RETURNS VOID AS $$
+BEGIN
+  IF p_days <= 0 THEN
+    RAISE EXCEPTION 'quarantine_origin: days must be > 0, got %', p_days;
+  END IF;
+  IF p_reason IS NULL OR length(trim(p_reason)) = 0 THEN
+    RAISE EXCEPTION 'quarantine_origin: reason is required';
+  END IF;
+
+  UPDATE nodes
+  SET    quarantined_until      = NOW() + (p_days || ' days')::INTERVAL,
+         consecutive_rejections = 0,
+         decay_reason           = p_reason
+  WHERE  node_id = p_node_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'quarantine_origin: unknown node_id %', p_node_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION quarantine_origin(TEXT, INT, TEXT)
+  TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (7) record_origin_rejection — encodes the §10.2 state machine
+--
+-- Called by the receiver pipeline whenever a §5 rule 1–20 rejection
+-- against `p_node_id` fires. Encodes the two §10.2 trigger modes:
+--   * single-strike: rule 19 (chain rewriting) → immediate quarantine
+--   * cumulative:   N consecutive other rejections → quarantine
+--
+-- Defaults (N = 5, K = 30) are SWARM_SPEC §10.2. Operator-overridable via
+-- the function arguments; the receiver's TS layer reads operator config
+-- and passes the resolved values, so per-peer policy lives outside the DB.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION record_origin_rejection(
+  p_node_id     TEXT,
+  p_rule_number INT,
+  p_n_threshold INT  DEFAULT 5,
+  p_k_days      INT  DEFAULT 30
+) RETURNS BOOLEAN AS $$
+DECLARE
+  v_new_count INT;
+BEGIN
+  IF p_rule_number < 1 OR p_rule_number > 20 THEN
+    RAISE EXCEPTION 'record_origin_rejection: rule_number must be in [1, 20], got %', p_rule_number;
+  END IF;
+  IF p_n_threshold < 1 THEN
+    RAISE EXCEPTION 'record_origin_rejection: n_threshold must be >= 1, got %', p_n_threshold;
+  END IF;
+
+  -- Single-strike branch (§10.2): rule 19 is chain-rewriting.
+  IF p_rule_number = 19 THEN
+    PERFORM quarantine_origin(
+      p_node_id,
+      p_k_days,
+      'single-strike: rule 19 (broken commitment chain)'
+    );
+    RETURN TRUE;
+  END IF;
+
+  -- Cumulative branch: increment, quarantine if threshold crossed.
+  UPDATE nodes
+  SET    consecutive_rejections = consecutive_rejections + 1
+  WHERE  node_id = p_node_id
+  RETURNING consecutive_rejections INTO v_new_count;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'record_origin_rejection: unknown node_id %', p_node_id;
+  END IF;
+
+  IF v_new_count >= p_n_threshold THEN
+    PERFORM quarantine_origin(
+      p_node_id,
+      p_k_days,
+      'cumulative: ' || v_new_count || ' consecutive rejections'
+    );
+    RETURN TRUE;
+  END IF;
+
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION record_origin_rejection(TEXT, INT, INT, INT)
+  TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (8) reset_origin_rejection_streak — break the §10.2 streak on a clean ingest
+--
+-- The §10.2 N-counter counts CONSECUTIVE rejections — a single accepted
+-- ingest breaks the streak. The receiver pipeline calls this on every
+-- successful ingest from `p_node_id`. No-op if the counter is already 0,
+-- which is the common path.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION reset_origin_rejection_streak(p_node_id TEXT)
+RETURNS VOID AS $$
+  UPDATE nodes
+  SET    consecutive_rejections = 0
+  WHERE  node_id = p_node_id
+    AND  consecutive_rejections > 0;
+$$ LANGUAGE sql;
+
+GRANT EXECUTE ON FUNCTION reset_origin_rejection_streak(TEXT)
+  TO anon, service_role;


### PR DESCRIPTION
## Summary

Closes-toward #107 (sub-phase 4f). Ships the SQL substrate for SWARM_SPEC v1.1 §10.1 (reputation decay) and §10.2 (quarantine state machine). Same scope discipline as PR #119 (4d): DB-level structure + transactional helpers now, runtime wiring lands in a follow-up TS PR.

## What's in this PR

**Migration `075_trust_edge_dynamics.sql`:**
- Extends `nodes` with six §10.1/§10.2 columns (`successful_inclusion_proof_rate_30d`, `avg_local_useful_count`, `age_factor`, `quarantined_until`, `last_decay_at`, `decay_reason`) plus a `consecutive_rejections` counter for the N-streak state machine.
- New `trust_edge_log` table — operator-facing append-only audit log of weight changes. UPDATE/DELETE forbidden by trigger (same defense pattern as `lesson_chain` from 074).
- Helper `compute_trust_weight(...)` — pure SQL §10.1 formula, `IMMUTABLE`, output clamped to `[0, 1]`, NULL-safe (`NULL` inputs collapse to `base_weight` so a fresh peer with no signal isn't driven to 0).
- Helper `record_trust_edge_change(...)` — atomic update + audit-log write, short-circuits on no-op weight changes, requires a non-empty `reason`.
- Helper `is_quarantined(...)` — single-column read for the polling-side filter. `COALESCE(..., FALSE)` so unknown peers aren't accidentally quarantined.
- Helper `quarantine_origin(...)` — sets §10.2 hold for K days, resets the rejection counter (the streak has been consumed).
- Helper `record_origin_rejection(...)` — encodes the §10.2 state machine: rule 19 single-strikes immediately, others accumulate to N. Defaults `N=5`, `K=30` per spec; both function-parameter-overridable so operator policy lives outside the schema.
- Helper `reset_origin_rejection_streak(...)` — clean ingest breaks the streak; conditional WHERE keeps the common path WAL-free.

**Test `migration-075-trust-edge-dynamics.test.ts`:**
- 44 contract-pin tests mirroring the 070-074 defensive pattern: SQL-text-level pins on every load-bearing structural invariant (column types/defaults/CHECK ranges, function signatures, formula clamping, state-machine transitions, GRANTs, append-only triggers).
- Full suite green: 427 tests.

## Out of scope for this PR (substrate-only discipline)

Per the 074 pattern, the runtime wiring lives in follow-ups so each PR stays small:
- REM-cycle hook that aggregates the four §10.1 input signals from existing tables and calls `compute_trust_weight` + `record_trust_edge_change`.
- `/swarm/lessons` polling filter that consults `is_quarantined` before contacting an origin.
- Receiver pipeline that calls `record_origin_rejection` on each §5 rule 1–20 hit.

The existing `nodes.trust_weight` / `trust_reason` columns from migration 071 are unchanged — this migration only adds. Existing rows keep working without backfill (`age_factor` defaults to 1.0, all signal columns NULLable).

## Test plan

- [x] `npm test` green (427 tests, 44 new)
- [x] Migration uses no DROP/DELETE/TRUNCATE (substrate-only invariant pinned by test)
- [ ] Reed runs migration manually after merge (autonomy loop is forbidden from running migrations, per 070-074 discipline)
- [ ] Follow-up PR will wire the REM-cycle recompute and polling-side filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)