### PR TITLE
feat(swarm): §10.4 anti-echo-chamber diversity substrate — sub-phase 4i.3 (#114)

### DIFF
--- a/mcp-server/src/__tests__/migration-082-swarm-lesson-diversity.test.ts
+++ b/mcp-server/src/__tests__/migration-082-swarm-lesson-diversity.test.ts
@@ -1,0 +1,244 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 082 — §10.4 anti-echo-chamber substrate (#114, sub-phase 4i.3)
+//
+// Same defensive contract-pin pattern as migration-070..081 tests: read
+// the SQL, normalise it, regex-pin every load-bearing structural invariant.
+// The autonomy loop cannot execute migrations (Reed runs them by hand
+// after merge) so contract tests live at the SQL-text level.
+//
+// Pins three groups of contracts that any future edit MUST keep:
+//   1. swarm_lessons.local_weight column (DEFAULT 1.0, CHECK 0..1, indexed).
+//   2. lesson_diversity_log append-only audit table — including the
+//      (new_weight <= prev_weight) CHECK that encodes §10.4's "decrease
+//      ... rather than increase" wording at the SQL layer.
+//   3. rem_diversity_check_lessons RPC — 6-arg STABLE signature, 7-col
+//      return shape, local-only invariant (only swarm_lessons), all six
+//      thresholds parameterised, GRANTed to anon + service_role.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/082_swarm_lesson_diversity.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so prose like
+// "no DROP" inside a comment cannot accidentally satisfy or violate a
+// structural assertion below.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent
+// or keyword-case drift without weakening the structural contracts.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) swarm_lessons.local_weight column
+// ---------------------------------------------------------------------------
+
+test("swarm_lessons gets local_weight column with DEFAULT 1.0 and 0..1 CHECK", () => {
+  // The DEFAULT 1.0 is the no-op anchor: every existing row keeps full
+  // weight until §10.4 ratchets it down. Without it, the existing
+  // swarm_lessons rows would be NULL on a column declared NOT NULL — the
+  // ALTER would fail on the first node that runs the migration with data.
+  assert.match(
+    SQL,
+    /alter table swarm_lessons\s+add column if not exists local_weight real not null default 1\.0\s+check\s*\(\s*local_weight >= 0 and local_weight <= 1\s*\)/,
+  );
+});
+
+test("swarm_lessons gets a btree index on local_weight", () => {
+  // Future recall queries that filter / order by local_weight (§10.4 says
+  // the lesson's influence is reduced — the natural query is "give me
+  // lessons with local_weight above some floor") need an index to avoid
+  // a sequential scan on a growing swarm_lessons table.
+  assert.match(SQL, /create index if not exists swarm_lessons_local_weight_idx\s+on swarm_lessons \(local_weight\)/);
+});
+
+// ---------------------------------------------------------------------------
+// (2) lesson_diversity_log append-only audit table
+// ---------------------------------------------------------------------------
+
+test("lesson_diversity_log table has the required columns + types", () => {
+  // Pin the column shape — the rem-diversity service writes against this
+  // exact set. Renaming or dropping any column is a silent contract break.
+  assert.match(SQL, /create table if not exists lesson_diversity_log\b/);
+  assert.match(SQL, /lesson_id\s+uuid\s+not null references swarm_lessons\(id\) on delete cascade/);
+  assert.match(SQL, /prev_weight\s+real\s+not null check\s*\(\s*prev_weight >= 0 and prev_weight <= 1\s*\)/);
+  assert.match(SQL, /new_weight\s+real\s+not null check\s*\(\s*new_weight\s+>= 0 and new_weight\s+<= 1\s*\)/);
+  assert.match(SQL, /topic_cohort_size\s+int\s+not null check\s*\(\s*topic_cohort_size >= 1\s*\)/);
+  assert.match(SQL, /near_dup_origin_count\s+int\s+not null check\s*\(\s*near_dup_origin_count >= 1\s*\)/);
+  assert.match(SQL, /over_concentration\s+float\s+not null check\s*\(\s*over_concentration >= 0 and over_concentration <= 1\s*\)/);
+  assert.match(SQL, /reason\s+text\s+not null check\s*\(\s*octet_length\(reason\) <= 512\s*\)/);
+  assert.match(SQL, /near_dup_lesson_ids\s+uuid\[\]\s+not null default '\{\}'/);
+});
+
+test("lesson_diversity_log enforces (new_weight <= prev_weight) at the SQL layer", () => {
+  // The §10.4 spec wording is "decrease its local weight ... rather than
+  // increase". This CHECK is the single most important contract on this
+  // migration: it makes accidental amplification structurally impossible,
+  // not application-discipline-dependent.
+  assert.match(SQL, /check \(new_weight <= prev_weight\)/);
+});
+
+test("lesson_diversity_log has an index on (lesson_id, at DESC) for audit lookups", () => {
+  // The natural operator query is "what's the audit history for THIS
+  // lesson?" — a (lesson_id, at DESC) index supports the most recent-first
+  // scan without a sort step.
+  assert.match(SQL, /create index if not exists lesson_diversity_log_lesson_idx\s+on lesson_diversity_log \(lesson_id, at desc\)/);
+});
+
+// ---------------------------------------------------------------------------
+// (3) rem_diversity_check_lessons signature + parameters
+// ---------------------------------------------------------------------------
+
+test("rem_diversity_check_lessons has the documented 6-arg signature", () => {
+  // Param order matters because callers (services/rem-diversity.ts) bind
+  // by name via supabase-js, but the named-args RPC convention still
+  // relies on the database knowing the parameter list. A reorder here
+  // would be a silent ABI change.
+  assert.match(
+    SQL,
+    /create or replace function rem_diversity_check_lessons\s*\(\s*p_topic_cosine\s+float\s+default\s+0\.85\s*,\s*p_duplicate_cosine\s+float\s+default\s+0\.95\s*,\s*p_evidence_count_band\s+int\s+default\s+1\s*,\s*p_signed_at_window_d\s+int\s+default\s+7\s*,\s*p_min_cohort_size\s+int\s+default\s+3\s*,\s*p_over_concentration\s+float\s+default\s+0\.8\s*\)/,
+  );
+});
+
+test("rem_diversity_check_lessons is declared STABLE (read-only side-effect class)", () => {
+  // STABLE marks a pure read RPC: PG can cache results within a query, and
+  // crucially it documents to operators that this function does not mutate
+  // any rows. A future edit that turns it VOLATILE would silently broaden
+  // the contract.
+  assert.match(SQL, /language sql\s+stable\b/);
+});
+
+test("rem_diversity_check_lessons returns the documented 7 columns", () => {
+  // Pin the return shape: the rem-diversity service consumes every one of
+  // these columns. Renaming or dropping any of them is a silent breaking
+  // change at the JS/SQL boundary.
+  assert.match(
+    SQL,
+    /returns table\s*\(\s*swarm_lesson_id\s+uuid\s*,\s*origin_node_id\s+text\s*,\s*swarm_lesson_text\s+text\s*,\s*topic_cohort_size\s+int\s*,\s*near_dup_origin_count\s+int\s*,\s*over_concentration\s+float\s*,\s*near_dup_lesson_ids\s+uuid\[\]\s*\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) Local-only invariant — function reads ONLY swarm_lessons
+// ---------------------------------------------------------------------------
+
+test("rem_diversity_check_lessons reads from swarm_lessons", () => {
+  // The receiver-side per-peer concentration signal is a swarm-table-only
+  // signal. Pin the FROM clause so a future edit can't silently broaden
+  // the source set.
+  assert.match(SQL, /from swarm_lessons\b/);
+});
+
+test("rem_diversity_check_lessons does NOT read experiences or local lessons", () => {
+  // §10.4 is explicitly about peer concentration — joining `experiences`
+  // or `lessons` would mix lived-evidence signal into a diversity check
+  // that is supposed to operate on inter-peer over-concentration. Pin the
+  // absence so a future edit can't accidentally widen the source set.
+  assert.doesNotMatch(SQL, /\bjoin\s+experiences\b/);
+  assert.doesNotMatch(SQL, /\bfrom\s+experiences\b/);
+  assert.doesNotMatch(SQL, /\bjoin\s+lessons\b/);
+  assert.doesNotMatch(SQL, /\bfrom\s+lessons\b/);
+});
+
+test("rem_diversity_check_lessons does NOT cross-reference other swarm tables", () => {
+  // swarm_hub_anchors, swarm_lesson_contradictions, tier_promotion_log,
+  // trust_edge_log all exist; pulling them into the diversity pass would
+  // mix in tier / contradiction / trust signals that are not part of §10.4.
+  // Pin the absence.
+  assert.doesNotMatch(SQL, /\bjoin\s+swarm_hub_anchors\b/);
+  assert.doesNotMatch(SQL, /\bjoin\s+swarm_lesson_contradictions\b/);
+  assert.doesNotMatch(SQL, /\bjoin\s+tier_promotion_log\b/);
+  assert.doesNotMatch(SQL, /\bjoin\s+trust_edge_log\b/);
+  assert.doesNotMatch(SQL, /\bjoin\s+nodes\b/);
+});
+
+// ---------------------------------------------------------------------------
+// (5) Threshold parameters — every gate flows from a parameter, not a literal
+// ---------------------------------------------------------------------------
+
+test("rem_diversity_check_lessons uses p_topic_cosine for the topic-cohort cosine bound", () => {
+  // Operators tune topic coverage per their audit aggressiveness.
+  assert.match(SQL, /\(\s*1 - \(\s*other\.embedding <=> l\.embedding\s*\)\s*\) >= p_topic_cosine/);
+});
+
+test("rem_diversity_check_lessons uses p_duplicate_cosine for the near-duplicate cosine bound", () => {
+  // §10.4 spec text: "cosine_similarity > 0.95" — pin that the bound is
+  // the parameter, defaulted to that value, not a hard-coded literal.
+  assert.match(SQL, /\(\s*1 - \(\s*other\.embedding <=> tc\.center_emb\s*\)\s*\) >= p_duplicate_cosine/);
+});
+
+test("rem_diversity_check_lessons uses p_evidence_count_band for the evidence-count similarity gate", () => {
+  // §10.4 spec text: "evidence_count similar" — implementation-defined.
+  // We use |Δ| <= band and surface the band as a parameter so a future
+  // operator can loosen / tighten without a migration.
+  assert.match(SQL, /abs\(\s*other\.evidence_count - tc\.center_evidence\s*\) <= p_evidence_count_band/);
+});
+
+test("rem_diversity_check_lessons uses p_signed_at_window_d for the signed_at proximity gate", () => {
+  // §10.4 spec text: "signed_at within 7 days" — pin parameter binding.
+  assert.match(SQL, /abs\(\s*extract\(epoch from \(\s*other\.signed_at - tc\.center_signed_at\s*\)\)\s*\) <= \(\s*p_signed_at_window_d \* 86400\s*\)/);
+});
+
+test("rem_diversity_check_lessons enforces p_min_cohort_size as a statistical floor", () => {
+  // A 1-peer cohort cannot meaningfully be over-concentrated; the floor
+  // exists so a brand-new node with one peer doesn't decrement every
+  // single import on day one. Pin the floor as a parameter so the
+  // operator can lower it for testing without a migration.
+  assert.match(SQL, /tc\.topic_cohort_size >= p_min_cohort_size/);
+});
+
+test("rem_diversity_check_lessons enforces over_concentration via the parameter", () => {
+  // §10.4 threshold flows from the parameter, not a hard-coded 0.8.
+  // The implementation uses >= (not >) to match the issue's "4 of 5 →
+  // trigger" acceptance test, which is exactly 80%.
+  assert.match(
+    SQL,
+    /\(\s*nd\.near_dup_origin_count::float \/ nullif\(\s*tc\.topic_cohort_size\s*,\s*0\s*\)\s*\) >= p_over_concentration/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (6) GRANT EXECUTE — without it the digest pipeline hits permissions errors
+// ---------------------------------------------------------------------------
+
+test("rem_diversity_check_lessons GRANTs EXECUTE to anon + service_role", () => {
+  assert.match(
+    SQL,
+    /grant execute on function rem_diversity_check_lessons\s*\(\s*float\s*,\s*float\s*,\s*int\s*,\s*int\s*,\s*int\s*,\s*float\s*\)\s+to anon\s*,\s*service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (7) Migration discipline — additive only, no destructive DDL
+// ---------------------------------------------------------------------------
+
+test("migration 082 contains no DROP / DELETE / TRUNCATE statements", () => {
+  // The autonomy loop must never authorise destructive migrations. Same
+  // hard rule as 071 / 075 / 078 / 079 / 081 — pin it.
+  // (CREATE OR REPLACE FUNCTION is fine; that's not a DROP.)
+  assert.doesNotMatch(SQL, /\bdrop\s+(table|index|constraint|trigger|view)\b/);
+  assert.doesNotMatch(SQL, /\bdrop\s+function\b/);
+  assert.doesNotMatch(SQL, /\bdelete\s+from\b/);
+  assert.doesNotMatch(SQL, /\btruncate\b/);
+});
+
+test("migration 082 does NOT grant UPDATE/DELETE on lesson_diversity_log (append-only)", () => {
+  // The append-only contract is enforced by withholding UPDATE/DELETE
+  // grants. The migration must not introduce them; if a future operator
+  // needs to redact a row, that's a separate, manually-reviewed migration.
+  assert.doesNotMatch(SQL, /grant\s+update[^;]*\bon\s+lesson_diversity_log\b/);
+  assert.doesNotMatch(SQL, /grant\s+delete[^;]*\bon\s+lesson_diversity_log\b/);
+});

--- a/mcp-server/src/__tests__/rem-diversity.test.ts
+++ b/mcp-server/src/__tests__/rem-diversity.test.ts
@@ -1,0 +1,324 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  scoreFinding,
+  formatReason,
+  RemDiversityFinding,
+  RemDiversityService,
+  RemDiversityDeps,
+  RemDiversityOutcome,
+} from "../services/rem-diversity.js";
+
+// ---------------------------------------------------------------------------
+// REM diversity service unit tests — Swarm Phase 4i, sub-phase 4i.3 (#114).
+//
+// Two layers of coverage matching rem-audit / rem-promotion split:
+//   * Pure helpers (`scoreFinding`, `formatReason`) tested against bare
+//     object inputs — the deterministic decision boundary.
+//   * Orchestrator (`runDiversityPass` via `applyFinding`) tested against
+//     in-memory dep stubs — verifies side-effect order, no-op short-
+//     circuit, partial-failure isolation, and the (new_weight <=
+//     prev_weight) invariant at the application layer.
+// ---------------------------------------------------------------------------
+
+function makeFinding(overrides: Partial<RemDiversityFinding> = {}): RemDiversityFinding {
+  return {
+    swarm_lesson_id: "11111111-1111-1111-1111-111111111111",
+    origin_node_id:  "node-peer-x",
+    swarm_lesson_text: "swarm-imported lesson body",
+    topic_cohort_size: 5,
+    near_dup_origin_count: 4,           // 4/5 = 0.8 — the §10.4 issue's
+    over_concentration: 0.8,            // canonical "4 of 5 peers" case
+    near_dup_lesson_ids: [
+      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      "cccccccc-cccc-cccc-cccc-cccccccccccc",
+      "dddddddd-dddd-dddd-dddd-dddddddddddd",
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (1) Pure decision layer — scoreFinding
+// ---------------------------------------------------------------------------
+
+test("scoreFinding multiplies prev_weight by (1 - over_concentration)", () => {
+  // The §10.4 canonical case: 4/5 peers → over=0.8 → factor=0.2 → new
+  // weight is 20% of prev. With prev=1.0 the new weight is 0.2.
+  const r = scoreFinding(1.0, makeFinding({ over_concentration: 0.8 }));
+  assert.ok(Math.abs(r.new_weight - 0.2) < 1e-9);
+});
+
+test("scoreFinding silences a 100%-concentrated lesson entirely", () => {
+  // over=1.0 → factor=0 → new_weight=0. This is the "everyone holds the
+  // same near-duplicate" edge: the lesson contributes nothing to local
+  // recall until the cohort diversifies.
+  const r = scoreFinding(1.0, makeFinding({ over_concentration: 1.0 }));
+  assert.equal(r.new_weight, 0);
+});
+
+test("scoreFinding scales an already-decremented weight further (multiplicative)", () => {
+  // Sub-phase 4i.3 leaves stacking up to the caller. If a lesson got
+  // decremented to 0.5 in a prior cycle and a fresh diversity pass finds
+  // over=0.8 again, the new weight is 0.5 * 0.2 = 0.1. The (new_weight <=
+  // prev_weight) CHECK on lesson_diversity_log permits this (0.1 < 0.5).
+  const r = scoreFinding(0.5, makeFinding({ over_concentration: 0.8 }));
+  assert.ok(Math.abs(r.new_weight - 0.1) < 1e-9);
+});
+
+test("scoreFinding clamps over_concentration outside [0, 1] without throwing", () => {
+  // Defensive: should never see these in practice (the SQL CHECK is 0..1)
+  // but the formula must not blow up if a future RPC change lets a
+  // pathological value through.
+  const negative = scoreFinding(1.0, makeFinding({ over_concentration: -0.5 }));
+  // over clamped to 0 → factor=1 → new_weight = prev * 1 = 1.0
+  assert.equal(negative.new_weight, 1.0);
+
+  const huge = scoreFinding(1.0, makeFinding({ over_concentration: 1.7 }));
+  // over clamped to 1 → factor=0 → new_weight = 0
+  assert.equal(huge.new_weight, 0);
+});
+
+test("scoreFinding never amplifies — new_weight <= prev_weight always", () => {
+  // The application-layer guarantee that mirrors the SQL CHECK on
+  // lesson_diversity_log.(new_weight <= prev_weight). Even if a future
+  // edit accidentally inverts the formula, the min(prev, ...) clamp
+  // prevents the orchestrator from emitting an amplifying log row.
+  for (const over of [0.0, 0.3, 0.5, 0.8, 0.95, 1.0]) {
+    const r = scoreFinding(0.7, makeFinding({ over_concentration: over }));
+    assert.ok(r.new_weight <= 0.7, `over=${over} produced new_weight=${r.new_weight}`);
+    assert.ok(r.new_weight >= 0,   `over=${over} produced negative new_weight=${r.new_weight}`);
+  }
+});
+
+test("formatReason embeds spec section, cohort ratio, origin, and over value", () => {
+  const reason = formatReason(makeFinding());
+  assert.match(reason, /§10\.4/);
+  assert.match(reason, /4\/5/);
+  assert.match(reason, /node-peer-x/);
+  assert.match(reason, /over_concentration=0\.80/);
+  // Sanity: under 512 bytes (the lesson_diversity_log.reason CHECK).
+  assert.ok(Buffer.byteLength(reason, "utf8") <= 512);
+});
+
+// ---------------------------------------------------------------------------
+// (2) Orchestrator — runDiversityPass / applyFinding
+// ---------------------------------------------------------------------------
+
+interface StubLog {
+  applyCalls: Array<{
+    lessonId: string;
+    prevWeight: number;
+    newWeight: number;
+    finding: RemDiversityFinding;
+    reason: string;
+  }>;
+}
+
+function makeService(): RemDiversityService {
+  // We never hit the real RPC — runDiversityPass is exercised via a
+  // monkey-patched findOverconcentrated below. Construct with throwaway
+  // creds; SupabaseClient is lazily initialised and we won't make any
+  // network calls in tests.
+  return new RemDiversityService("http://test.invalid", "test-anon-key");
+}
+
+function makeDeps(
+  initialWeights: Map<string, number>,
+  log: StubLog,
+  opts: { failApply?: string; failRead?: string } = {},
+): RemDiversityDeps {
+  return {
+    async readLocalWeight(lessonId) {
+      if (opts.failRead === lessonId) {
+        throw new Error(`stub read fail for ${lessonId}`);
+      }
+      return initialWeights.get(lessonId) ?? 1.0;
+    },
+    async applyWeightChange(lessonId, prevWeight, newWeight, finding, reason) {
+      if (opts.failApply === lessonId) {
+        throw new Error(`stub apply fail for ${lessonId}`);
+      }
+      log.applyCalls.push({ lessonId, prevWeight, newWeight, finding, reason });
+      initialWeights.set(lessonId, newWeight);
+    },
+  };
+}
+
+test("runDiversityPass applies the weight decrement for each finding", async () => {
+  const svc = makeService();
+  const finding = makeFinding({ swarm_lesson_id: "11111111-1111-1111-1111-111111111111" });
+  // Stub the RPC layer.
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [finding];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map([[finding.swarm_lesson_id, 1.0]]);
+  const deps = makeDeps(weights, log);
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+
+  assert.equal(outcomes.length, 1);
+  const o = outcomes[0];
+  assert.equal(o.swarm_lesson_id, finding.swarm_lesson_id);
+  assert.equal(o.applied, true);
+  assert.equal(o.prev_weight, 1.0);
+  assert.ok(Math.abs(o.new_weight - 0.2) < 1e-9);
+  assert.equal(log.applyCalls.length, 1);
+  // The audit-log call carried the full finding (the audit row needs all
+  // four context columns: cohort size, dup count, over, dup ids).
+  assert.equal(log.applyCalls[0].finding.near_dup_lesson_ids.length, 4);
+});
+
+test("runDiversityPass with empty findings returns empty outcomes (no DB writes)", async () => {
+  const svc = makeService();
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map<string, number>();
+  const deps = makeDeps(weights, log);
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+  assert.deepEqual(outcomes, []);
+  assert.equal(log.applyCalls.length, 0);
+});
+
+test("applyFinding short-circuits when new_weight === prev_weight (no audit spam)", async () => {
+  // over=0 means factor=1 means new_weight = prev_weight. The orchestrator
+  // must not emit a no-op audit log row in that case (the audit log would
+  // grow without any actual transition to record). This is the application-
+  // layer analogue of tier_promotion_log's (from_tier <> to_tier) CHECK.
+  const svc = makeService();
+  const finding = makeFinding({ over_concentration: 0.0 });
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [finding];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map([[finding.swarm_lesson_id, 1.0]]);
+  const deps = makeDeps(weights, log);
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+
+  assert.equal(outcomes.length, 1);
+  assert.equal(outcomes[0].applied, false);  // skipped
+  assert.equal(outcomes[0].prev_weight, 1.0);
+  assert.equal(outcomes[0].new_weight, 1.0);
+  assert.equal(log.applyCalls.length, 0, "no audit row written for a no-op");
+});
+
+test("applyFinding skips no-op when prev_weight is already 0", async () => {
+  // A previously-silenced lesson stays silenced. The formula computes
+  // new_weight = 0 * factor = 0, which is === prev_weight, so the
+  // short-circuit kicks in and avoids audit spam.
+  const svc = makeService();
+  const finding = makeFinding({ over_concentration: 0.95 });
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [finding];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map([[finding.swarm_lesson_id, 0.0]]);
+  const deps = makeDeps(weights, log);
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+
+  assert.equal(outcomes[0].applied, false);
+  assert.equal(outcomes[0].new_weight, 0);
+  assert.equal(log.applyCalls.length, 0);
+});
+
+test("runDiversityPass isolates per-finding errors — one failure does not block others", async () => {
+  // Same digest-discipline as rem-audit: the diversity pass runs every
+  // REM cycle and a transient apply failure on one lesson must not poison
+  // the whole pass. Pin per-finding error isolation.
+  const svc = makeService();
+  const a = makeFinding({ swarm_lesson_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" });
+  const b = makeFinding({ swarm_lesson_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" });
+  const c = makeFinding({ swarm_lesson_id: "cccccccc-cccc-cccc-cccc-cccccccccccc" });
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [a, b, c];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map([
+    [a.swarm_lesson_id, 1.0],
+    [b.swarm_lesson_id, 1.0],
+    [c.swarm_lesson_id, 1.0],
+  ]);
+  const deps = makeDeps(weights, log, { failApply: b.swarm_lesson_id });
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+
+  assert.equal(outcomes.length, 3);
+  assert.equal(outcomes[0].applied, true);
+  assert.equal(outcomes[0].error, undefined);
+  assert.equal(outcomes[1].applied, false);
+  assert.match(outcomes[1].error ?? "", /stub apply fail/);
+  assert.equal(outcomes[2].applied, true);
+  assert.equal(outcomes[2].error, undefined);
+  // Only A and C made it to the audit log.
+  assert.equal(log.applyCalls.length, 2);
+  assert.deepEqual(
+    log.applyCalls.map((c) => c.lessonId).sort(),
+    [a.swarm_lesson_id, c.swarm_lesson_id].sort(),
+  );
+});
+
+test("runDiversityPass surfaces read errors as outcome.error without throwing", async () => {
+  const svc = makeService();
+  const finding = makeFinding();
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [finding];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map<string, number>();
+  const deps = makeDeps(weights, log, { failRead: finding.swarm_lesson_id });
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+
+  assert.equal(outcomes.length, 1);
+  assert.equal(outcomes[0].applied, false);
+  assert.match(outcomes[0].error ?? "", /stub read fail/);
+  assert.equal(log.applyCalls.length, 0);
+});
+
+test("runDiversityPass preserves SQL-layer invariant: outcome.new_weight <= outcome.prev_weight", async () => {
+  // Cross-check the orchestrator output against the SQL CHECK on
+  // lesson_diversity_log. Even if scoreFinding's clamp later regresses,
+  // this end-to-end pin keeps the orchestrator from emitting audit rows
+  // that the DB would reject.
+  const svc = makeService();
+  const findings = [
+    makeFinding({ swarm_lesson_id: "11111111-1111-1111-1111-111111111111", over_concentration: 0.8 }),
+    makeFinding({ swarm_lesson_id: "22222222-2222-2222-2222-222222222222", over_concentration: 0.95 }),
+    makeFinding({ swarm_lesson_id: "33333333-3333-3333-3333-333333333333", over_concentration: 1.0 }),
+  ];
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => findings;
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map(findings.map((f) => [f.swarm_lesson_id, 0.7] as [string, number]));
+  const deps = makeDeps(weights, log);
+
+  const outcomes = await svc.runDiversityPass({}, deps);
+
+  for (const o of outcomes) {
+    assert.ok(o.new_weight <= o.prev_weight, `${o.swarm_lesson_id}: new=${o.new_weight} prev=${o.prev_weight}`);
+    assert.ok(o.new_weight >= 0, `${o.swarm_lesson_id}: negative new_weight ${o.new_weight}`);
+  }
+});
+
+test("runDiversityPass outcome carries the finding's cohort + concentration metadata", async () => {
+  // The 4i.4 wiring step (digest.ts step 3.7) needs the cohort ratio +
+  // over value to print a meaningful summary. Pin that the orchestrator
+  // forwards them from the finding to the outcome unchanged.
+  const svc = makeService();
+  const finding = makeFinding({
+    topic_cohort_size: 7,
+    near_dup_origin_count: 6,
+    over_concentration: 6 / 7,
+  });
+  (svc as unknown as { findOverconcentrated: () => Promise<RemDiversityFinding[]> })
+    .findOverconcentrated = async () => [finding];
+  const log: StubLog = { applyCalls: [] };
+  const weights = new Map([[finding.swarm_lesson_id, 1.0]]);
+  const deps = makeDeps(weights, log);
+
+  const [o] = await svc.runDiversityPass({}, deps);
+  assert.equal(o.topic_cohort_size, 7);
+  assert.equal(o.near_dup_origin_count, 6);
+  assert.ok(Math.abs(o.over_concentration - 6 / 7) < 1e-9);
+});

--- a/mcp-server/src/services/rem-diversity.ts
+++ b/mcp-server/src/services/rem-diversity.ts
@@ -1,0 +1,295 @@
+/**
+ * REM diversity service — Swarm Phase 4i, sub-phase 4i.3 (issue #114).
+ *
+ * Implements the orchestrator side of SWARM_SPEC §10.4 "Anti-echo-chamber
+ * (diversity policy)": the receiver scans its swarm_lessons for topic-
+ * cohort over-concentration and decrements the local_weight of any lesson
+ * that >= p_over_concentration of the topic-cohort peer set holds in
+ * near-duplicate form. Cohort-level repetition is the inverse of true
+ * corroboration (different evidence chains reaching similar conclusions);
+ * §10.4 calls it out as plagiarism / re-broadcast amplification and
+ * requires the receiver to push back rather than reinforce.
+ *
+ * Three-stage pipeline (mirrors rem-audit.ts / rem-promotion.ts):
+ *   1. RPC `rem_diversity_check_lessons` (migration 082) returns the rows
+ *      that crossed the over-concentration threshold.
+ *   2. For each row, the orchestrator:
+ *        a. reads the lesson's current local_weight
+ *        b. computes new_weight = prev_weight * (1 − over_concentration)
+ *        c. appends a lesson_diversity_log row FIRST (the (new_weight <=
+ *           prev_weight) CHECK is the SQL-layer guarantee that this
+ *           multiplier never accidentally amplifies)
+ *        d. flips swarm_lessons.local_weight to new_weight
+ *   3. Returns a structured per-lesson outcome so a future digest.ts
+ *      step 3.7 wiring (sub-phase 4i.4) can include it in the cycle
+ *      summary. This sub-phase ships substrate only — wiring follows in
+ *      4i.4 to keep the §10.5/§10.6 digest steps from PRs #125/#129
+ *      mergeable in either order.
+ *
+ * Local-only invariant: same as 079 / 081 — the RPC reads ONLY
+ * swarm_lessons. §10.4 is explicitly a per-peer concentration signal; any
+ * cross-table join to `experiences` or `lessons` would mix lived-evidence
+ * into a diversity check that is supposed to operate on inter-peer
+ * over-concentration. The orchestrator does not pass any non-swarm input
+ * back into the RPC, preserving this end-to-end.
+ *
+ * §10.4 weight formula:
+ *   over_concentration ∈ [p_over_concentration, 1.0]  (RPC threshold)
+ *   factor             = (1 − over_concentration)     ∈ [0, 1 − p_over_concentration]
+ *   new_weight         = max(0, min(prev_weight, prev_weight * factor))
+ * The clamp enforces three §10.4 invariants:
+ *   * never increases  (the SQL CHECK plus the min(prev_weight, ...))
+ *   * never goes below 0
+ *   * a 100%-concentrated cohort silences the lesson entirely
+ *     (factor = 0 → new_weight = 0).
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+export interface RemDiversityFinding {
+  swarm_lesson_id: string;
+  origin_node_id: string;
+  swarm_lesson_text: string;
+  topic_cohort_size: number;
+  near_dup_origin_count: number;
+  over_concentration: number;
+  near_dup_lesson_ids: string[];
+}
+
+export interface RemDiversityOptions {
+  topicCosine?: number;
+  duplicateCosine?: number;
+  evidenceCountBand?: number;
+  signedAtWindowDays?: number;
+  minCohortSize?: number;
+  overConcentration?: number;
+}
+
+export interface RemDiversityOutcome {
+  swarm_lesson_id: string;
+  origin_node_id: string;
+  topic_cohort_size: number;
+  near_dup_origin_count: number;
+  over_concentration: number;
+  prev_weight: number;
+  new_weight: number;
+  applied: boolean;
+  error?: string;
+}
+
+/**
+ * Pure decision layer: derive the new local_weight + audit reason from a
+ * single RPC finding's prior weight. No DB dependency — exercise in unit
+ * tests with bare object inputs.
+ *
+ * Three guarantees enforced in code (in addition to the SQL CHECK):
+ *   * Clamps over_concentration to [0, 1] so a malformed RPC row cannot
+ *     produce a factor outside [0, 1].
+ *   * min(prev_weight, prev_weight * factor) ensures the multiplier never
+ *     amplifies even if a future caller passes a factor > 1.
+ *   * max(0, ...) ensures the result respects the swarm_lessons.local_weight
+ *     CHECK lower bound.
+ */
+export function scoreFinding(
+  prevWeight: number,
+  finding: RemDiversityFinding,
+): { new_weight: number; reason: string } {
+  const over = Math.max(0, Math.min(1, finding.over_concentration));
+  const factor = 1 - over;
+  const candidate = prevWeight * factor;
+  const new_weight = Math.max(0, Math.min(prevWeight, candidate));
+  const reason = formatReason(finding);
+  return { new_weight, reason };
+}
+
+/**
+ * Audit-log reason string. Captures the four pieces of context an operator
+ * (or a future REM cycle) needs to understand WHY the lesson's local_weight
+ * dropped:
+ *   1. spec section (§10.4) — so the audit row is self-describing
+ *   2. near_dup_origin_count / topic_cohort_size — the raw concentration
+ *   3. over_concentration — the derived ratio that drove the decrement
+ *   4. origin_node_id — so an operator can spot which peer is over-broadcasting
+ * The combined length is well under the 512-byte CHECK on lesson_diversity_log.reason.
+ */
+export function formatReason(finding: RemDiversityFinding): string {
+  const over = finding.over_concentration.toFixed(2);
+  return (
+    `§10.4 echo-chamber: ${finding.near_dup_origin_count}/${finding.topic_cohort_size} ` +
+    `cohort peers (incl. ${finding.origin_node_id}) hold near-duplicate ` +
+    `(over_concentration=${over})`
+  );
+}
+
+/**
+ * Side-effect bag — every DB write goes through one of these so the
+ * orchestrator is testable without a live Supabase.
+ */
+export interface RemDiversityDeps {
+  /** Read the current local_weight for a swarm_lesson; defaults to 1.0 for unknowns. */
+  readLocalWeight(lessonId: string): Promise<number>;
+  /** Append a lesson_diversity_log row + flip swarm_lessons.local_weight in that order. */
+  applyWeightChange(
+    lessonId: string,
+    prevWeight: number,
+    newWeight: number,
+    finding: RemDiversityFinding,
+    reason: string,
+  ): Promise<void>;
+}
+
+export class RemDiversityService {
+  private db: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.db = createClient(supabaseUrl, supabaseKey);
+  }
+
+  /** Run the §10.4 RPC and return the over-concentrated findings. */
+  async findOverconcentrated(
+    opts: RemDiversityOptions = {},
+  ): Promise<RemDiversityFinding[]> {
+    const { data, error } = await this.db.rpc("rem_diversity_check_lessons", {
+      p_topic_cosine:        opts.topicCosine        ?? 0.85,
+      p_duplicate_cosine:    opts.duplicateCosine    ?? 0.95,
+      p_evidence_count_band: opts.evidenceCountBand  ?? 1,
+      p_signed_at_window_d:  opts.signedAtWindowDays ?? 7,
+      p_min_cohort_size:     opts.minCohortSize      ?? 3,
+      p_over_concentration:  opts.overConcentration  ?? 0.8,
+    });
+    if (error) {
+      throw new Error(
+        `rem_diversity_check_lessons failed: ${error.message ?? String(error)}`,
+      );
+    }
+    return (data ?? []) as RemDiversityFinding[];
+  }
+
+  /**
+   * Run the full §10.4 cycle: query, then for each finding apply the
+   * weight decrement (with audit-log append). Returns one outcome row per
+   * finding. Per-finding errors are caught so one failure cannot block the
+   * rest of the diversity pass — the digest pipeline runs every cycle and
+   * a transient DB hiccup shouldn't poison it.
+   */
+  async runDiversityPass(
+    opts: RemDiversityOptions,
+    deps: RemDiversityDeps,
+  ): Promise<RemDiversityOutcome[]> {
+    const findings = await this.findOverconcentrated(opts);
+    const outcomes: RemDiversityOutcome[] = [];
+    for (const finding of findings) {
+      outcomes.push(await this.applyFinding(finding, deps));
+    }
+    return outcomes;
+  }
+
+  /**
+   * Apply the weight change for a single finding. Side-effect order is
+   * intentional and mirrors rem-promotion.ts (audit-first):
+   *   1. read prev_weight
+   *   2. compute new_weight via scoreFinding
+   *   3. if new_weight === prev_weight, short-circuit (no audit spam from
+   *      no-op transitions; the SQL CHECK on (from_tier <> to_tier) is the
+   *      analogue for tier_promotion_log — diversity log just needs the
+   *      app-layer no-op guard since strict equality on REAL is fine when
+   *      both sides came through the same scoreFinding formula)
+   *   4. applyWeightChange: log row INSERT first (durable audit), then
+   *      swarm_lessons.local_weight flip second. If the log INSERT fails,
+   *      the weight stays at prev (visible decrement is impossible without
+   *      an audit row).
+   *
+   * On any failure the partial-progress outcome is returned with `error`
+   * set — the orchestrator never throws across findings.
+   */
+  private async applyFinding(
+    finding: RemDiversityFinding,
+    deps: RemDiversityDeps,
+  ): Promise<RemDiversityOutcome> {
+    const outcome: RemDiversityOutcome = {
+      swarm_lesson_id:       finding.swarm_lesson_id,
+      origin_node_id:        finding.origin_node_id,
+      topic_cohort_size:     finding.topic_cohort_size,
+      near_dup_origin_count: finding.near_dup_origin_count,
+      over_concentration:    finding.over_concentration,
+      prev_weight:           1.0,
+      new_weight:            1.0,
+      applied:               false,
+    };
+    try {
+      const prevWeight = await deps.readLocalWeight(finding.swarm_lesson_id);
+      outcome.prev_weight = prevWeight;
+      const { new_weight, reason } = scoreFinding(prevWeight, finding);
+      outcome.new_weight = new_weight;
+      if (new_weight >= prevWeight) {
+        // No-op: nothing to decrement. Skip the audit row entirely.
+        return outcome;
+      }
+      await deps.applyWeightChange(
+        finding.swarm_lesson_id,
+        prevWeight,
+        new_weight,
+        finding,
+        reason,
+      );
+      outcome.applied = true;
+    } catch (err) {
+      outcome.error = err instanceof Error ? err.message : String(err);
+    }
+    return outcome;
+  }
+
+  /**
+   * Default deps wired against the service's own SupabaseClient. The 4i.4
+   * digest.ts wiring step uses this; tests inject mocks instead.
+   *
+   * applyWeightChange: append the audit row FIRST (durable evidence), then
+   * UPDATE swarm_lessons.local_weight SECOND. If the UPDATE fails, the log
+   * still records the intended transition and a future cycle can retry.
+   * If the UPDATE succeeds but the log INSERT had failed, we'd never reach
+   * the UPDATE — so weight-without-audit is structurally impossible.
+   */
+  defaultDeps(): RemDiversityDeps {
+    const db = this.db;
+    return {
+      async readLocalWeight(lessonId) {
+        const { data, error } = await db
+          .from("swarm_lessons")
+          .select("local_weight")
+          .eq("id", lessonId)
+          .maybeSingle();
+        if (error) {
+          throw new Error(`read local_weight failed: ${error.message}`);
+        }
+        const w = (data as { local_weight?: number } | null)?.local_weight;
+        return typeof w === "number" ? w : 1.0;
+      },
+      async applyWeightChange(lessonId, prevWeight, newWeight, finding, reason) {
+        const insertRes = await db.from("lesson_diversity_log").insert({
+          lesson_id:             lessonId,
+          prev_weight:           prevWeight,
+          new_weight:            newWeight,
+          topic_cohort_size:     finding.topic_cohort_size,
+          near_dup_origin_count: finding.near_dup_origin_count,
+          over_concentration:    finding.over_concentration,
+          reason,
+          near_dup_lesson_ids:   finding.near_dup_lesson_ids,
+        });
+        if (insertRes.error) {
+          throw new Error(
+            `lesson_diversity_log insert failed: ${insertRes.error.message}`,
+          );
+        }
+        const updateRes = await db
+          .from("swarm_lessons")
+          .update({ local_weight: newWeight })
+          .eq("id", lessonId);
+        if (updateRes.error) {
+          throw new Error(
+            `swarm_lessons.local_weight update failed: ${updateRes.error.message}`,
+          );
+        }
+      },
+    };
+  }
+}

--- a/supabase/migrations/082_swarm_lesson_diversity.sql
+++ b/supabase/migrations/082_swarm_lesson_diversity.sql
@@ -1,0 +1,206 @@
+-- 082_swarm_lesson_diversity.sql — Swarm Phase 4i, sub-phase 4i.3 (issue #114)
+--
+-- Implements the substrate for SWARM_SPEC §10.4 "Anti-echo-chamber (diversity
+-- policy)". A topic-cohort-relative concentration check identifies swarm-
+-- imported lessons that >80% of the receiver's per-topic peer set holds in
+-- near-duplicate form, and surfaces a row that the orchestrator (REM cycle)
+-- consumes to decrement the lesson's `local_weight`.
+--
+-- §10.4 contract being pinned here:
+--   "Within any topic cohort the receiver tracks across its peer set, if the
+--    same lesson (id match, OR cosine_similarity > 0.95 AND evidence_count
+--    similar AND signed_at within 7 days) is held by >80% of the cohort, the
+--    receiver MUST decrease its local weight by a factor of (1 −
+--    over_concentration) rather than increase it."
+--
+-- Slot note: 4i.2 (PR #129) claims slot 081; this migration takes the next
+-- free slot 082. Reed merges 4i.2 first, then 4i.3 — both are sub-phases of
+-- issue #114 and the order is documented in the PR description.
+--
+-- Dependencies (Reed merges in order):
+--   * migration 071  — swarm_lessons (id, embedding, origin_node_id,
+--                       synthesized_from_cluster_size, signed_at, content)
+--   * migration 078  — swarm_lessons.lesson_tier ('A'/'B' firebreak), so
+--                       this migration's ALTER coexists with 4i.1.
+--
+-- Three pieces, mirroring 4h's substrate (079) + 4i.1 (078) splits:
+--   1. ALTER swarm_lessons add local_weight column (DEFAULT 1.0). The recall
+--      / scoring code multiplies by this; a 1.0 default means "no change"
+--      and §10.4 only ratchets it down. The diversity log records every
+--      transition so the operator can audit weight-loss origin.
+--   2. lesson_diversity_log — append-only audit trail. Mirrors the
+--      tier_promotion_log / trust_edge_log patterns: append-only by
+--      withholding UPDATE/DELETE grants. The (new_weight <= prev_weight)
+--      CHECK encodes §10.4's "decrease ... rather than increase" wording at
+--      the SQL layer, not by application discipline.
+--   3. rem_diversity_check_lessons — STABLE read-side RPC that returns the
+--      over-concentrated rows. The applier (rem-diversity service, ships in
+--      this same PR) reads the per-lesson prev_weight, computes the new
+--      weight via (1 − over_concentration), writes the audit log, and flips
+--      swarm_lessons.local_weight. Side effects live in TS so the SQL stays
+--      pure / replayable / cacheable.
+--
+-- Local-only invariant: like 079 + 081, this RPC reads ONLY swarm_lessons.
+-- The §10.4 spec is "across the receiver's peer set" — peer set is exactly
+-- swarm_lessons.origin_node_id. Pulling in `experiences` or `lessons` would
+-- mix lived-evidence signal into a diversity check that explicitly operates
+-- on inter-peer concentration. Cross-table joins are absent by design.
+--
+-- This migration ONLY creates structure + ALTERs swarm_lessons (purely
+-- additive column with safe DEFAULT). No DROP, no DELETE, no data backfill.
+-- Reed runs the migration manually after merge — the autonomy loop is
+-- forbidden from executing it.
+
+-- ---------------------------------------------------------------------------
+-- (1) local_weight column on swarm_lessons.
+-- DEFAULT 1.0 is the no-op default — every existing row keeps full weight
+-- until §10.4 ratchets it down. CHECK 0..1 prevents pathological values.
+-- The (1 − over_concentration) reduction is multiplicative (see service),
+-- so the column never goes above 1.0 in normal operation.
+-- ---------------------------------------------------------------------------
+ALTER TABLE swarm_lessons
+  ADD COLUMN IF NOT EXISTS local_weight REAL NOT NULL DEFAULT 1.0
+  CHECK (local_weight >= 0 AND local_weight <= 1);
+
+CREATE INDEX IF NOT EXISTS swarm_lessons_local_weight_idx
+  ON swarm_lessons (local_weight);
+
+COMMENT ON COLUMN swarm_lessons.local_weight IS
+  'docs/SWARM_SPEC.md §10.4 anti-echo-chamber. Multiplier the receiver applies to this lesson''s influence on local recall. DEFAULT 1.0; the §10.4 REM pass multiplies by (1 − over_concentration) when a topic-cohort over-concentration is detected. CHECK 0..1 prevents pathological values. See lesson_diversity_log for the append-only audit of every transition.';
+
+-- ---------------------------------------------------------------------------
+-- (2) lesson_diversity_log — append-only audit trail.
+-- §10.4 only ratchets DOWN (a near-duplicate-rich cohort can only decrease
+-- a lesson's local_weight); the (new_weight <= prev_weight) CHECK encodes
+-- that "rather than increase" wording at the SQL layer. Append-only is
+-- enforced by withholding UPDATE/DELETE grants — never re-issue them.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lesson_diversity_log (
+  id                     BIGSERIAL PRIMARY KEY,
+  lesson_id              UUID  NOT NULL REFERENCES swarm_lessons(id) ON DELETE CASCADE,
+  prev_weight            REAL  NOT NULL CHECK (prev_weight >= 0 AND prev_weight <= 1),
+  new_weight             REAL  NOT NULL CHECK (new_weight  >= 0 AND new_weight  <= 1),
+  topic_cohort_size      INT   NOT NULL CHECK (topic_cohort_size >= 1),
+  near_dup_origin_count  INT   NOT NULL CHECK (near_dup_origin_count >= 1),
+  over_concentration     FLOAT NOT NULL CHECK (over_concentration >= 0 AND over_concentration <= 1),
+  reason                 TEXT  NOT NULL CHECK (octet_length(reason) <= 512),
+  near_dup_lesson_ids    UUID[] NOT NULL DEFAULT '{}',
+  at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (new_weight <= prev_weight)
+);
+
+CREATE INDEX IF NOT EXISTS lesson_diversity_log_lesson_idx
+  ON lesson_diversity_log (lesson_id, at DESC);
+
+COMMENT ON TABLE lesson_diversity_log IS
+  'docs/SWARM_SPEC.md §10.4 append-only audit of swarm_lessons.local_weight reductions. The (new_weight <= prev_weight) CHECK encodes §10.4''s "decrease ... rather than increase" wording at the SQL layer. Append-only is enforced by withholding UPDATE/DELETE grants — never re-issue them. Operators inspect this log to understand why a swarm lesson''s influence dropped.';
+
+-- ---------------------------------------------------------------------------
+-- (3) rem_diversity_check_lessons — STABLE read-side RPC.
+--
+-- For every swarm_lesson L, computes:
+--   * topic_cohort_size = COUNT(DISTINCT origin_node_id) over swarm_lessons
+--                          with cosine_similarity(other.embedding, L.embedding)
+--                          >= p_topic_cosine. INCLUDES L itself.
+--   * near_dup_origin_count = COUNT(DISTINCT origin_node_id) over swarm_lessons
+--                              where the §10.4 same-lesson predicate matches:
+--                                cosine >= p_duplicate_cosine
+--                                AND |evidence_count_diff| <= p_evidence_count_band
+--                                AND |signed_at_diff| <= p_signed_at_window_d days.
+--                              INCLUDES L itself.
+--   * over_concentration = near_dup_origin_count / topic_cohort_size
+--
+-- Returns one row per L where:
+--   * topic_cohort_size >= p_min_cohort_size  (statistical floor — single-peer
+--                                              cohorts can't be over-concentrated)
+--   * over_concentration >= p_over_concentration  (§10.4 threshold; default
+--                                                  0.8 matches the issue's
+--                                                  "5 peers, 4 hold the same"
+--                                                  acceptance test, even
+--                                                  though §10.4 spec text says
+--                                                  ">80%". The >= reading is
+--                                                  intentional — see PR.)
+--
+-- The thresholds are RPC parameters (not constants) so a node operator can
+-- tune them per their audit aggressiveness without a migration. Defaults
+-- follow §10.4 spec text + issue acceptance: topic 0.85 (matches 4h),
+-- duplicate 0.95 (spec text), evidence-count band ±1 (proxy for "similar"),
+-- signed-at window 7 days (spec text), cohort floor 3 (statistical floor),
+-- over-concentration 0.8 (matches the 4-of-5 acceptance test).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rem_diversity_check_lessons(
+  p_topic_cosine        FLOAT DEFAULT 0.85,
+  p_duplicate_cosine    FLOAT DEFAULT 0.95,
+  p_evidence_count_band INT   DEFAULT 1,
+  p_signed_at_window_d  INT   DEFAULT 7,
+  p_min_cohort_size     INT   DEFAULT 3,
+  p_over_concentration  FLOAT DEFAULT 0.8
+)
+RETURNS TABLE (
+  swarm_lesson_id        UUID,
+  origin_node_id         TEXT,
+  swarm_lesson_text      TEXT,
+  topic_cohort_size      INT,
+  near_dup_origin_count  INT,
+  over_concentration     FLOAT,
+  near_dup_lesson_ids    UUID[]
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH all_lessons AS (
+    SELECT
+      id,
+      embedding,
+      origin_node_id,
+      content,
+      synthesized_from_cluster_size AS evidence_count,
+      signed_at
+    FROM swarm_lessons
+    WHERE embedding IS NOT NULL
+  ),
+  topic_cohort AS (
+    SELECT
+      l.id              AS center_id,
+      l.embedding       AS center_emb,
+      l.origin_node_id  AS center_origin,
+      l.content         AS center_content,
+      l.evidence_count  AS center_evidence,
+      l.signed_at       AS center_signed_at,
+      COUNT(DISTINCT other.origin_node_id)::INT AS topic_cohort_size
+    FROM all_lessons l
+    JOIN all_lessons other
+      ON (1 - (other.embedding <=> l.embedding)) >= p_topic_cosine
+    GROUP BY l.id, l.embedding, l.origin_node_id, l.content, l.evidence_count, l.signed_at
+  ),
+  near_dup_origins AS (
+    SELECT
+      tc.center_id,
+      array_agg(DISTINCT other.id ORDER BY other.id) AS near_dup_lesson_ids,
+      COUNT(DISTINCT other.origin_node_id)::INT     AS near_dup_origin_count
+    FROM topic_cohort tc
+    JOIN all_lessons other
+      ON (1 - (other.embedding <=> tc.center_emb)) >= p_duplicate_cosine
+     AND ABS(other.evidence_count - tc.center_evidence) <= p_evidence_count_band
+     AND ABS(EXTRACT(epoch FROM (other.signed_at - tc.center_signed_at))) <= (p_signed_at_window_d * 86400)
+    GROUP BY tc.center_id
+  )
+  SELECT
+    tc.center_id        AS swarm_lesson_id,
+    tc.center_origin    AS origin_node_id,
+    tc.center_content   AS swarm_lesson_text,
+    tc.topic_cohort_size,
+    nd.near_dup_origin_count,
+    (nd.near_dup_origin_count::FLOAT / NULLIF(tc.topic_cohort_size, 0))::FLOAT AS over_concentration,
+    nd.near_dup_lesson_ids
+  FROM topic_cohort tc
+  JOIN near_dup_origins nd ON nd.center_id = tc.center_id
+  WHERE tc.topic_cohort_size >= p_min_cohort_size
+    AND (nd.near_dup_origin_count::FLOAT / NULLIF(tc.topic_cohort_size, 0)) >= p_over_concentration;
+$$;
+
+GRANT EXECUTE ON FUNCTION rem_diversity_check_lessons(FLOAT, FLOAT, INT, INT, INT, FLOAT)
+  TO anon, service_role;
+
+COMMENT ON FUNCTION rem_diversity_check_lessons(FLOAT, FLOAT, INT, INT, INT, FLOAT) IS
+  'SWARM_SPEC §10.4 anti-echo-chamber: returns swarm_lessons whose topic-cohort over-concentration meets/exceeds the threshold. STABLE / read-only — caller (rem-diversity service) executes the local_weight decrement + audit-log append. Reads ONLY swarm_lessons (per-peer concentration is a swarm-internal signal; cross-table joins would mix lived evidence into a diversity check by design).';


### PR DESCRIPTION
## Summary

Closes the §10 immune-system pillar that was still open after **4i.1** (firewall, PR #124) and **4i.2** (promotion arrow, PR #129): false amplification through cohort echo can now be detected at the receiver and the lesson's `local_weight` multiplicatively decremented by `(1 − over_concentration)`. Restores the swarm-thesis-defining property of cohort diversity (§10.7 pillar 3).

The §10.4 immune system after this PR + #129 + #124:

```
swarm-ingest ──► Tier-B ──┬── §10.5 contradicting cluster ──► forget + trust↓        (4h, on main)
                          ├── §10.6 corroborating cluster   ──► Tier-A + audit       (4i.2, PR #129)
                          └── §10.4 cohort over-concentration ──► local_weight × (1 − over)  (this PR)
```

## Files

* **`supabase/migrations/082_swarm_lesson_diversity.sql`** — `local_weight REAL DEFAULT 1.0` column on `swarm_lessons`, append-only `lesson_diversity_log` (with the load-bearing `(new_weight <= prev_weight)` CHECK that encodes §10.4's *\"decrease ... rather than increase\"* wording at the SQL layer), and the `rem_diversity_check_lessons` STABLE RPC.
* **`mcp-server/src/services/rem-diversity.ts`** — `RemDiversityService.runDiversityPass` with dependency-injected DB writes (mirrors `RemAuditService` / `RemPromotionService`). Side-effect order is intentional: `lesson_diversity_log` row written FIRST (durable audit), then `swarm_lessons.local_weight` flipped. If the log INSERT fails the weight stays at prev — visible decrement without an audit row is structurally impossible.

## Slot 082 (not 081)

PR #129 (sub-phase 4i.2) claims slot 081. 4i.3 takes the next free slot 082. Either merge order works: 4i.2 → 4i.3 needs no rebase; 4i.3 → 4i.2 also lands cleanly because the migrations are independent (082 only touches `swarm_lessons` + a new table; 081 only adds a new RPC).

## What's deferred to 4i.4 (digest.ts wiring)

PR #129 wires sub-phase 4i.2 into `digest.ts` as new step 3.6 (after the §10.5 forget arrow). Wiring §10.4 as step 3.7 in this PR would create a digest.ts merge conflict against #129 for no functional gain. The 4i.4 follow-up wires step 3.7 once both 4i.2 and 4i.3 are on main.

## Local-only invariant (Designprinzip 2 + §10.4)

The RPC reads ONLY `swarm_lessons`. §10.4 is an explicitly per-peer concentration signal — pulling in `experiences` or `lessons` would mix lived-evidence into a diversity check that operates on inter-peer over-concentration. Pinned by structural test (no JOIN on experiences / lessons / swarm_hub_anchors / swarm_lesson_contradictions / tier_promotion_log / trust_edge_log / nodes).

## §10.4 weight formula

```
over_concentration ∈ [p_over_concentration, 1.0]   (RPC threshold; default 0.8)
factor             = (1 − over_concentration)      ∈ [0, 1 − p_over_concentration]
new_weight         = max(0, min(prev_weight, prev_weight * factor))
```

Three invariants enforced both in code and in SQL:
* never increases (the SQL CHECK plus `min(prev_weight, ...)`)
* never goes below 0
* a 100%-concentrated cohort silences the lesson entirely (factor = 0)

## Threshold defaults & spec mapping

| Param | Default | §10.4 spec text |
|---|---|---|
| `p_topic_cosine` | 0.85 | \"any topic cohort\" — same default as 4h `p_min_cosine` |
| `p_duplicate_cosine` | 0.95 | \"cosine_similarity > 0.95\" |
| `p_evidence_count_band` | 1 | \"evidence_count similar\" — implementation-defined |
| `p_signed_at_window_d` | 7 | \"signed_at within 7 days\" |
| `p_min_cohort_size` | 3 | statistical floor: 1- or 2-peer cohorts can't be over-concentrated |
| `p_over_concentration` | 0.8 | \">80%\" — `>=` reading matches the issue's \"5 peers, 4 hold\" acceptance test (4/5 = exactly 80%) |

## Out of scope for 4i.3

* **digest.ts wiring** — sub-phase **4i.4**.
* **Recall-side application of `local_weight` to scoring** — the column ships here as the substrate; consumer wiring is a recall-path concern with its own test surface.
* **Cross-cohort topic discovery** — peer-set is the existing `swarm_lessons.origin_node_id` grouping, taken as given by `TrustEdge`.

## Test plan

- [x] `npm run build` clean (mcp-server)
- [x] `npm test` — 582 / 582 pass on a clean dist
- [x] migration-082 contract pins (17 tests): local_weight column shape, index, log table columns + `(new_weight <= prev_weight)` CHECK + log index, 6-arg RPC signature, STABLE, 7-col return shape, swarm_lessons-only invariant (no JOIN on experiences / lessons / swarm_hub_anchors / swarm_lesson_contradictions / tier_promotion_log / trust_edge_log / nodes), all six thresholds parameterised, GRANT, no DROP / DELETE / TRUNCATE, no UPDATE/DELETE grants on lesson_diversity_log
- [x] rem-diversity service tests (12 tests): scoreFinding multiplicative decrement, 100%-cohort silences, multiplicative stacking, clamp on malformed over, never-amplifies invariant, formatReason content + 512-byte size, runDiversityPass empty findings, no-op short-circuit (over=0), no-op-on-already-zero, per-finding error isolation, read-error surfaced as outcome.error, end-to-end SQL-CHECK invariant, outcome metadata forwarding
- [ ] Reed runs \`bash scripts/migrate.sh\` after merge

Closes part of #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)