### PR TITLE
feat(swarm): producer-side evidence storage — sub-phase 4e substrate (#105)

### DIFF
--- a/mcp-server/src/__tests__/migration-077-lesson-evidence-origin.test.ts
+++ b/mcp-server/src/__tests__/migration-077-lesson-evidence-origin.test.ts
@@ -1,0 +1,218 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 077 — lesson_evidence_origin (issue #105, sub-phase 4e)
+//
+// Producer-side substrate for the §4.6 inclusion-proof endpoint. The pins
+// below cover the load-bearing structural invariants the proof endpoint
+// (and the §4.6 invariant evidence_root == merkle_root(stored_leaves))
+// will rely on once the HTTP handler lands. Without these the table can
+// silently regress into shapes that *look* like an evidence store but
+// no longer enforce one:
+//
+//   1. Append-only must be SQL-side, not application-trust. A producer
+//      flow that's "carefully not running UPDATE" is one fat finger
+//      away from rewriting an already-published lesson's evidence set,
+//      which would let the §4.6 endpoint hand peers a proof against
+//      bytes the original signature does not cover.
+//   2. The hashed_experience_id shape pin (46 chars + Qm prefix) keeps
+//      a producer bug (passing a raw UUID, content blob, or different
+//      hash family) from ever entering the wire path.
+//   3. UNIQUE (lesson_id, hashed_experience_id) makes a forgotten
+//      dedupe in the producer flow fail loudly rather than emitting
+//      a tree the receiver will reject.
+//   4. The atomic record_lesson_evidence(...) RPC is the only intended
+//      writer; an idempotent retry on the same leaf set is a no-op,
+//      a divergent leaf set on an existing lesson is a hard error
+//      (the §4.6 contract is one signed evidence_root per lesson).
+//
+// Contract-test pattern mirrors migration-070..076: the autonomy loop
+// cannot execute migrations (Reed runs them by hand after merge), so
+// shape is pinned at the SQL-text level. Stripping comments before
+// keyword matching prevents an explanatory phrase like "no DROP" from
+// satisfying a structural assertion.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/077_lesson_evidence_origin.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) Table shape — every column the issue scope pins
+// ---------------------------------------------------------------------------
+
+test("lesson_evidence_origin table is created with the documented column set", () => {
+  assert.match(SQL, /create table if not exists lesson_evidence_origin\b/);
+  assert.match(SQL, /lesson_id\s+uuid\s+not null/);
+  assert.match(SQL, /position\s+int\s+not null/);
+  assert.match(SQL, /hashed_experience_id\s+text\s+not null/);
+  assert.match(SQL, /created_at\s+timestamptz\s+not null\s+default now\(\)/);
+});
+
+test("primary key is (lesson_id, position) — not a surrogate UUID", () => {
+  // Using the natural composite key both shrinks the row and pins the
+  // position uniqueness invariant in the most expressive place. A
+  // surrogate id would let two rows with the same (lesson_id, position)
+  // coexist if the UNIQUE was forgotten; the composite PK makes that
+  // impossible by construction.
+  assert.match(SQL, /primary key\s*\(\s*lesson_id\s*,\s*position\s*\)/);
+});
+
+test("position is non-negative", () => {
+  assert.match(SQL, /check\s*\(\s*position\s*>=\s*0\s*\)/);
+});
+
+test("hashed_experience_id shape: 46 chars + Qm prefix (sha2-256 base58btc multihash)", () => {
+  // The wire form per §3.7.1 is multihash(sha2-256, ...) in base58btc,
+  // which is deterministically a 46-char string starting with 'Qm'.
+  // Pinning this at the column level catches a producer that
+  // accidentally writes a raw UUID (36 chars) or content blob.
+  assert.match(SQL, /check\s*\(\s*length\s*\(\s*hashed_experience_id\s*\)\s*=\s*46\s*\)/);
+  assert.match(SQL, /check\s*\(\s*hashed_experience_id\s+like\s+'qm%'\s*\)/);
+});
+
+test("UNIQUE (lesson_id, hashed_experience_id) prevents duplicate leaves per lesson", () => {
+  // §3.7.1 leaves are deduped before the tree is built. A producer that
+  // forgets to dedupe would emit a different evidence_root than the
+  // receiver would compute when reconstructing from the proof. The
+  // UNIQUE makes the bug fail at INSERT time on the producer side.
+  assert.match(SQL, /unique\s*\(\s*lesson_id\s*,\s*hashed_experience_id\s*\)/);
+});
+
+test("lesson_id index for proof-endpoint lookup", () => {
+  // The §4.6 endpoint scans by lesson_id; without an index every proof
+  // request triggers a full table scan once the table has any size.
+  assert.match(SQL, /create index if not exists lesson_evidence_origin_lesson_id_idx\s+on lesson_evidence_origin \(lesson_id\)/);
+});
+
+// ---------------------------------------------------------------------------
+// (2) Append-only triggers
+// ---------------------------------------------------------------------------
+
+test("UPDATE is forbidden by trigger (append-only invariant)", () => {
+  assert.match(
+    SQL,
+    /create trigger lesson_evidence_origin_no_update\s+before update on lesson_evidence_origin\s+for each row execute function lesson_evidence_origin_no_mutate\(\)/,
+  );
+});
+
+test("DELETE is forbidden by trigger (append-only invariant)", () => {
+  assert.match(
+    SQL,
+    /create trigger lesson_evidence_origin_no_delete\s+before delete on lesson_evidence_origin\s+for each row execute function lesson_evidence_origin_no_mutate\(\)/,
+  );
+});
+
+test("trigger function exists and raises with the spec section in the message", () => {
+  assert.match(SQL, /create or replace function lesson_evidence_origin_no_mutate\(\) returns trigger/);
+  // Operator-readable error: include the spec section so a confused
+  // operator landing on the failure can find the rationale instantly.
+  assert.match(SQL, /raise exception\s+'lesson_evidence_origin is append-only — rows cannot be %.*swarm_spec §4\.6\)'/i);
+});
+
+// ---------------------------------------------------------------------------
+// (3) record_lesson_evidence RPC
+// ---------------------------------------------------------------------------
+
+test("record_lesson_evidence(UUID, TEXT[]) is created and granted", () => {
+  assert.match(SQL, /create or replace function record_lesson_evidence\(\s*p_lesson_id\s+uuid\s*,\s*p_hashed_experience_ids\s+text\[\]\s*\)\s+returns jsonb/);
+  assert.match(SQL, /grant execute on function record_lesson_evidence\(uuid, text\[\]\)\s+to anon, service_role/);
+});
+
+test("record_lesson_evidence rejects null lesson_id and empty/null evidence array", () => {
+  // The §3.1 rule "evidence_count >= 1" lives in the RPC body — a
+  // producer that calls with an empty leaf set MUST get a hard error
+  // rather than silently writing zero rows (which would later make the
+  // §4.6 endpoint return 200 with empty proofs).
+  assert.match(SQL, /if p_lesson_id is null then\s+return jsonb_build_object\('ok', false, 'error', 'lesson_id is required'\);/);
+  assert.match(
+    SQL,
+    /if p_hashed_experience_ids is null or array_length\(p_hashed_experience_ids, 1\) is null then\s+return jsonb_build_object\('ok', false, 'error', 'evidence_count must be >= 1 \(swarm_spec §3\.1\)'\);/,
+  );
+});
+
+test("record_lesson_evidence is idempotent on the same leaf set (already_recorded)", () => {
+  // The publishing flow may retry — re-recording the SAME leaves for the
+  // same lesson MUST be a safe no-op. The RPC compares the existing leaf
+  // set against the input and returns ok=false / error=already_recorded
+  // so the caller can distinguish "already done" from "did the work".
+  assert.match(SQL, /'already_recorded'/);
+});
+
+test("record_lesson_evidence rejects a divergent leaf set on existing lesson_id", () => {
+  // §4.6 contract: one evidence_root per lesson, immutable after signing.
+  // A divergent input MUST be a hard error, never a silent overwrite
+  // (the append-only trigger would block the overwrite anyway, but
+  // returning a clear leaf_set_mismatch error gives the producer a
+  // useful failure mode instead of a generic trigger raise).
+  assert.match(SQL, /'leaf_set_mismatch'/);
+});
+
+test("record_lesson_evidence inserts at canonical zero-based positions", () => {
+  // generate_subscripts(arr, 1) yields 1..N; we subtract one to land on
+  // zero-based position so position semantically matches array indexing
+  // in the wire-side merkle code (services/evidence-merkle.ts).
+  assert.match(
+    SQL,
+    /insert into lesson_evidence_origin \(lesson_id, position, hashed_experience_id\)\s+select p_lesson_id, i - 1, p_hashed_experience_ids\[i\]\s+from generate_subscripts\(p_hashed_experience_ids, 1\) as i;/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) get_lesson_evidence RPC
+// ---------------------------------------------------------------------------
+
+test("get_lesson_evidence returns ordered (position, hashed_experience_id) pairs", () => {
+  // Returning a setof rows with position included lets the proof-endpoint
+  // implementation reconstruct the producer-canonical order without
+  // relying on PostgreSQL's row-return order accidentally matching.
+  // Ordering by position ASC is the §3.7.1 leaf-order contract.
+  assert.match(SQL, /create or replace function get_lesson_evidence\(p_lesson_id uuid\)\s+returns table \(position int, hashed_experience_id text\)\s+language sql stable/);
+  assert.match(SQL, /select position, hashed_experience_id\s+from lesson_evidence_origin\s+where lesson_id = p_lesson_id\s+order by position asc/);
+});
+
+test("get_lesson_evidence is granted to anon and service_role", () => {
+  assert.match(SQL, /grant execute on function get_lesson_evidence\(uuid\) to anon, service_role/);
+});
+
+// ---------------------------------------------------------------------------
+// (5) Migration discipline — substrate-only, no DROP/DELETE/TRUNCATE
+// ---------------------------------------------------------------------------
+
+test("migration is substrate-only: no DROP, DELETE, or TRUNCATE on lesson_evidence_origin", () => {
+  // The 070-076 discipline: Reed runs migrations manually, the autonomy
+  // loop cannot execute them. A migration that destroys data couldn't
+  // be safely rolled back, so we keep this floor structural.
+  // (DROP TRIGGER IF EXISTS ... is allowed — it's the idempotent
+  // re-create pattern, not data destruction.)
+  assert.doesNotMatch(SQL, /drop\s+table\b/);
+  assert.doesNotMatch(SQL, /delete\s+from\s+lesson_evidence_origin/);
+  assert.doesNotMatch(SQL, /truncate\s+lesson_evidence_origin/);
+  // Defense pin: the trigger itself uses RAISE EXCEPTION for UPDATE/DELETE.
+  // The migration MUST NOT include any ALTER TABLE that would loosen the
+  // PK or drop the UNIQUE — none should appear at all.
+  assert.doesNotMatch(SQL, /alter\s+table\s+lesson_evidence_origin\s+drop/);
+});
+
+test("table and column COMMENTs cite SWARM_SPEC §4.6 — operator-discoverable rationale", () => {
+  // A future operator running `\d+ lesson_evidence_origin` in psql sees
+  // the spec citation directly. Same discipline as 074/075/076.
+  assert.match(SQL, /comment on table lesson_evidence_origin is\s+'mycelium swarm:.*swarm_spec §4\.6/i);
+  assert.match(SQL, /comment on column lesson_evidence_origin\.hashed_experience_id is/i);
+  assert.match(SQL, /comment on column lesson_evidence_origin\.position is\s+'zero-based.*swarm_spec §3\.7\.1/i);
+});

--- a/supabase/migrations/077_lesson_evidence_origin.sql
+++ b/supabase/migrations/077_lesson_evidence_origin.sql
@@ -1,0 +1,214 @@
+-- 077_lesson_evidence_origin.sql — Swarm Phase 4e (issue #105)
+--
+-- Producer-side substrate for the §4.6 Merkle inclusion-proof endpoint
+-- (`GET /swarm/lessons/{id}/proof`). Stores, per locally-published Lesson,
+-- the ordered list of `hashed_experience_id` leaves that fed its
+-- `evidence_root` at signing time.
+--
+-- Why a separate table (and not a JSONB column on `lessons`):
+--
+--   * `lessons.metadata` is application-mutable: the autonomy loop, REM
+--     promotions, and operator tools all write into it. A leaves array
+--     stored there could be silently rewritten, breaking the §4.6 invariant
+--     that `evidence_root == merkle_root(stored_leaves)` for every proof
+--     this node ever issues.
+--   * Append-only enforcement is column-by-column impossible inside a
+--     JSONB blob. A dedicated table lets us put the trigger on UPDATE/DELETE
+--     and put a row-level UNIQUE on (lesson_id, position) — the structural
+--     guarantee the proof endpoint relies on.
+--   * §4.6 may be queried at arbitrary cadence per lesson; a normalised
+--     row-per-leaf shape supports the future per-leaf incremental fetch
+--     path (4e successor) without a schema rewrite.
+--
+-- Privacy invariant — only the **hashed** experience id is stored. Raw
+-- experience IDs never enter this table. Hashes are produced by
+-- `hashExperienceId(...)` (services/evidence-merkle.ts, sub-phase 4c).
+-- The shape constraint (CHECK) catches obvious raw-ID smuggling: the
+-- hashed form is a 46-char base58btc multihash starting with 'Qm'; any
+-- input that isn't that shape is rejected at INSERT time.
+--
+-- Append-only by trigger — same defense pattern as `lesson_chain` (074)
+-- and `trust_edge_log` (075). An operator with table-owner privileges
+-- still cannot silently rewrite a previously-published lesson's evidence
+-- set, which would let the proof endpoint return a "valid" proof against
+-- a different leaf set than the one that was originally signed.
+--
+-- Reed runs the migration manually after merge — the autonomy loop is
+-- forbidden from executing it (migration discipline from 070-076).
+
+-- ---------------------------------------------------------------------------
+-- (1) lesson_evidence_origin table
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lesson_evidence_origin (
+  lesson_id              UUID        NOT NULL,
+  position               INT         NOT NULL,
+  hashed_experience_id   TEXT        NOT NULL,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (lesson_id, position),
+  -- §4.6: every leaf in the proof MUST be a sha2-256 multihash in
+  -- base58btc. The shape pin keeps a producer bug (passing a raw UUID,
+  -- a content blob, a different hash family) from silently committing
+  -- bytes the §4.6 endpoint will later sign over and the receiver will
+  -- reject as malformed. 46 chars + 'Qm' prefix is the deterministic
+  -- output of multihash(sha2-256, ...) in base58btc; see evidence-merkle.ts.
+  CHECK (LENGTH(hashed_experience_id) = 46),
+  CHECK (hashed_experience_id LIKE 'Qm%'),
+  CHECK (position >= 0),
+  -- A lesson MUST NOT have two leaves at the same position (caught by
+  -- the PRIMARY KEY) AND MUST NOT have the same leaf at two positions
+  -- (the deduped-and-sorted contract from §3.7.1). This UNIQUE pin
+  -- makes a producer that forgets to dedupe before writing the leaves
+  -- fail loudly rather than emitting a tree the receiver will reject.
+  UNIQUE (lesson_id, hashed_experience_id)
+);
+
+CREATE INDEX IF NOT EXISTS lesson_evidence_origin_lesson_id_idx
+  ON lesson_evidence_origin (lesson_id);
+
+COMMENT ON TABLE lesson_evidence_origin IS
+  'Mycelium swarm: per-locally-published-Lesson list of hashed_experience_id leaves that fed its evidence_root at signing time. SWARM_SPEC §4.6 producer-side substrate for the inclusion-proof endpoint. Append-only by trigger; UPDATE and DELETE raise. Only hashes (never raw experience IDs) are stored.';
+
+COMMENT ON COLUMN lesson_evidence_origin.hashed_experience_id IS
+  'sha2-256 multihash of the raw experience id, encoded base58btc (46-char Qm... string). Produced by services/evidence-merkle.ts hashExperienceId(). Raw IDs MUST NOT be stored — only the hashed form leaves any module.';
+
+COMMENT ON COLUMN lesson_evidence_origin.position IS
+  'Zero-based index into the producer-canonical leaf order. SWARM_SPEC §3.7.1 sorts leaves ascending before tree construction; position pins that order so the proof endpoint can rebuild the same tree without re-sorting at query time.';
+
+-- ---------------------------------------------------------------------------
+-- (2) Append-only enforcement
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION lesson_evidence_origin_no_mutate() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION
+    'lesson_evidence_origin is append-only — rows cannot be % (SWARM_SPEC §4.6)',
+    TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS lesson_evidence_origin_no_update ON lesson_evidence_origin;
+CREATE TRIGGER lesson_evidence_origin_no_update
+  BEFORE UPDATE ON lesson_evidence_origin
+  FOR EACH ROW EXECUTE FUNCTION lesson_evidence_origin_no_mutate();
+
+DROP TRIGGER IF EXISTS lesson_evidence_origin_no_delete ON lesson_evidence_origin;
+CREATE TRIGGER lesson_evidence_origin_no_delete
+  BEFORE DELETE ON lesson_evidence_origin
+  FOR EACH ROW EXECUTE FUNCTION lesson_evidence_origin_no_mutate();
+
+-- ---------------------------------------------------------------------------
+-- (3) record_lesson_evidence — atomic insert of all leaves for one lesson.
+--
+-- Single round-trip from the Lesson-publishing flow. Either every leaf is
+-- recorded (success) or none are (transactional rollback on any CHECK or
+-- UNIQUE violation). Idempotency: re-recording the SAME leaf set for the
+-- same lesson_id is a no-op (returns ok=false with reason='already_recorded')
+-- so a publisher retry doesn't double-write. A DIFFERENT leaf set for an
+-- existing lesson_id is a hard error (returns ok=false with
+-- reason='leaf_set_mismatch') — the §4.6 contract is one signed
+-- evidence_root per lesson, immutable once signed.
+--
+-- Input p_hashed_experience_ids is the producer-canonical (sorted, deduped)
+-- leaf order, not raw experience ids. The producer constructs this by
+-- calling buildEvidenceRoot(...).leaves from evidence-merkle.ts and passing
+-- that array verbatim — the function does NOT re-sort, dedupe, or hash.
+-- That keeps the SQL pure and the privacy boundary in one TS module.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION record_lesson_evidence(
+  p_lesson_id              UUID,
+  p_hashed_experience_ids  TEXT[]
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_count       INT;
+  v_existing    INT;
+  v_existing_set TEXT[];
+  v_input_set   TEXT[];
+BEGIN
+  IF p_lesson_id IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'lesson_id is required');
+  END IF;
+  IF p_hashed_experience_ids IS NULL OR array_length(p_hashed_experience_ids, 1) IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'evidence_count must be >= 1 (SWARM_SPEC §3.1)');
+  END IF;
+
+  v_count := array_length(p_hashed_experience_ids, 1);
+
+  -- Idempotency check: does this lesson already have evidence?
+  SELECT COUNT(*) INTO v_existing
+  FROM lesson_evidence_origin
+  WHERE lesson_id = p_lesson_id;
+
+  IF v_existing > 0 THEN
+    -- Compare existing leaves against input. Position-ordered comparison
+    -- so a re-publish with the same canonical order returns ok=false /
+    -- already_recorded (idempotent retry), and any divergence is a hard
+    -- mismatch (the lesson was already signed against a different root).
+    SELECT array_agg(hashed_experience_id ORDER BY position)
+      INTO v_existing_set
+    FROM lesson_evidence_origin
+    WHERE lesson_id = p_lesson_id;
+
+    v_input_set := p_hashed_experience_ids;
+
+    IF v_existing_set = v_input_set THEN
+      RETURN jsonb_build_object(
+        'ok',             false,
+        'error',          'already_recorded',
+        'lesson_id',      p_lesson_id,
+        'evidence_count', v_existing
+      );
+    ELSE
+      RETURN jsonb_build_object(
+        'ok',             false,
+        'error',          'leaf_set_mismatch',
+        'lesson_id',      p_lesson_id,
+        'existing_count', v_existing,
+        'input_count',    v_count
+      );
+    END IF;
+  END IF;
+
+  -- Atomic insert of all leaves at their canonical positions. The
+  -- generate_subscripts iteration preserves array order, which IS the
+  -- producer-canonical position contract. CHECK constraints on shape
+  -- and the PRIMARY KEY on (lesson_id, position) catch any malformed
+  -- input at row-level — the whole insert rolls back transactionally
+  -- on the first violation.
+  INSERT INTO lesson_evidence_origin (lesson_id, position, hashed_experience_id)
+  SELECT p_lesson_id, i - 1, p_hashed_experience_ids[i]
+  FROM generate_subscripts(p_hashed_experience_ids, 1) AS i;
+
+  RETURN jsonb_build_object(
+    'ok',             true,
+    'lesson_id',      p_lesson_id,
+    'evidence_count', v_count
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION record_lesson_evidence(UUID, TEXT[])
+  TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (4) get_lesson_evidence — read-side helper for the §4.6 endpoint.
+--
+-- Returns the canonical leaf order for the lesson. Empty array when the
+-- lesson is unknown (the §4.6 endpoint maps that to HTTP 404 — never
+-- a 200 with empty proofs, which would let a malicious caller forge
+-- "this node holds no evidence" answers). The endpoint distinguishes
+-- 404 from 410 (forgotten/superseded) by checking against the lessons
+-- table separately — this RPC's job is just the leaf lookup.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_lesson_evidence(p_lesson_id UUID)
+RETURNS TABLE (position INT, hashed_experience_id TEXT)
+LANGUAGE sql STABLE
+AS $$
+  SELECT position, hashed_experience_id
+  FROM lesson_evidence_origin
+  WHERE lesson_id = p_lesson_id
+  ORDER BY position ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_lesson_evidence(UUID) TO anon, service_role;


### PR DESCRIPTION
## Summary

Sub-phase 4e of the v1.1 PoK + self-healing roadmap (RFC #100, spec PR #101). Ships the **producer-side substrate** for the `GET /swarm/lessons/{id}/proof` endpoint specified in `docs/SWARM_SPEC.md` §4.6: a normalised, append-only store of `hashed_experience_id` leaves per locally-published Lesson, plus the two RPCs the future HTTP handler will use.

Substrate-only PR, same discipline as #119 (4d) and #120 (4f). The runtime wiring (HTTP handler + wire-validator rules 17/18) lands in a follow-up that depends on #118 (4c — evidence-merkle).

## What ships

**Migration `077_lesson_evidence_origin.sql`:**
- New `lesson_evidence_origin` table — composite PK `(lesson_id, position)`, `UNIQUE (lesson_id, hashed_experience_id)`, append-only by trigger (UPDATE+DELETE raise).
- `hashed_experience_id` shape pinned at the column level: `LENGTH = 46` AND `LIKE 'Qm%'` — the deterministic `multihash(sha2-256, ...) base58btc` form from `services/evidence-merkle.ts`. A producer that smuggles a raw UUID, content blob, or different hash family fails at INSERT time.
- `record_lesson_evidence(UUID, TEXT[])` — atomic transactional insert of all leaves at canonical zero-based positions. Idempotent on the same leaf set (returns `ok=false / already_recorded`); hard error on a divergent leaf set for an existing lesson_id (`ok=false / leaf_set_mismatch` — never a silent overwrite).
- `get_lesson_evidence(UUID)` — read-side helper that returns ordered `(position, hashed_experience_id)` pairs. Empty result is NOT a silent 200 with empty proofs; the §4.6 endpoint will map it to HTTP 404 separately.

**Test `migration-077-lesson-evidence-origin.test.ts`:**
- 18 contract-pin tests on the migration, mirroring the 070-076 defensive pattern.
- SQL-text-level pins on table shape, the `hashed_experience_id` format CHECKs, append-only triggers, RPC signatures + GRANTs, idempotency / mismatch error literals, zero-based-position insertion, no `DROP`/`DELETE`/`TRUNCATE`, operator-discoverable §4.6 / §3.7.1 citations in COMMENTs.

## Why a separate table (not a JSONB column on `lessons`)

- `lessons.metadata` is application-mutable: REM promotions, autonomy loop, operator tools all write into it. A leaves array stored there could be silently rewritten, breaking the §4.6 invariant `evidence_root == merkle_root(stored_leaves)` for every proof this node ever issues.
- Append-only enforcement is column-by-column impossible inside a JSONB blob. A dedicated table puts the trigger on UPDATE/DELETE and the row-level UNIQUE on `(lesson_id, position)`.
- A normalised row-per-leaf shape supports the future per-leaf incremental fetch path (4e successor) without a schema rewrite.

## Privacy invariant

Only the **hashed** experience id is stored. Raw experience IDs never enter this table — hashes are produced by `hashExperienceId(...)` in `services/evidence-merkle.ts` (sub-phase 4c, PR #118). The shape CHECKs catch the obvious raw-ID smuggling bugs.

## Out of scope for this PR (substrate-only discipline)

Per the 074/075 pattern, the runtime wiring lives in a follow-up so each PR stays small:
- HTTP handler `GET /swarm/lessons/{id}/proof` (calls `get_lesson_evidence`, uses `buildInclusionProof` from `services/evidence-merkle.ts`)
- Wire-validator rules **17** (`inclusion_proofs.length === evidence_count`) and **18** (every `merkle_path` reconstructs `evidence_root`)
- Privacy-invariant test that the response body never contains unhashed UUID-shaped fields tied to local experiences
- 410 (Gone) response path for forgotten/superseded lessons (needs a tombstone table or the existing forget audit-trail)
- Producer-flow TS code that calls `record_lesson_evidence` at lesson-publish time (no v1.1 publishing flow exists yet — the SQL substrate ships now, the producer wires up when the publishing path lands)

## Test plan

- [x] `npm run build` clean (mcp-server)
- [x] `npm test` — 401 / 401 pass (was 383, **+18 new** contract pins)
- [x] Migration is `DROP`/`DELETE`/`TRUNCATE`-free on `lesson_evidence_origin` (substrate-only invariant pinned by test)
- [ ] Reed runs `bash scripts/migrate.sh` after merge
- [ ] Follow-up PR (stacked on #118) wires the HTTP handler + wire-validator rules 17/18

Closes part of #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)