### PR TITLE
docs(swarm): fix 4i status row — migration 076 → 078

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -627,7 +627,7 @@ swarm-labelled phase merges to `main`.
 | 4f — TrustEdge auto-tuning + quarantine (migration 075) | §10.1, §10.2 | [#107](https://github.com/Dewinator/mycelium/issues/107) | — | ⏳ spec-only |
 | 4g — ConscienceAgent contradicts-trigger | §10.3 | [#108](https://github.com/Dewinator/mycelium/issues/108) | — | ⏳ spec-only |
 | 4h — REM self-audit pass | §10.5 | [#109](https://github.com/Dewinator/mycelium/issues/109) | — | ⏳ spec-only |
-| 4i — Two-tier pinning + diversity policy (migration 076) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | — | ⏳ spec-only |
+| 4i — Two-tier pinning + diversity policy (migration 078) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | — | ⏳ spec-only |
 | 5 — Outbound peer discovery / gossip client | §3, §7 | _not yet issued_ | — | ⏳ spec-only |
 | 6 — Lesson publishing pipeline (producer side) | §4, §6 | _not yet issued_ | — | ⏳ spec-only |
 | 7 — Lesson ingestion pipeline (consumer side) | §5, §7 | _not yet issued_ | — | ⏳ spec-only |


### PR DESCRIPTION
## Summary

The §9 implementation-status table in `docs/SWARM_SPEC.md` referenced "migration 076" for sub-phase 4i (issue #114), but slot 076 was claimed by sub-phase 4g (PR #121's `076_lesson_contradictions.sql`, since renamed to 080 to avoid colliding with 078's `lesson_tier` work). The actual 4i migration shipping in PR #124 is `078_lesson_tiers.sql`.

PR #124's own slot note already documents the rename — *"the 4i issue body referenced 076_lesson_tiers.sql, but slot 076 was claimed by PR #121"* — but the status table itself was never corrected. This brings the spec text in line with the migration that actually ships.

## Why this is a separate PR

- PR #124's scope is migration + tests; bundling a spec edit would muddy its review surface.
- Other 4* rows (4b/4c via #118, 4g via #121) are intentionally left for their own PRs to update on merge, per the table's stated discipline: *"Update this table whenever a swarm-labelled phase merges to `main`."*
- This single-line fix is a factual error (slot 076 doesn't exist; 4i ≠ 076), independent of any unmerged scope.

## Conflict surface

- PRs #118 and #121 modify rows 4b/4c and 4g respectively. This PR only touches row 4i. Git's line-level merge handles disjoint table rows cleanly — verified by inspecting the three diffs.

## Test plan

- [x] `git diff` shows a single-character change (`076` → `078`) on one line.
- [x] No code, build, or migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)