### PR TITLE
fix(swarm): GRANT SELECT on phase-4 tables — #134

### DIFF
--- a/mcp-server/src/__tests__/migration-083-phase4-grants.test.ts
+++ b/mcp-server/src/__tests__/migration-083-phase4-grants.test.ts
@@ -1,0 +1,126 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 083 — Phase 4 read-grant fixup (issue #134)
+//
+// Five of the Phase-4 swarm tables (nodes, swarm_lessons, trust_edge_log,
+// lesson_evidence_origin, tier_promotion_log, lesson_diversity_log) ship
+// without GRANT SELECT to anon / service_role, so PostgREST returns HTTP
+// 403 on every read on a fresh install. 083 fixes that by adding the
+// missing read grants in one place.
+//
+// Same defensive contract-pin pattern as the 070-082 tests: the autonomy
+// loop cannot execute migrations against a real PG / PostgREST instance,
+// so the fix is pinned at the SQL-text level. Stripping comments before
+// keyword matching prevents an explanatory phrase from satisfying or
+// violating a structural assertion below.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/083_phase4_grants.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace for keyword pins.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) Every Phase-4 table the issue lists gets GRANT SELECT.
+// ---------------------------------------------------------------------------
+
+const TABLES = [
+  "nodes",
+  "swarm_lessons",
+  "trust_edge_log",
+  "lesson_evidence_origin",
+  "tier_promotion_log",
+  "swarm_lessons_broadcast_eligible",
+  "swarm_lesson_contradictions",
+  "lesson_diversity_log",
+];
+
+for (const table of TABLES) {
+  test(`grants SELECT on ${table} to anon + service_role`, () => {
+    // Pin the exact grant statement: SELECT only, both roles. The grant
+    // pattern allows arbitrary whitespace between keywords but pins the
+    // role list to anon + service_role (in either order — both are
+    // equivalent at the SQL layer; matching the canonical "anon,
+    // service_role" form documented in the issue).
+    const pattern = new RegExp(
+      `grant\\s+select\\s+on\\s+${table}\\s+to\\s+anon\\s*,\\s*service_role`,
+    );
+    assert.match(SQL, pattern);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// (2) Read-only — no write privileges introduced by this migration.
+// ---------------------------------------------------------------------------
+
+test("migration 083 grants ONLY SELECT — no INSERT / UPDATE / DELETE / TRUNCATE / REFERENCES", () => {
+  // The issue's hard contract: "Write privileges stay locked — only
+  // SELECT is granted; service-role still needs the existing trigger /
+  // RPC / RLS path for any write." Pin the absence of every other DML
+  // privilege keyword in any GRANT statement.
+  assert.doesNotMatch(SQL, /grant[^;]*\binsert\b/);
+  assert.doesNotMatch(SQL, /grant[^;]*\bupdate\b/);
+  assert.doesNotMatch(SQL, /grant[^;]*\bdelete\b/);
+  assert.doesNotMatch(SQL, /grant[^;]*\btruncate\b/);
+  assert.doesNotMatch(SQL, /grant[^;]*\breferences\b/);
+  assert.doesNotMatch(SQL, /grant[^;]*\btrigger\b/);
+  // ALL would silently include INSERT/UPDATE/DELETE — pin its absence.
+  assert.doesNotMatch(SQL, /grant\s+all\b/);
+});
+
+// ---------------------------------------------------------------------------
+// (3) Additive only — no destructive DDL, matches 071 / 078 / 081 / 082.
+// ---------------------------------------------------------------------------
+
+test("migration 083 contains no DROP / DELETE / TRUNCATE / REVOKE statements", () => {
+  // The autonomy loop must never authorise destructive migrations; the
+  // grant fixup adds privilege, never removes any. A future REVOKE
+  // would belong in a separately reviewed migration.
+  assert.doesNotMatch(SQL, /\bdrop\s+(table|index|view|function|constraint|trigger)\b/);
+  assert.doesNotMatch(SQL, /\bdelete\s+from\b/);
+  assert.doesNotMatch(SQL, /\btruncate\b/);
+  assert.doesNotMatch(SQL, /\brevoke\b/);
+});
+
+// ---------------------------------------------------------------------------
+// (4) PostgREST hot-reload — pick up grants without a service restart.
+// ---------------------------------------------------------------------------
+
+test("migration 083 ends with NOTIFY pgrst, 'reload schema'", () => {
+  // Without this, PostgREST keeps its cached schema until the next
+  // service restart, so the grants apply at the SQL layer but reads
+  // still 403 through the API. The trailing NOTIFY is what closes the
+  // loop on existing deploys.
+  assert.match(SQL, /notify\s+pgrst\s*,\s*'reload schema'/);
+});
+
+// ---------------------------------------------------------------------------
+// (5) Idempotency — GRANT is idempotent in Postgres; pin that we don't
+// guard with conditional logic that could mask a misspelled table name.
+// ---------------------------------------------------------------------------
+
+test("migration 083 issues plain GRANT statements — no DO / IF / EXISTS guards", () => {
+  // GRANT is naturally idempotent: re-granting the same privilege is a
+  // no-op. Wrapping a GRANT in DO $$ IF EXISTS ... END $$ would mask a
+  // misspelled table name (the IF EXISTS would silently skip). Plain
+  // GRANT statements fail loudly on the first apply if a table name is
+  // wrong — exactly the behaviour we want at migration time.
+  assert.doesNotMatch(SQL, /\bdo\s+\$\$/);
+  assert.doesNotMatch(SQL, /\bgrant\b[^;]*\bif\s+exists\b/);
+});

--- a/supabase/migrations/083_phase4_grants.sql
+++ b/supabase/migrations/083_phase4_grants.sql
@@ -1,0 +1,79 @@
+-- 083_phase4_grants.sql — Swarm Phase 4 read-grant fixup (issue #134)
+--
+-- Migrations 070..082 introduced the Phase-4 swarm substrate (nodes,
+-- swarm_lessons, trust_edge_log, lesson_evidence_origin, tier_promotion_log,
+-- swarm_lessons_broadcast_eligible, swarm_lesson_contradictions,
+-- lesson_diversity_log). Five of those tables ship without GRANT SELECT
+-- to anon / service_role, so PostgREST returns HTTP 403 on every read
+-- of those tables on a fresh install — the dashboard, MCP tools, and
+-- any external client are locked out until a hand-fix is applied.
+--
+-- The two exceptions (swarm_lessons_broadcast_eligible already granted
+-- in 078, swarm_lesson_contradictions already granted in 080) are
+-- re-granted here for completeness; GRANT is idempotent in Postgres so
+-- the redundancy is a no-op. Listing them here keeps the inventory of
+-- "what Phase 4 publishes via PostgREST" in one place rather than
+-- spread across seven migrations.
+--
+-- Scope discipline (matches the 071 / 078 / 081 / 082 hard rules):
+--   * Read-only — only SELECT is granted. Writes still flow through the
+--     existing RPC / trigger / RLS path.
+--   * Additive — no DROP, no DELETE, no TRUNCATE, no REVOKE.
+--   * Idempotent — re-running this migration is a no-op (GRANT is
+--     idempotent at the SQL layer).
+--
+-- The trailing NOTIFY pgrst, 'reload schema' is the standard PostgREST
+-- hot-reload signal: PostgREST picks up the new grants without a
+-- service restart. Same pattern that 078's broadcast-eligible grant
+-- relies on at the existing-deploy boundary.
+
+-- ---------------------------------------------------------------------------
+-- (1) nodes — created in 070_node_identity.sql, never granted.
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON nodes                            TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (2) swarm_lessons — created in 071_swarm_storage.sql, never granted.
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON swarm_lessons                    TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (3) trust_edge_log — created in 075_trust_edge_dynamics.sql, never granted.
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON trust_edge_log                   TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (4) lesson_evidence_origin — created in 077_lesson_evidence_origin.sql,
+-- never granted.
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON lesson_evidence_origin           TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (5) tier_promotion_log — created in 078_lesson_tiers.sql, never granted.
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON tier_promotion_log               TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (6) swarm_lessons_broadcast_eligible — view created in 078_lesson_tiers.sql,
+-- already granted at line 115; re-granted here for inventory completeness
+-- (GRANT is idempotent — no-op on existing deploys).
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON swarm_lessons_broadcast_eligible TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (7) swarm_lesson_contradictions — created in 080_lesson_contradictions.sql,
+-- already granted at lines 117-120; re-granted here for inventory
+-- completeness (GRANT is idempotent — no-op on existing deploys).
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON swarm_lesson_contradictions      TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- (8) lesson_diversity_log — created in 082_swarm_lesson_diversity.sql,
+-- never granted.
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON lesson_diversity_log             TO anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- PostgREST hot-reload — pick up the new grants without a service restart.
+-- ---------------------------------------------------------------------------
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Closes #134.

## Summary

- Adds migration `083_phase4_grants.sql` that grants `SELECT` on the eight Phase-4 tables/views to `anon` + `service_role`. Without it, PostgREST returns HTTP 403 on every read of those tables on a fresh install — the dashboard schwarm tab and any MCP tool that surfaces Phase-4 substrate is silently locked out until a hand-fix is applied.
- Adds contract test `migration-083-phase4-grants.test.ts` (12 assertions) pinning the load-bearing invariants of the fixup.

## What 083 grants

| Source migration | Object | Status before 083 |
|---|---|---|
| 070 | `nodes` | not granted |
| 071 | `swarm_lessons` | not granted |
| 075 | `trust_edge_log` | not granted |
| 077 | `lesson_evidence_origin` | not granted |
| 078 | `tier_promotion_log` | not granted |
| 078 | `swarm_lessons_broadcast_eligible` (view) | already granted (line 115) |
| 080 | `swarm_lesson_contradictions` | already granted (lines 117–120) |
| 082 | `lesson_diversity_log` | not granted |

The two already-granted entries are re-granted here for inventory completeness — `GRANT` is idempotent in Postgres, so the redundancy is a no-op on existing deploys. Listing them all in one place keeps the inventory of "what Phase 4 publishes via PostgREST" honest rather than scattered across seven migrations.

## Read-only — write privileges stay locked

Only `SELECT` is granted. The contract test pins the absence of `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE` / `REFERENCES` / `TRIGGER` / `ALL` in any `GRANT` statement in 083. Writes still flow through the existing trigger / RPC / RLS path.

## PostgREST hot-reload

The trailing `NOTIFY pgrst, 'reload schema'` lets PostgREST pick up the grants without a service restart — same pattern as the rest of the Phase-4 migration discipline.

## Why a new slot, not an in-place edit of 070..082

Migrations 070..082 are immutable history (same discipline as #135's PR #140). `GRANT` is naturally idempotent, so 083 is safe to apply on:
- fresh DBs that never had any of the grants → 083 installs all eight.
- existing DBs where 078/080 already granted theirs → 083 re-grants two and adds six (the re-grants are no-ops).
- DBs that hand-patched the missing grants locally → 083 is a no-op.

## Contract test pins

- All eight Phase-4 tables get `GRANT SELECT` to `anon` + `service_role` (eight assertions, one per table).
- Read-only: no `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE` / `REFERENCES` / `TRIGGER` / `ALL` in any `GRANT`.
- Migration discipline: no `DROP` / `DELETE` / `TRUNCATE` / `REVOKE`.
- Trailing `NOTIFY pgrst, 'reload schema'` present.
- Plain `GRANT` statements — no `DO $$` blocks or `IF EXISTS` guards. A misspelled table name should fail loudly at apply time, not be silently skipped.

12/12 contract-test assertions pass locally; 078 / 080 / 082 contract tests still pass (45/45 across all three) — no regression.

## Out of scope (per #134's "Out of scope")

- Backfilling grants into the 070..082 migration files — those are immutable history. The fix is a new migration.
- Granting any privilege beyond `SELECT`.
- RLS policies — orthogonal to grants and not part of this scope.
- A test that empirically hits PostgREST against each table and asserts 200 — the autonomy loop has no PostgREST instance available; the grant is pinned at the SQL-text level instead. Reed: smoke-test the dashboard schwarm tab against a fresh deploy after 083 applies.

## Test plan

- [x] `node --test dist/__tests__/migration-083-phase4-grants.test.js` → 12/12 pass
- [x] `node --test dist/__tests__/migration-{078,080,082}-*.test.js` → 45/45 pass (no regression)
- [ ] Reed: apply 083 against the dev DB, confirm `swarm-overview` (or any direct PostgREST GET against e.g. `/swarm_lessons`) now returns 200 / `[]` instead of 403.
- [ ] Reed: smoke-test the dashboard schwarm tab end-to-end after 083 applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)