### PR TITLE
feat(swarm): wire-validator v1.1 — rules 16 + 20 (#102, sub-phase 4b)

### DIFF
--- a/mcp-server/src/__tests__/wire-validator.test.ts
+++ b/mcp-server/src/__tests__/wire-validator.test.ts
@@ -60,6 +60,11 @@ function attachSignature(
 // ---------------------------------------------------------------------------
 
 function buildValidLesson(producer: Identity): Record<string, unknown> {
+  // WIRE_SPEC_VERSION is "1.1", so the fixture MUST carry the five PoK
+  // fields specified in SWARM_SPEC §3.1 — otherwise rule 2 (presence)
+  // would reject. The values are minimal but spec-shaped: a 32-byte-ish
+  // multihash placeholder, evidence_count >= 1, prev_lesson_hash=null
+  // (this lesson stands as if it were the producer's very first).
   const unsigned = {
     id: "11111111-2222-3333-4444-555555555555",
     content: "Lessons must be generalized before they leave a node.",
@@ -70,6 +75,30 @@ function buildValidLesson(producer: Identity): Record<string, unknown> {
     created_at: "2026-04-27T10:00:00.000Z",
     tags: ["test", "swarm"],
     spec_version: WIRE_SPEC_VERSION,
+    evidence_root: "1220" + "ab".repeat(32),
+    evidence_count: 4,
+    prev_lesson_hash: null,
+    maturity_age_days: 1,
+    useful_count: 0,
+  };
+  return attachSignature(unsigned, producer.pem);
+}
+
+/**
+ * Backward-compat fixture: a v1.0 record served by an older producer to a
+ * v1.1 receiver. Per SWARM_SPEC §1, minor bumps are additive — a v1.1
+ * receiver MUST keep accepting v1.0 records (without PoK fields).
+ */
+function buildValidV10Lesson(producer: Identity): Record<string, unknown> {
+  const unsigned = {
+    id: "11111111-2222-3333-4444-666666666666",
+    content: "Old-style lesson without PoK fields.",
+    embedding: full768Embedding(2),
+    synthesized_from_cluster_size: 3,
+    origin_node_id: producer.nodeId,
+    signed_at: "2026-04-28T11:00:00.000Z",
+    created_at: "2026-04-27T10:00:00.000Z",
+    spec_version: "1.0",
   };
   return attachSignature(unsigned, producer.pem);
 }
@@ -416,4 +445,196 @@ test("rule 5: unknown origin_node_id (no pubkey resolver hit) is rejected", asyn
     getPubkeyForNode: () => null,
   });
   expectErr(result, 5);
+});
+
+// ---------------------------------------------------------------------------
+// v1.1 PoK rules — sub-phase 4b (issue #102)
+//
+// Rules 16 + 20 plus the rule-2 presence checks for the five new fields.
+// Rules 17/18/19 are out-of-band (they require a fetched proof or a
+// receiver-side prev-lesson cache) and live in their own sub-phases.
+// ---------------------------------------------------------------------------
+
+test("backward-compat: a v1.0 Lesson is still accepted by a v1.1 receiver", async () => {
+  const producer = freshIdentity();
+  const record = buildValidV10Lesson(producer);
+  const result = await validateWireRecord(record, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  assert.equal(result.ok, true);
+});
+
+test("rule 16: v1.1 Lesson with evidence_count = 0 is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer);
+  const { signature: _omit, ...unsigned } = valid;
+  const broken = attachSignature(
+    { ...unsigned, evidence_count: 0 },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 16);
+});
+
+test("rule 16: v1.1 Lesson with non-integer evidence_count is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer);
+  const { signature: _omit, ...unsigned } = valid;
+  const broken = attachSignature(
+    { ...unsigned, evidence_count: 2.5 },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 16);
+});
+
+test("rule 20: v1.1 Lesson with maturity_age_days < 0 is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer);
+  const { signature: _omit, ...unsigned } = valid;
+  const broken = attachSignature(
+    { ...unsigned, maturity_age_days: -1 },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 20);
+});
+
+test("rule 20: v1.1 Lesson with useful_count < 0 is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer);
+  const { signature: _omit, ...unsigned } = valid;
+  const broken = attachSignature(
+    { ...unsigned, useful_count: -3 },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 20);
+});
+
+test("rule 20: v1.0 Lesson carrying a v1.1 field (cross-version smuggling) is rejected", async () => {
+  const producer = freshIdentity();
+  const v10 = buildValidV10Lesson(producer);
+  const { signature: _omit, ...unsigned } = v10;
+  // Sneak a single PoK field into an otherwise-valid v1.0 record. Rule 20's
+  // third leg fires on ANY v1.1 field, not just all five.
+  const broken = attachSignature(
+    { ...unsigned, evidence_root: "1220" + "cd".repeat(32) },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 20);
+});
+
+test("rule 20: v1.0 Lesson carrying useful_count alone is rejected (single-field smuggle)", async () => {
+  const producer = freshIdentity();
+  const v10 = buildValidV10Lesson(producer);
+  const { signature: _omit, ...unsigned } = v10;
+  const broken = attachSignature(
+    { ...unsigned, useful_count: 7 },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 20);
+});
+
+test("rule 2: v1.1 Lesson missing evidence_root is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer) as Record<string, unknown>;
+  delete valid.evidence_root;
+  const result = await validateWireRecord(valid, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 2);
+});
+
+test("rule 2: v1.1 Lesson missing prev_lesson_hash (not even null) is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer) as Record<string, unknown>;
+  delete valid.prev_lesson_hash;
+  const result = await validateWireRecord(valid, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 2);
+});
+
+test("rule 3: v1.1 Lesson with prev_lesson_hash typed as number is rejected", async () => {
+  const producer = freshIdentity();
+  const valid = buildValidLesson(producer);
+  const { signature: _omit, ...unsigned } = valid;
+  const broken = attachSignature(
+    { ...unsigned, prev_lesson_hash: 42 },
+    producer.pem
+  );
+  const result = await validateWireRecord(broken, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  expectErr(result, 3);
+});
+
+test("v1.1 Lesson with prev_lesson_hash = null (first-ever-published) is accepted", async () => {
+  // Already covered implicitly by buildValidLesson, but pinned explicitly so
+  // a future tightening that demands a non-null hash trips this guard.
+  const producer = freshIdentity();
+  const record = buildValidLesson(producer);
+  const result = await validateWireRecord(record, "lesson", {
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    getPubkeyForNode: makePubkeyResolver(
+      new Map([[producer.nodeId, producer.pubkeyRaw]])
+    ),
+  });
+  assert.equal(result.ok, true);
 });

--- a/mcp-server/src/services/wire-validator.ts
+++ b/mcp-server/src/services/wire-validator.ts
@@ -167,14 +167,34 @@ function checkEmbedding(value: unknown): ValidationErr | null {
 }
 
 /** Parse `<major>.<minor>` per SWARM_SPEC §1. Returns null if malformed. */
-function parseSpecMajor(specVersion: string): number | null {
+function parseSpec(specVersion: string): { major: number; minor: number } | null {
   // Spec §1: decimal integers, no leading zeros, no whitespace. Single-digit
   // majors are common ("1.0"), multi-digit minors are valid ("1.10"); we
   // accept any non-leading-zero decimal pair.
   const m = specVersion.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
   if (!m) return null;
-  return Number(m[1]);
+  return { major: Number(m[1]), minor: Number(m[2]) };
 }
+
+// v1.1 Proof-of-Knowledge field set on Lesson (SWARM_SPEC §3.1, §3.7).
+// `prev_lesson_hash` is intentionally absent here because its type is
+// `string | null` (first-ever-published lesson uses null) — the generic
+// string-or-array typing pass cannot express that union, so it is checked
+// inline below.
+const LESSON_V11_REQUIRED: readonly FieldSpec[] = [
+  { name: "evidence_root", type: "string" },
+  { name: "evidence_count", type: "number" },
+  { name: "maturity_age_days", type: "number" },
+  { name: "useful_count", type: "number" },
+];
+
+const LESSON_V11_FIELD_NAMES = [
+  "evidence_root",
+  "evidence_count",
+  "prev_lesson_hash",
+  "maturity_age_days",
+  "useful_count",
+] as const;
 
 /** Parse an ISO-8601 timestamp into ms-epoch, or null if unparseable. */
 function parseTimestamp(s: string): number | null {
@@ -232,17 +252,17 @@ export async function validateWireRecord(
   // Rule 1: spec_version major. Done after presence/type so we know the
   // field is at least a string before we try to parse it.
   const specVersion = record.spec_version as string;
-  const major = parseSpecMajor(specVersion);
-  if (major === null) {
+  const spec = parseSpec(specVersion);
+  if (spec === null) {
     // A string that isn't a valid <major>.<minor> is a type-shape problem
     // for that field — it can't pass spec-version negotiation but it isn't
     // a major mismatch in the rule-1 sense either. Surface as rule 3.
     return fail(3, `spec_version "${specVersion}" is not a valid <major>.<minor>`);
   }
-  if (major !== opts.ourSpecMajor) {
+  if (spec.major !== opts.ourSpecMajor) {
     return fail(
       1,
-      `spec_version major ${major} != receiver's major ${opts.ourSpecMajor}`
+      `spec_version major ${spec.major} != receiver's major ${opts.ourSpecMajor}`
     );
   }
 
@@ -316,6 +336,75 @@ export async function validateWireRecord(
         11,
         `Lesson.synthesized_from_cluster_size must be >= 2, got ${n}`
       );
+    }
+  }
+
+  // SWARM_SPEC §5 v1.1 additions for Lesson — rules 16 and 20 (rules
+  // 17/18/19 are out-of-band: 17/18 require a fetched proof, 19 requires
+  // the receiver's prev-lesson cache).
+  //
+  // The minor-version split is: v1.0 records MUST NOT carry the five
+  // PoK fields (rule 20 third leg, the cross-version smuggling guard);
+  // v1.1+ records MUST carry all five (rule 2 — required-field presence)
+  // and satisfy the count floors (rules 16 + 20 first/second legs).
+  if (kind === "lesson") {
+    const v11FieldsPresent = LESSON_V11_FIELD_NAMES.filter(
+      (f) => f in record && record[f] !== undefined
+    );
+
+    if (spec.major === 1 && spec.minor === 0) {
+      // Rule 20 (third leg): v1.0 records MUST NOT carry v1.1 fields.
+      // Even one PoK field on a "1.0" record is forbidden — this is the
+      // cross-version smuggling check, not a "best-effort additive" path.
+      if (v11FieldsPresent.length > 0) {
+        return fail(
+          20,
+          `v1.1 fields present on spec_version="1.0" record: ${v11FieldsPresent.join(", ")}`
+        );
+      }
+    } else if (spec.major === 1 && spec.minor >= 1) {
+      // Rule 2 / 3 for the four typed v1.1 required fields.
+      const v11Err = checkPresentAndTyped(record, LESSON_V11_REQUIRED);
+      if (v11Err) return v11Err;
+
+      // prev_lesson_hash: required, but typed `string | null`. The generic
+      // helper above does not encode the union, so handle it inline.
+      // Presence is the absence of the JS-undefined sentinel; explicit
+      // `null` is allowed (first-ever-published lesson, §3.1).
+      if (!("prev_lesson_hash" in record) || record.prev_lesson_hash === undefined) {
+        return fail(2, `missing required field: prev_lesson_hash`);
+      }
+      const prevHash = record.prev_lesson_hash;
+      if (prevHash !== null && typeof prevHash !== "string") {
+        return fail(
+          3,
+          `prev_lesson_hash must be string or null, got ${typeof prevHash}`
+        );
+      }
+
+      // Rule 16: evidence_count must be a positive integer.
+      const evCount = record.evidence_count as number;
+      if (!Number.isInteger(evCount) || evCount < 1) {
+        return fail(16, `Lesson.evidence_count must be an integer >= 1, got ${evCount}`);
+      }
+
+      // Rule 20 (first leg): maturity_age_days >= 0.
+      const maturity = record.maturity_age_days as number;
+      if (!Number.isInteger(maturity) || maturity < 0) {
+        return fail(
+          20,
+          `Lesson.maturity_age_days must be a non-negative integer, got ${maturity}`
+        );
+      }
+
+      // Rule 20 (second leg): useful_count >= 0.
+      const useful = record.useful_count as number;
+      if (!Number.isInteger(useful) || useful < 0) {
+        return fail(
+          20,
+          `Lesson.useful_count must be a non-negative integer, got ${useful}`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Closes the runtime half of issue #102 (sub-phase 4b). PR #106 already shipped scope #1 (the v1.1 fields on the wire-types `Lesson` interface); this PR delivers scope #2 (validator rejection rules 16 + 20) and scope #3 (v1.1 fixture tests).

## What runs now

- **Rule 16** — `evidence_count < 1` on a v1.1 `Lesson` → drop.
- **Rule 20** — `maturity_age_days < 0` OR `useful_count < 0` on a v1.1 `Lesson` → drop. Also, **any** of the five PoK fields present on a `spec_version="1.0"` record → drop (cross-version smuggling).
- **Rule 2 / 3** for the four typed v1.1 required fields, plus the `string | null` union on `prev_lesson_hash`.

## Out of scope (later sub-phases)

- **Rule 17 / 18** — Merkle root + leaf count checks require a fetched proof, that's the consumer side of 4e.
- **Rule 19** — `prev_lesson_hash` chain check requires the receiver-side prev-lesson cache, that's 4d's consumer half.

## Backward compat

A fresh test pins that a `spec_version="1.0"` record without PoK fields is still accepted by a v1.1 receiver — additive minor bumps per SWARM_SPEC §1 are non-breaking.

The existing `buildValidLesson` fixture already used `spec_version="1.1"` but was missing the PoK fields; after this change it carries spec-shaped values so the happy path stays green and reflects what a real v1.1 producer emits.

## Test plan

- [x] `npm test` green: 394 pass (+11 new), 0 fail
- [x] All v1.0 records still validate (backward-compat fixture)
- [x] Rule 16 fires on `evidence_count = 0` and on non-integer counts
- [x] Rule 20 fires on each negative-count leg and on cross-version smuggling
- [x] Rule 2 fires when v1.1 fields are missing on a v1.1 record
- [x] `prev_lesson_hash = null` accepted (first-ever-published lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)