### PR TITLE
docs(swarm): refresh §9 implementation status table

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -629,7 +629,7 @@ swarm-labelled phase merges to `main`.
 | 4h — REM self-audit pass (§10.5 falsification arrow) | §10.5 | [#109](https://github.com/Dewinator/mycelium/issues/109) | `8cad92f` | ✅ on `main` |
 | 4i.1 — Two-tier pinning + broadcast firewall (migration 078) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | `db98ea0` | ✅ on `main` |
 | 4i.2 — REM promotion-audit Tier-B → Tier-A (migration 081, §10.6 promote arrow) | §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | — | 🟡 PR [#129](https://github.com/Dewinator/mycelium/pull/129) open |
-| 4i.3 — Anti-echo-chamber receiver-cohort diversity pass | §10.4 | _not yet issued_ | — | ⏳ spec-only |
+| 4i.3 — Anti-echo-chamber receiver-cohort diversity pass (migration 082) | §10.4 | [#114](https://github.com/Dewinator/mycelium/issues/114) | — | 🟡 PR [#131](https://github.com/Dewinator/mycelium/pull/131) open |
 | 4i.4 — Producer-side Tier-A tagging on local-lesson insert | §10.6 | _not yet issued_ | — | ⏳ spec-only |
 | 5 — Outbound peer discovery / gossip client | §3, §7 | _not yet issued_ | — | ⏳ spec-only |
 | 6 — Lesson publishing pipeline (producer side) | §4, §6 | _not yet issued_ | — | ⏳ spec-only |
@@ -638,8 +638,8 @@ swarm-labelled phase merges to `main`.
 | 9 — Diversity-preserving sync policy | §0.3, §10.4 | _not yet issued_ | — | ⏳ spec-only |
 
 Phase 4 is now substantially landed: 4a–4c, 4f–4h, and 4i.1 are on `main`;
-4d, 4e (endpoint), and 4i.2 are open PRs awaiting Reed's manual merge;
-4i.3 and 4i.4 are the residual sub-phases scoped out of 4i.2 (PR #129).
+4d, 4e (endpoint), 4i.2, and 4i.3 are open PRs awaiting Reed's manual merge;
+4i.4 is the residual producer-side tagging sub-phase, still spec-only.
 Phases 5–9 remain spec-only — the project's current priority stays
 *Gehirn perfektionieren* (see [`CLAUDE.md` § Roadmap (Reed 2026-04-26)](../CLAUDE.md)).
 The wire contract is frozen at v1.1 so an independent implementer can

--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -620,26 +620,31 @@ swarm-labelled phase merges to `main`.
 | 3c — `GET /.well-known/mycelium-node` advertisement | §3.2 | [#87](https://github.com/Dewinator/mycelium/issues/87) | `be59267` | ✅ on `main` |
 | 3d — Peer + signed-record storage (migration 071) | §6 | [#88](https://github.com/Dewinator/mycelium/issues/88) | `b0eca59` | ✅ on `main` |
 | 4a — PoK + self-healing spec (v1.1) | §3.1, §3.7, §4.6, §5 (16–20), §10 | [#100](https://github.com/Dewinator/mycelium/issues/100) | `3292bd6` | ✅ on `main` |
-| 4b — `wire-types.ts` v1.1 fields + JCS validator update | §3.1 | [#102](https://github.com/Dewinator/mycelium/issues/102) | `a33a5e5` | ✅ on `main` |
-| 4c — Evidence Merkle builder service | §3.7.1 | [#103](https://github.com/Dewinator/mycelium/issues/103) | _PR pending_ | 🟡 implemented |
-| 4d — `prev_lesson_hash` chain table (migration 074) | §3.7.2 | [#104](https://github.com/Dewinator/mycelium/issues/104) | — | ⏳ spec-only |
-| 4e — `/swarm/lessons/{id}/proof` endpoint | §4.6 | [#105](https://github.com/Dewinator/mycelium/issues/105) | — | ⏳ spec-only |
-| 4f — TrustEdge auto-tuning + quarantine (migration 075) | §10.1, §10.2 | [#107](https://github.com/Dewinator/mycelium/issues/107) | — | ⏳ spec-only |
-| 4g — ConscienceAgent contradicts-trigger (migration 080) | §10.3 | [#108](https://github.com/Dewinator/mycelium/issues/108) | _PR pending_ | 🟡 in review |
-| 4h — REM self-audit pass | §10.5 | [#109](https://github.com/Dewinator/mycelium/issues/109) | — | ⏳ spec-only |
-| 4i — Two-tier pinning + diversity policy (migration 078) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | — | ⏳ spec-only |
+| 4b — `wire-types.ts` v1.1 fields + JCS validator update | §3.1 | [#102](https://github.com/Dewinator/mycelium/issues/102) | `a33a5e5`, `dd68ab0` | ✅ on `main` |
+| 4c — Evidence Merkle builder service | §3.7.1 | [#103](https://github.com/Dewinator/mycelium/issues/103) | `289ac96` | ✅ on `main` |
+| 4d — `prev_lesson_hash` chain table (migration 074) | §3.7.2 | [#104](https://github.com/Dewinator/mycelium/issues/104) | — | 🟡 PR [#119](https://github.com/Dewinator/mycelium/pull/119) open |
+| 4e — `/swarm/lessons/{id}/proof` endpoint | §4.6 | [#105](https://github.com/Dewinator/mycelium/issues/105) | `a78f436` (substrate) | 🟡 endpoint PR [#128](https://github.com/Dewinator/mycelium/pull/128) open |
+| 4f — TrustEdge auto-tuning + quarantine (migration 075) | §10.1, §10.2 | [#107](https://github.com/Dewinator/mycelium/issues/107) | `25bf3a8` | ✅ on `main` |
+| 4g — ConscienceAgent contradicts-trigger (migration 080) | §10.3 | [#108](https://github.com/Dewinator/mycelium/issues/108) | `6d59674` | ✅ on `main` |
+| 4h — REM self-audit pass (§10.5 falsification arrow) | §10.5 | [#109](https://github.com/Dewinator/mycelium/issues/109) | `8cad92f` | ✅ on `main` |
+| 4i.1 — Two-tier pinning + broadcast firewall (migration 078) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | `db98ea0` | ✅ on `main` |
+| 4i.2 — REM promotion-audit Tier-B → Tier-A (migration 081, §10.6 promote arrow) | §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | — | 🟡 PR [#129](https://github.com/Dewinator/mycelium/pull/129) open |
+| 4i.3 — Anti-echo-chamber receiver-cohort diversity pass | §10.4 | _not yet issued_ | — | ⏳ spec-only |
+| 4i.4 — Producer-side Tier-A tagging on local-lesson insert | §10.6 | _not yet issued_ | — | ⏳ spec-only |
 | 5 — Outbound peer discovery / gossip client | §3, §7 | _not yet issued_ | — | ⏳ spec-only |
 | 6 — Lesson publishing pipeline (producer side) | §4, §6 | _not yet issued_ | — | ⏳ spec-only |
 | 7 — Lesson ingestion pipeline (consumer side) | §5, §7 | _not yet issued_ | — | ⏳ spec-only |
 | 8 — `HubAnchor` exchange | §4 | _not yet issued_ | — | ⏳ spec-only |
 | 9 — Diversity-preserving sync policy | §0.3, §10.4 | _not yet issued_ | — | ⏳ spec-only |
 
-Phases 4b–9 are spec-only after this revision lands — the project's
-current priority remains *Gehirn perfektionieren* (see [`CLAUDE.md` §
-Roadmap (Reed 2026-04-26)](../CLAUDE.md)). The wire contract is frozen
-at v1.1 so an independent implementer can already build a v1.1-equivalent
-peer with full PoK and self-healing semantics, and be guaranteed to
-remain compatible once 4b+ lands here.
+Phase 4 is now substantially landed: 4a–4c, 4f–4h, and 4i.1 are on `main`;
+4d, 4e (endpoint), and 4i.2 are open PRs awaiting Reed's manual merge;
+4i.3 and 4i.4 are the residual sub-phases scoped out of 4i.2 (PR #129).
+Phases 5–9 remain spec-only — the project's current priority stays
+*Gehirn perfektionieren* (see [`CLAUDE.md` § Roadmap (Reed 2026-04-26)](../CLAUDE.md)).
+The wire contract is frozen at v1.1 so an independent implementer can
+already build a v1.1-equivalent peer with full PoK and self-healing
+semantics, and remain compatible once the residual sub-phases land here.
 
 ---
 


### PR DESCRIPTION
## Summary

The §9 status table in `docs/SWARM_SPEC.md` had drifted significantly from `main`. Six sub-phases that have landed (4c, 4d-substrate, 4e-substrate, 4f, 4g, 4h, 4i.1) were still labelled "spec-only" or "PR pending"; three open PRs (#119 / #128 / #129) had no row state at all; and the omnibus 4i row hid the four-way decomposition (4i.1 firewall, 4i.2 promotion-audit, 4i.3 receiver-cohort diversity, 4i.4 producer-side Tier-A tagging) that was scoped out in PR #129's body.

## Changes

- Update `4b` row to also list `dd68ab0` (#123 — runtime half: rules 16/20 + v1.1 presence).
- Mark `4c` (`289ac96`), `4f` (`25bf3a8`), `4g` (`6d59674`), `4h` (`8cad92f`), and `4i.1` (`db98ea0`) ✅ on `main` with their merged-commit hashes.
- Mark `4d`, `4e` (endpoint), and `4i.2` 🟡 with links to their open PRs (#119 / #128 / #129).
- Split the single `4i` row into `4i.1` … `4i.4` so the residual receiver-cohort and producer-side-tagging work is visible in the table, not hidden in a PR body.
- Rewrite the trailing paragraph — *"Phases 4b–9 are spec-only after this revision lands"* was outright wrong now; replaced with an accurate snapshot.

## Out of scope

No spec changes — this is documentation only. The wire contract stays frozen at v1.1.

## Test plan

- [x] `git diff` reviewed — only `docs/SWARM_SPEC.md` lines 622–642 affected
- [x] All commit hashes cross-checked against `git log` on `main`
- [x] All PR numbers cross-checked against `gh pr list --state open`
- [ ] Reed merges manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)