### PR TITLE
feat(swarm): trust-edge decay + quarantine release sweeps — #141

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -625,6 +625,7 @@ swarm-labelled phase merges to `main`.
 | 4d — `prev_lesson_hash` chain table (migration 074) | §3.7.2 | [#104](https://github.com/Dewinator/mycelium/issues/104) | — | 🟡 PR [#119](https://github.com/Dewinator/mycelium/pull/119) open |
 | 4e — `/swarm/lessons/{id}/proof` endpoint | §4.6 | [#105](https://github.com/Dewinator/mycelium/issues/105) | `a78f436` (substrate) | 🟡 endpoint PR [#128](https://github.com/Dewinator/mycelium/pull/128) open |
 | 4f — TrustEdge auto-tuning + quarantine (migration 075) | §10.1, §10.2 | [#107](https://github.com/Dewinator/mycelium/issues/107) | `25bf3a8` | ✅ on `main` |
+| 4f.1 — Trust-edge decay + quarantine release sweeps (migration 083) | §10.1, §10.2 | [#141](https://github.com/Dewinator/mycelium/issues/141) | — | 🟡 PR open (this branch) |
 | 4g — ConscienceAgent contradicts-trigger (migration 080) | §10.3 | [#108](https://github.com/Dewinator/mycelium/issues/108) | `6d59674` | ✅ on `main` |
 | 4h — REM self-audit pass (§10.5 falsification arrow) | §10.5 | [#109](https://github.com/Dewinator/mycelium/issues/109) | `8cad92f` | ✅ on `main` |
 | 4i.1 — Two-tier pinning + broadcast firewall (migration 078) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | `db98ea0` | ✅ on `main` |

--- a/mcp-server/src/__tests__/migration-083-trust-edge-lifecycle.test.ts
+++ b/mcp-server/src/__tests__/migration-083-trust-edge-lifecycle.test.ts
@@ -1,0 +1,203 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 083 — §10 lifecycle sweeps (issue #141)
+//
+// Same defensive contract-pin pattern as migration-070..082 tests: read the
+// SQL, normalise it, regex-pin every load-bearing structural invariant.
+// Reed runs migrations manually after merge — the autonomy loop is forbidden
+// from executing them — so the contract tests live at the SQL-text level.
+//
+// Pins two groups of contracts that any future edit MUST keep:
+//   1. trust_edge_decay_step(p_silence_days, p_step, p_min_gap_hours)
+//      — three-arg signature, neutral-deadband no-op, calls
+//        record_trust_edge_change with the canonical reason string,
+//        guards on is_self / last_seen_at / last_decay_at cooldown,
+//        GRANTed to anon + service_role.
+//   2. quarantine_release_step()
+//      — zero-arg signature, INSERTs into trust_edge_log with reason
+//        'quarantine-expired' (direct INSERT bypasses the no-op short-
+//        circuit in record_trust_edge_change), clears quarantined_until
+//        + consecutive_rejections, GRANTed to anon + service_role.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/083_trust_edge_lifecycle.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so prose like
+// "no DROP" inside a comment cannot accidentally satisfy or violate a
+// structural assertion below.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent
+// or keyword-case drift without weakening the structural contracts.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) trust_edge_decay_step — silence decay toward neutral
+// ---------------------------------------------------------------------------
+
+test("trust_edge_decay_step has the canonical 3-arg signature with documented defaults", () => {
+  // Signature pin: (silence_days INT default 7, step REAL default 0.05,
+  // min_gap_hours INT default 24). Renaming a param or changing a default
+  // would silently change the §10.1 cadence — pin all three.
+  assert.match(
+    SQL,
+    /create or replace function trust_edge_decay_step\(\s*p_silence_days\s+int\s+default\s+7\s*,\s*p_step\s+real\s+default\s+0\.05\s*,\s*p_min_gap_hours\s+int\s+default\s+24\s*\)\s+returns\s+int/,
+  );
+});
+
+test("trust_edge_decay_step rejects out-of-range parameter values", () => {
+  // Defensive validation. silence_days >= 1 prevents "decay every peer
+  // every tick"; step in (0, 0.5] prevents trust collapse / negative steps;
+  // min_gap_hours >= 1 prevents the per-peer cooldown from going subzero.
+  assert.match(SQL, /silence_days must be >= 1/);
+  assert.match(SQL, /step must be in \(0, 0\.5\]/);
+  assert.match(SQL, /min_gap_hours must be >= 1/);
+});
+
+test("trust_edge_decay_step skips self and applies the cooldown gate", () => {
+  // Two contracts that protect against runaway behaviour:
+  //   * is_self = TRUE rows are explicitly excluded (we never decay our
+  //     own trust toward neutral; self trust is operator-set).
+  //   * last_decay_at cooldown gate prevents a fast scheduler from
+  //     hammering the same peer N times per cycle. A future refactor that
+  //     drops the COALESCE-NULL allowance would silently freeze every
+  //     peer that hasn't decayed yet — pin both halves.
+  assert.match(SQL, /coalesce\(is_self,\s*false\) = false/);
+  assert.match(SQL, /last_seen_at is not null/);
+  assert.match(SQL, /last_seen_at < now\(\) - \(p_silence_days \|\| ' days'\)::interval/);
+  assert.match(SQL, /last_decay_at is null\s+or\s+last_decay_at < now\(\) - \(p_min_gap_hours \|\| ' hours'\)::interval/);
+});
+
+test("trust_edge_decay_step has a neutral deadband around 0.5", () => {
+  // The 0.495..0.505 deadband prevents oscillation: without it, a peer at
+  // 0.504 would be dragged to 0.454 by the > branch, then bounced back to
+  // 0.504 by the < branch on the next tick. The deadband collapses both
+  // branches to the no-op exit. Pin both the range and the explicit
+  // 'silence-decay-neutral-deadband' reason — the dashboard reads
+  // decay_reason and a renamed reason would silently break the UI.
+  assert.match(SQL, /v_row\.trust_weight between 0\.495 and 0\.505/);
+  assert.match(SQL, /'silence-decay-neutral-deadband'/);
+});
+
+test("trust_edge_decay_step clamps both decay branches at 0.5", () => {
+  // GREATEST(0.5, w-step) on the > branch and LEAST(0.5, w+step) on the
+  // < branch. Without the clamps a peer at 0.51 dragged by step=0.05
+  // would land at 0.46, crossing the neutral mid-line — defeating the
+  // "drift toward 0.5" intent and creating a sign-flip the audit log
+  // can't easily explain.
+  assert.match(SQL, /v_new := greatest\(0\.5::real, v_row\.trust_weight - p_step\)/);
+  assert.match(SQL, /v_new := least\(0\.5::real, v_row\.trust_weight \+ p_step\)/);
+});
+
+test("trust_edge_decay_step routes through record_trust_edge_change with the canonical reason", () => {
+  // Persistence MUST go through migration 075's record_trust_edge_change
+  // so the audit row + last_decay_at stamp + no-op short-circuit all
+  // happen in one transaction. A direct UPDATE on nodes.trust_weight
+  // here would skip the audit log — that's exactly the foot-gun §10.1
+  // forbids ("operator audit surface"). The reason string is also pinned
+  // because the dashboard groups decay events by reason text.
+  assert.match(
+    SQL,
+    /perform record_trust_edge_change\(\s*v_row\.node_id\s*,\s*v_new\s*,\s*'silence-decay-toward-neutral'\s*\)/,
+  );
+});
+
+test("trust_edge_decay_step is GRANTed to anon and service_role", () => {
+  assert.match(
+    SQL,
+    /grant execute on function trust_edge_decay_step\(int,\s*real,\s*int\)\s+to anon,\s*service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) quarantine_release_step — §10.2 expiry-based release
+// ---------------------------------------------------------------------------
+
+test("quarantine_release_step has the canonical zero-arg signature", () => {
+  // Zero args — the function selects only rows where quarantined_until is
+  // already in the past, so the operator never has to pass a "now" or
+  // "lookback window". Adding parameters later is a compatible change;
+  // adding REQUIRED parameters is a contract break.
+  assert.match(
+    SQL,
+    /create or replace function quarantine_release_step\(\s*\)\s+returns\s+int/,
+  );
+});
+
+test("quarantine_release_step selects only expired quarantines", () => {
+  // The WHERE clause is the entire safety surface of this function:
+  // selecting too widely would release peers who are actively quarantined,
+  // and selecting too narrowly would leave released peers stuck with
+  // stale quarantined_until values forever. Pin both halves.
+  assert.match(SQL, /quarantined_until is not null/);
+  assert.match(SQL, /quarantined_until < now\(\)/);
+});
+
+test("quarantine_release_step writes a release audit row directly into trust_edge_log", () => {
+  // Direct INSERT (not via record_trust_edge_change) is intentional:
+  // weight_before == weight_after on a release would trigger
+  // record_trust_edge_change's no-op short-circuit and silently drop the
+  // audit row. Migration 075's append-only trigger only blocks UPDATE +
+  // DELETE, so a bare INSERT is a legal append.
+  assert.match(
+    SQL,
+    /insert into trust_edge_log \(node_id,\s*weight_before,\s*weight_after,\s*reason\)\s+values \(v_row\.node_id,\s*v_row\.trust_weight,\s*v_row\.trust_weight,\s*'quarantine-expired'\)/,
+  );
+});
+
+test("quarantine_release_step clears the §10.2 state-machine fields", () => {
+  // The release MUST clear quarantined_until + reset consecutive_rejections.
+  // Without the rejections reset, a peer that comes back online after a
+  // 30-day quarantine starts already 5/5 rejections deep — the next §5
+  // rule failure would re-quarantine immediately. last_decay_at gets
+  // stamped so the operator UI shows a real "last lifecycle event".
+  assert.match(SQL, /quarantined_until\s*=\s*null/);
+  assert.match(SQL, /consecutive_rejections\s*=\s*0/);
+  assert.match(SQL, /decay_reason\s*=\s*'quarantine-expired'/);
+  assert.match(SQL, /last_decay_at\s*=\s*now\(\)/);
+});
+
+test("quarantine_release_step is GRANTed to anon and service_role", () => {
+  assert.match(
+    SQL,
+    /grant execute on function quarantine_release_step\(\)\s+to anon,\s*service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) Migration discipline (mirrors 070..082 tests)
+// ---------------------------------------------------------------------------
+
+test("migration is purely additive — no DROP / DELETE / TRUNCATE", () => {
+  // §10.1 audit log integrity AND §10.2 state-machine integrity both
+  // depend on the migration NEVER tearing down existing structure. A
+  // future edit that adds a DROP TABLE / DELETE FROM / TRUNCATE here
+  // would be a silent contract break — pin the absence at the SQL-text
+  // level so the agent loop catches it before the migration ships.
+  assert.doesNotMatch(SQL, /\bdrop\s+(table|function|index|trigger|view)\b/);
+  assert.doesNotMatch(SQL, /\bdelete\s+from\b/);
+  assert.doesNotMatch(SQL, /\btruncate\b/);
+});
+
+test("migration uses CREATE OR REPLACE for both functions (re-run safe)", () => {
+  // Reed re-runs migrate.sh on every merge — both functions must support
+  // re-creation without errors. CREATE OR REPLACE is the established
+  // pattern (see 075's compute_trust_weight, record_trust_edge_change,
+  // quarantine_origin, record_origin_rejection, reset_origin_rejection_streak).
+  const replaceCount = (SQL.match(/create or replace function/g) ?? []).length;
+  assert.equal(replaceCount, 2, "expected exactly two CREATE OR REPLACE FUNCTION blocks");
+});

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -17,7 +17,7 @@ mkdir -p "$STATE_DIR"
 
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-COMPONENTS="docker supabase-pg supabase-rest ollama embedding-model dashboard"
+COMPONENTS="docker supabase-pg supabase-rest ollama embedding-model dashboard quarantine-release"
 OVERALL="ok"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG"; }
@@ -49,6 +49,38 @@ probe_dashboard() {
   local code
   code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://127.0.0.1:8787/ 2>/dev/null || echo "000")
   [ "$code" = "200" ]
+}
+
+# Sweep §10.2 expired quarantines. The probe IS the action — calling
+# `quarantine_release_step()` is idempotent (returns 0 when nothing is
+# expired, which is the steady state). We treat any non-zero return value
+# as "ok with detail" so the dashboard can surface the count without
+# painting the component red. A psql failure (DB locked, container down)
+# IS a probe failure; the supabase-pg recovery path will handle it.
+probe_quarantine_release() {
+  if ! docker exec vectormemory-db pg_isready -U postgres >/dev/null 2>&1; then
+    return 1
+  fi
+  local out
+  out=$(docker exec vectormemory-db psql \
+    -U postgres -d vectormemory \
+    --quiet --no-align --tuples-only \
+    -c "SELECT quarantine_release_step();" 2>/dev/null) || return 1
+  out="$(echo "$out" | tr -d '[:space:]')"
+  if [ -z "$out" ]; then
+    return 1
+  fi
+  if [ "$out" != "0" ]; then
+    log "quarantine_release: released $out node(s)"
+    set_status "quarantine-release" "ok" "released ${out} node(s)"
+    return 0
+  fi
+  return 0
+}
+heal_quarantine_release() {
+  # The function is idempotent and depends only on supabase-pg. If the
+  # probe failed, the supabase recovery path is the right place to fix it.
+  return 1
 }
 
 # ── Backoff ──────────────────────────────────────────────
@@ -143,6 +175,14 @@ else
   set_status "embedding-model" "skipped" "ollama down"
 fi
 check_component "dashboard" probe_dashboard heal_dashboard
+
+# Quarantine release runs only when supabase-pg is up; otherwise mark as
+# skipped so the dashboard doesn't show stale red status during DB outages.
+if [ "$(get_status supabase-pg)" = "ok" ]; then
+  check_component "quarantine-release" probe_quarantine_release heal_quarantine_release
+else
+  set_status "quarantine-release" "skipped" "supabase-pg down"
+fi
 
 # ── Status-Snapshot ──────────────────────────────────────
 {

--- a/supabase/migrations/083_trust_edge_lifecycle.sql
+++ b/supabase/migrations/083_trust_edge_lifecycle.sql
@@ -1,0 +1,202 @@
+-- 083_trust_edge_lifecycle.sql — Swarm Phase 4f follow-up (issue #141)
+--
+-- Implements the two §10 lifecycle sweeps that have substrate but no
+-- scheduler in main as of migration 082:
+--
+--   1. trust_edge_decay_step()       — §10.1 silence decay toward neutral
+--   2. quarantine_release_step()     — §10.2 expiry-based release
+--
+-- Without these, the dashboard's "quarantäne abgelaufen?"-Feld stays stale
+-- and trust accounts pile up indefinitely with no friction toward the
+-- neutral baseline (0.5). The §10 self-correcting loop is open.
+--
+-- Both functions are idempotent and safe to call on every tick — they
+-- short-circuit when there is nothing to do, so the choice of cadence
+-- (digest cycle vs. watchdog tick) is purely a latency / observability
+-- preference, not a correctness one.
+--
+-- Trust-weight semantics in this codebase:
+--   `nodes.trust_weight` is REAL in [0, 1] (CHECK + DEFAULT 0.5; see
+--   migrations 070/071/075). Neutral is 0.5, not 0 — so "decay toward
+--   neutral" is "drift toward 0.5", not "drift toward 0".
+--   The original spec text in #141 reads "if current weight is negative
+--   add +0.05; if positive subtract -0.05". We translate that to the
+--   actual [0, 1] coordinate system: pull above-neutral toward 0.5 by
+--   subtracting 0.05; push below-neutral toward 0.5 by adding 0.05.
+--   Cap at ±0.005 around 0.5 so the weight never overshoots into the
+--   opposite half (oscillating sign would defeat the audit log).
+--
+-- Schedule discipline (mirrors migrations 075/079/081/082):
+--   Reed runs the migration manually after merge — the autonomy loop is
+--   forbidden from executing it.
+--
+-- This PR ships ONLY the SQL functions plus a watchdog-side scheduler
+-- for `quarantine_release_step()`. Wiring `trust_edge_decay_step()` into
+-- `digest.ts` (the spec-text suggestion) is deferred to a follow-up PR
+-- because PR #132 (4i.3 follow-up) currently owns the digest.ts surface
+-- and cross-PR digest.ts edits are how the autonomy loop has historically
+-- generated rebase pain (lesson 2026-04-30 in vector-memory). The
+-- function is fully callable from any scheduler today.
+--
+-- ---------------------------------------------------------------------------
+-- (1) trust_edge_decay_step — §10.1 silence decay toward neutral (0.5)
+--
+-- For every peer with `last_seen_at < NOW() - INTERVAL p_silence_days days`
+-- AND `last_decay_at IS NULL OR last_decay_at < NOW() - INTERVAL p_min_gap_hours hours`:
+--   * if trust_weight > 0.505 → new_weight = trust_weight - p_step (clamp 0.5..1)
+--   * if trust_weight < 0.495 → new_weight = trust_weight + p_step (clamp 0..0.5)
+--   * else                    → no change (within neutral deadband)
+--
+-- Persistence goes through the existing `record_trust_edge_change()` RPC
+-- from migration 075 so the audit trail and no-op short-circuit semantics
+-- already in place are honoured. The only direct UPDATE this function
+-- performs is on `nodes.last_decay_at` for rows where neither branch fired
+-- (so the cooldown advances even on neutral-deadband rows — otherwise we'd
+-- re-evaluate the same neutral peer every tick and produce a loud no-op).
+--
+-- Returns INT = number of rows where trust_weight actually changed.
+-- The watchdog/digest scheduler logs this count for operator visibility.
+--
+-- The neutral deadband (±0.005) prevents oscillation: a peer at 0.504
+-- that we drag down by 0.05 would land at 0.454 — under neutral, next
+-- tick the +branch fires and overshoots up to 0.504 again. The deadband
+-- collapses both branches to the no-op exit when |w − 0.5| ≤ 0.005.
+--
+-- p_silence_days defaults to 7 (the spec text). p_step defaults to 0.05
+-- (the spec text). p_min_gap_hours defaults to 24 (one decay per UTC day
+-- per peer — matches the "nightly cycle" suggested cadence even if the
+-- caller fires more often).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION trust_edge_decay_step(
+  p_silence_days  INT  DEFAULT 7,
+  p_step          REAL DEFAULT 0.05,
+  p_min_gap_hours INT  DEFAULT 24
+) RETURNS INT AS $$
+DECLARE
+  v_changed INT := 0;
+  v_row     RECORD;
+  v_new     REAL;
+BEGIN
+  IF p_silence_days  < 1 THEN
+    RAISE EXCEPTION 'trust_edge_decay_step: silence_days must be >= 1, got %', p_silence_days;
+  END IF;
+  IF p_step <= 0 OR p_step > 0.5 THEN
+    RAISE EXCEPTION 'trust_edge_decay_step: step must be in (0, 0.5], got %', p_step;
+  END IF;
+  IF p_min_gap_hours < 1 THEN
+    RAISE EXCEPTION 'trust_edge_decay_step: min_gap_hours must be >= 1, got %', p_min_gap_hours;
+  END IF;
+
+  FOR v_row IN
+    SELECT node_id, trust_weight
+    FROM   nodes
+    WHERE  COALESCE(is_self, FALSE) = FALSE
+      AND  last_seen_at IS NOT NULL
+      AND  last_seen_at < NOW() - (p_silence_days || ' days')::INTERVAL
+      AND  (last_decay_at IS NULL
+            OR last_decay_at < NOW() - (p_min_gap_hours || ' hours')::INTERVAL)
+  LOOP
+    -- Neutral deadband — skip the no-op branch. We still advance the
+    -- cooldown via the trailing UPDATE (see below) so the next tick
+    -- doesn't re-scan the same row.
+    IF v_row.trust_weight BETWEEN 0.495 AND 0.505 THEN
+      UPDATE nodes
+      SET    last_decay_at = NOW(),
+             decay_reason  = 'silence-decay-neutral-deadband'
+      WHERE  node_id = v_row.node_id;
+      CONTINUE;
+    END IF;
+
+    IF v_row.trust_weight > 0.505 THEN
+      v_new := GREATEST(0.5::REAL, v_row.trust_weight - p_step);
+    ELSE
+      v_new := LEAST(0.5::REAL, v_row.trust_weight + p_step);
+    END IF;
+
+    -- record_trust_edge_change writes the audit row, updates trust_weight,
+    -- and stamps last_decay_at + decay_reason. Its no-op short-circuit
+    -- (identical weight) protects us if the deadband math ever rounds
+    -- to the existing value — the audit log only grows on real change.
+    PERFORM record_trust_edge_change(
+      v_row.node_id,
+      v_new,
+      'silence-decay-toward-neutral'
+    );
+    v_changed := v_changed + 1;
+  END LOOP;
+
+  RETURN v_changed;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION trust_edge_decay_step(INT, REAL, INT)
+  TO anon, service_role;
+
+COMMENT ON FUNCTION trust_edge_decay_step(INT, REAL, INT) IS
+  'docs/SWARM_SPEC.md §10.1 silence decay sweep. Drifts trust_weight toward 0.5 for peers silent > p_silence_days. Idempotent — guarded by a per-peer p_min_gap_hours cooldown. Returns count of weights actually changed. See migration 083 header for parameter semantics.';
+
+-- ---------------------------------------------------------------------------
+-- (2) quarantine_release_step — §10.2 expiry-based release sweep
+--
+-- For every peer with `quarantined_until IS NOT NULL AND quarantined_until < NOW()`:
+--   * SET quarantined_until = NULL
+--   * SET decay_reason     = 'quarantine-expired'
+--   * SET last_decay_at    = NOW()
+--   * INSERT a row into trust_edge_log with weight_before = weight_after =
+--     current trust_weight, reason = 'quarantine-expired'. Direct INSERT
+--     bypasses record_trust_edge_change()'s no-op short-circuit (same
+--     weight in/out would silently drop the audit row otherwise) — the
+--     append-only trigger from migration 075 only blocks UPDATE/DELETE,
+--     not INSERT, so this is a legal append.
+--
+-- Returns INT = number of nodes released. Idempotent — selects only rows
+-- with `quarantined_until < NOW()`, so a second call within the same
+-- transaction returns 0.
+--
+-- Why both branches stamp `last_decay_at`: the operator dashboard reads
+-- last_decay_at to display "last lifecycle event" per peer; a release
+-- without that stamp would look like the peer is silently quarantined
+-- forever in the UI even though quarantined_until is now NULL.
+--
+-- The `consecutive_rejections > 0` filter from issue #141's body is
+-- intentionally NOT applied here. Migration 075 §10.2 already resets
+-- consecutive_rejections to 0 inside `quarantine_origin()` — by the time
+-- a node sits in `quarantined_until > NOW()` it always has counter = 0.
+-- Filtering on `> 0` would zero-out every release call, which is the
+-- opposite of what the issue intends. See issue #141 thread before
+-- changing this back.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION quarantine_release_step()
+RETURNS INT AS $$
+DECLARE
+  v_count INT := 0;
+  v_row   RECORD;
+BEGIN
+  FOR v_row IN
+    SELECT node_id, trust_weight
+    FROM   nodes
+    WHERE  quarantined_until IS NOT NULL
+      AND  quarantined_until < NOW()
+  LOOP
+    INSERT INTO trust_edge_log (node_id, weight_before, weight_after, reason)
+    VALUES (v_row.node_id, v_row.trust_weight, v_row.trust_weight, 'quarantine-expired');
+
+    UPDATE nodes
+    SET    quarantined_until      = NULL,
+           consecutive_rejections = 0,
+           decay_reason           = 'quarantine-expired',
+           last_decay_at          = NOW()
+    WHERE  node_id = v_row.node_id;
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION quarantine_release_step()
+  TO anon, service_role;
+
+COMMENT ON FUNCTION quarantine_release_step() IS
+  'docs/SWARM_SPEC.md §10.2 quarantine release sweep. Clears expired quarantines (quarantined_until < NOW()), writes a release row to trust_edge_log, and stamps last_decay_at. Idempotent — short-circuits when nothing has expired. Returns count of nodes released. Designed for the watchdog 5-minute cadence.';


### PR DESCRIPTION
## Summary

Closes the §10 lifecycle gap: trust accounts and quarantine state had substrate (migration 075) but no scheduler. Adds two idempotent SQL sweeps callable from any tick + a watchdog scheduler for the quarantine-release one.

Closes #141.

## What this PR ships

### Migration 083 (`supabase/migrations/083_trust_edge_lifecycle.sql`)

**`trust_edge_decay_step(p_silence_days, p_step, p_min_gap_hours)`** — §10.1 silence decay
- Drifts `trust_weight` toward `0.5` for peers with `last_seen_at > 7d`.
- Skips `is_self`. Cooldown gate (default 24 h) prevents fast schedulers from hammering the same peer.
- ±0.005 neutral deadband prevents oscillation: a peer at `0.504` won't bounce to `0.454` and back to `0.504` next tick.
- Both branches clamp at `0.5` (`GREATEST(0.5, w-step)` and `LEAST(0.5, w+step)`) so a sign-flip is impossible.
- Persists through the existing `record_trust_edge_change()` RPC so the audit trail and no-op short-circuit semantics from migration 075 are honoured.
- Returns `INT` (count of weights actually changed).

**`quarantine_release_step()`** — §10.2 expiry-based release
- Selects only `quarantined_until IS NOT NULL AND quarantined_until < NOW()`.
- Clears `quarantined_until`, resets `consecutive_rejections` (otherwise a peer returning after 30 days would start already 5/5 rejections deep), stamps `decay_reason = 'quarantine-expired'`, advances `last_decay_at`.
- Direct `INSERT INTO trust_edge_log` (not via `record_trust_edge_change`) is intentional: same-weight in/out would trigger the no-op short-circuit and silently drop the audit row. Migration 075's append-only trigger only blocks UPDATE/DELETE, so the bare INSERT is a legal append.
- Returns `INT` (count of nodes released).

Both functions are idempotent — safe to call on every tick. The choice of cadence is a latency / observability preference, not a correctness one.

### Watchdog wiring (`scripts/watchdog.sh`)

New `quarantine-release` component that calls `quarantine_release_step()` each 5-minute tick. The probe **is** the action — when the steady state holds (nothing expired) it returns `0` and stays green; non-zero counts get logged to `vectormemory-watchdog.log` and surfaced in `STATUS_FILE` so the dashboard can show "released N node(s)".

Component is `skipped` (not failed) when `supabase-pg` is down — a DB outage is the supabase-pg recovery path's concern, not a separate alert.

### What's deliberately deferred

**Trust-edge decay scheduling is NOT wired in this PR.** The spec text in #141 suggests the nightly REM digest cycle (`digest.ts`), but **PR #132** (4i.3 follow-up) currently owns the `digest.ts` surface and parallel `digest.ts` edits have historically caused rebase pain (the autonomy lesson 2026-04-30 explicitly calls this out). The function is fully callable; the digest.ts wiring is a clean follow-up PR once #132 lands.

### Spec status

`docs/SWARM_SPEC.md` §9 table gets a new **4f.1** row pointing at this PR.

## Test plan

- [x] `cd mcp-server && rm -rf dist && npm run build` — clean
- [x] `cd mcp-server && npm test` — **660 / 660 pass** (14 new contract-pins for migration 083)
- [x] `bash -n scripts/watchdog.sh` — clean
- [ ] Reed merges; runs `bash scripts/migrate.sh` to apply migration 083
- [ ] Reed observes the watchdog log on next 5-min tick (`~/Library/Logs/vectormemory-watchdog.log`) — should see `quarantine_release: released 0 node(s)` only when there's actually something to release; steady state is silent.

## Out of scope

- Wiring `trust_edge_decay_step()` into `digest.ts` (deferred — see "What's deliberately deferred" above).
- A dashboard component for the new `quarantine-release` watchdog status (the existing dashboard reads `STATUS_FILE` already; the new component appears automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)