### PR TITLE
feat(swarm): swarm_pin_lesson MCP tool — issue #143 first write-side slice

### DIFF
--- a/mcp-server/src/__tests__/swarm-pin.test.ts
+++ b/mcp-server/src/__tests__/swarm-pin.test.ts
@@ -1,0 +1,264 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SwarmPinService,
+  buildPinReason,
+  type LessonTier,
+  type SwarmPinDeps,
+} from "../services/swarm-pin.js";
+import {
+  swarmPinLesson,
+  swarmPinLessonSchema,
+} from "../tools/swarm-pin.js";
+
+// ---------------------------------------------------------------------------
+// swarm_pin_lesson — first write-side slice of issue #143
+//
+// Covers four contracts the §10.6 operator override depends on:
+//   1. buildPinReason produces the 'operator-pinned' machine-readable prefix
+//      and respects the migration-078 octet_length(reason) <= 512 bound,
+//      including UTF-8 boundary safety on truncation.
+//   2. SwarmPinService.pinLesson rejects no-op transitions BEFORE touching
+//      the DB, so the audit log never sees a (from = to) row that the
+//      migration-078 CHECK would reject anyway.
+//   3. SwarmPinService.pinLesson writes the audit row BEFORE the tier
+//      UPDATE — the §10.6 traceability contract requires every transition
+//      attempt on the log even when the UPDATE later fails.
+//   4. The MCP tool's ethics-gate refuses without
+//      OPENCLAW_ALLOW_SWARM_WRITE=1, mirroring the OPENCLAW_ALLOW_BREEDING
+//      pattern, and the Zod schema validates the UUID + tier inputs.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// (1) buildPinReason
+// ---------------------------------------------------------------------------
+
+test("buildPinReason returns bare prefix when note is missing", () => {
+  assert.equal(buildPinReason(), "operator-pinned");
+  assert.equal(buildPinReason(undefined), "operator-pinned");
+  assert.equal(buildPinReason(""), "operator-pinned");
+  assert.equal(buildPinReason("   "), "operator-pinned");
+});
+
+test("buildPinReason embeds caller note after ': ' separator", () => {
+  assert.equal(
+    buildPinReason("manually corroborated against logbook"),
+    "operator-pinned: manually corroborated against logbook",
+  );
+});
+
+test("buildPinReason trims surrounding whitespace from caller note", () => {
+  assert.equal(
+    buildPinReason("   trimmed   "),
+    "operator-pinned: trimmed",
+  );
+});
+
+test("buildPinReason truncates oversize notes within the 512-octet budget", () => {
+  // Build a note larger than the per-note budget. After buildPinReason
+  // the full reason must still fit the migration-078 reason CHECK.
+  const huge = "x".repeat(800);
+  const out = buildPinReason(huge);
+  // Exact char counts vary based on truncation strategy; the contract is
+  // "stays under the migration-078 octet bound".
+  assert.ok(
+    Buffer.byteLength(out, "utf8") <= 512,
+    `reason should fit 512 octets, got ${Buffer.byteLength(out, "utf8")}`,
+  );
+  assert.ok(out.startsWith("operator-pinned: "));
+  // Truncation should leave an ellipsis to signal that data was cut.
+  assert.ok(out.endsWith("…"), "truncated reason should end with ellipsis");
+});
+
+test("buildPinReason does NOT split a multi-byte UTF-8 codepoint", () => {
+  // 4-byte emoji repeated until well past the budget. A naive byte-cut
+  // would leave a half-codepoint at the end and Postgres would reject it.
+  const emoji = "🌱"; // U+1F331, 4 bytes UTF-8
+  const note = emoji.repeat(200); // 800 bytes
+  const out = buildPinReason(note);
+  // Round-tripping through Buffer should not throw; if we'd cut mid-codepoint,
+  // the final char would be a replacement character rather than `…`.
+  assert.ok(
+    out.endsWith("…"),
+    "ellipsis should appear at a clean codepoint boundary",
+  );
+  assert.ok(Buffer.byteLength(out, "utf8") <= 512);
+});
+
+// ---------------------------------------------------------------------------
+// (2) SwarmPinService.pinLesson — orchestration
+// ---------------------------------------------------------------------------
+
+interface RecordedCalls {
+  fetched:    string[];
+  recorded:   Array<{ id: string; from: LessonTier; to: LessonTier; reason: string }>;
+  updated:    Array<{ id: string; tier: LessonTier }>;
+}
+
+function makeDeps(
+  initialTier: LessonTier | null,
+  opts: { recordFails?: boolean; updateFails?: boolean } = {},
+): { deps: SwarmPinDeps; calls: RecordedCalls } {
+  const calls: RecordedCalls = { fetched: [], recorded: [], updated: [] };
+  const deps: SwarmPinDeps = {
+    async fetchCurrentTier(id) {
+      calls.fetched.push(id);
+      return initialTier;
+    },
+    async recordTierTransition(id, from, to, reason) {
+      calls.recorded.push({ id, from, to, reason });
+      if (opts.recordFails) throw new Error("audit-log-down");
+    },
+    async updateLessonTier(id, tier) {
+      calls.updated.push({ id, tier });
+      if (opts.updateFails) throw new Error("update-down");
+    },
+  };
+  return { deps, calls };
+}
+
+const FAKE_ID = "11111111-2222-3333-4444-555555555555";
+
+test("pinLesson promotes B → A and writes the audit row first", async () => {
+  const svc = new SwarmPinService("http://stub", "stub");
+  const { deps, calls } = makeDeps("B");
+  const out = await svc.pinLesson(FAKE_ID, "A", undefined, deps);
+
+  assert.deepEqual(out, {
+    lesson_id: FAKE_ID,
+    from_tier: "B",
+    to_tier:   "A",
+    reason:    "operator-pinned",
+  });
+  assert.deepEqual(calls.fetched, [FAKE_ID]);
+  assert.equal(calls.recorded.length, 1);
+  assert.equal(calls.recorded[0].from, "B");
+  assert.equal(calls.recorded[0].to, "A");
+  assert.equal(calls.updated.length, 1);
+  assert.equal(calls.updated[0].tier, "A");
+});
+
+test("pinLesson demotes A → B and threads the caller note into the audit reason", async () => {
+  const svc = new SwarmPinService("http://stub", "stub");
+  const { deps, calls } = makeDeps("A");
+  const out = await svc.pinLesson(FAKE_ID, "B", "contested by local logs", deps);
+
+  assert.equal(out.from_tier, "A");
+  assert.equal(out.to_tier, "B");
+  assert.equal(out.reason, "operator-pinned: contested by local logs");
+  assert.equal(calls.recorded[0].reason, "operator-pinned: contested by local logs");
+});
+
+test("pinLesson rejects a no-op (current tier already equals target)", async () => {
+  const svc = new SwarmPinService("http://stub", "stub");
+  const { deps, calls } = makeDeps("A");
+  await assert.rejects(
+    svc.pinLesson(FAKE_ID, "A", undefined, deps),
+    /already at tier A/i,
+  );
+  // CRITICAL: the no-op rejection happens BEFORE any DB writes, so the
+  // audit log is never polluted by would-be no-ops.
+  assert.equal(calls.recorded.length, 0);
+  assert.equal(calls.updated.length, 0);
+});
+
+test("pinLesson rejects when the lesson does not exist", async () => {
+  const svc = new SwarmPinService("http://stub", "stub");
+  const { deps, calls } = makeDeps(null);
+  await assert.rejects(
+    svc.pinLesson(FAKE_ID, "A", undefined, deps),
+    /not found/i,
+  );
+  assert.equal(calls.recorded.length, 0);
+  assert.equal(calls.updated.length, 0);
+});
+
+test("pinLesson skips the tier UPDATE when the audit-log INSERT fails", async () => {
+  // §10.6 traceability: losing the audit is worse than a stuck tier.
+  // If the audit-log INSERT fails, the UPDATE must NOT run (otherwise we'd
+  // have a silent transition that the operator cannot retrace).
+  const svc = new SwarmPinService("http://stub", "stub");
+  const { deps, calls } = makeDeps("B", { recordFails: true });
+  await assert.rejects(
+    svc.pinLesson(FAKE_ID, "A", undefined, deps),
+    /audit-log-down/,
+  );
+  assert.equal(calls.recorded.length, 1, "audit insert should be attempted");
+  assert.equal(calls.updated.length, 0, "tier update must NOT run when audit failed");
+});
+
+test("pinLesson surfaces a failed UPDATE after the audit row is durable", async () => {
+  // Symmetric: audit row IS in the log (durable transition record), but
+  // the tier flip itself failed. Caller must see the error so they can
+  // retry; the log entry now serves as the trail of the attempt.
+  const svc = new SwarmPinService("http://stub", "stub");
+  const { deps, calls } = makeDeps("B", { updateFails: true });
+  await assert.rejects(
+    svc.pinLesson(FAKE_ID, "A", undefined, deps),
+    /update-down/,
+  );
+  assert.equal(calls.recorded.length, 1);
+  assert.equal(calls.updated.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// (3) MCP tool: ethics-gate + Zod schema
+// ---------------------------------------------------------------------------
+
+test("swarmPinLesson refuses when OPENCLAW_ALLOW_SWARM_WRITE is unset", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  try {
+    const stubPin = {} as unknown as SwarmPinService;
+    const stubMem = {} as unknown as Parameters<typeof swarmPinLesson>[1];
+    const out = await swarmPinLesson(stubPin, stubMem, {
+      lesson_id: FAKE_ID,
+      tier: "A",
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+    assert.ok(out.fix_hint, "structured error must carry a fix_hint");
+  } finally {
+    if (original !== undefined) process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmPinLesson refuses with non-'1' env values (only '1' opens the gate)", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "true"; // truthy but not '1'
+  try {
+    const stubPin = {} as unknown as SwarmPinService;
+    const stubMem = {} as unknown as Parameters<typeof swarmPinLesson>[1];
+    const out = await swarmPinLesson(stubPin, stubMem, {
+      lesson_id: FAKE_ID,
+      tier: "A",
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmPinLessonSchema rejects malformed UUIDs and out-of-range tiers", () => {
+  // Zod's safeParse so we get the structured error rather than a throw.
+  const bad1 = swarmPinLessonSchema.safeParse({
+    lesson_id: "not-a-uuid",
+    tier: "A",
+  });
+  assert.equal(bad1.success, false);
+
+  const bad2 = swarmPinLessonSchema.safeParse({
+    lesson_id: FAKE_ID,
+    tier: "C", // out of enum
+  });
+  assert.equal(bad2.success, false);
+
+  const ok = swarmPinLessonSchema.safeParse({
+    lesson_id: FAKE_ID,
+    tier: "A",
+    reason: "x",
+  });
+  assert.equal(ok.success, true);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -156,6 +156,10 @@ import { NodeIdentityService } from "./services/node-identity.js";
 import {
   nodeIdentityGetSchema, nodeIdentityGet,
 } from "./tools/node-identity.js";
+import { SwarmPinService } from "./services/swarm-pin.js";
+import {
+  swarmPinLessonSchema, swarmPinLessonHandler,
+} from "./tools/swarm-pin.js";
 import {
   getSelfModelSchema, getSelfModel,
   updateSelfModelSchema, updateSelfModel,
@@ -225,6 +229,7 @@ const guardService = new GuardService(
 const neurochemistryService = new NeurochemistryService(SUPABASE_URL, SUPABASE_KEY);
 const relationsService      = new RelationsService(SUPABASE_URL, SUPABASE_KEY);
 const nodeIdentityService   = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY);
+const swarmPinService       = new SwarmPinService(SUPABASE_URL, SUPABASE_KEY);
 const remAuditService       = new RemAuditService(SUPABASE_URL, SUPABASE_KEY);
 const remPromotionService   = new RemPromotionService(SUPABASE_URL, SUPABASE_KEY);
 // DEFERRED 2026-04-26 — federation service parked until federation phase.
@@ -850,6 +855,26 @@ server.tool(
   "Return THIS node's cryptographic identity row: node_id (multihash of pubkey, base58btc-encoded per docs/SWARM_SPEC.md §3.5), base64 pubkey, optional display_name, created_at. Returns a friendly 'not initialized' message when the bootstrap script hasn't run yet.",
   nodeIdentityGetSchema.shape,
   withErrorHandling((input) => nodeIdentityGet(nodeIdentityService, nodeIdentityGetSchema.parse(input)))
+);
+
+// --- swarm phase 4 write-side: manual lesson-tier override (issue #143) ----
+// First write-side slice of issue #143's MCP-tool surface. Mirrors the
+// §10.6 promotion path (RemPromotionService) but operator-driven instead
+// of evidence-driven: an operator asserts "this lesson belongs at tier X"
+// and the audit row in `tier_promotion_log` records the intent.
+//
+// Behind the OPENCLAW_ALLOW_SWARM_WRITE=1 ethics-gate (mirrors the
+// OPENCLAW_ALLOW_BREEDING gate). Without the env flag the tool refuses
+// with a structured `{ ok:false, error, fix_hint }` instead of throwing,
+// so an LLM agent that calls it without operator consent learns from the
+// hint rather than crashing the session.
+server.tool(
+  "swarm_pin_lesson",
+  "Operator-side override of swarm_lessons.lesson_tier. Pins a lesson to 'A' (broadcast-eligible) or 'B' (tentative, firebreak). Writes an append-only audit row to tier_promotion_log with reason prefix 'operator-pinned'. REQUIRES OPENCLAW_ALLOW_SWARM_WRITE=1 — refuses with a structured error otherwise. Also writes a 'decisions'-category memory tagged 'swarm' on success (best-effort).",
+  swarmPinLessonSchema.shape,
+  withErrorHandling((input) =>
+    swarmPinLessonHandler(swarmPinService, memoryService, swarmPinLessonSchema.parse(input)),
+  ),
 );
 
 /* DEFERRED 2026-04-26 — pairing (tinder) + federation-PKI + federation Phase 2.

--- a/mcp-server/src/services/swarm-pin.ts
+++ b/mcp-server/src/services/swarm-pin.ts
@@ -1,0 +1,192 @@
+/**
+ * Swarm pin-lesson service — Swarm Phase 4 / issue #143 write-side slice.
+ *
+ * Manual operator-side override of `swarm_lessons.lesson_tier`. Mirrors the
+ * §10.6 promotion path implemented by `RemPromotionService` (sub-phase 4i.2),
+ * but without the corroborating-cluster gate: an operator who calls this
+ * tool is asserting "I have decided this lesson belongs at tier X" and the
+ * audit row in `tier_promotion_log` records that intent.
+ *
+ * Two design points worth holding in one frame with rem-promotion.ts:
+ *
+ *   1. **Audit-first ordering.** `tier_promotion_log` INSERT happens BEFORE
+ *      the `swarm_lessons.lesson_tier` UPDATE. If the UPDATE fails, the
+ *      audit row still records the operator's *intent*. Losing the audit
+ *      row is worse than a stuck tier — the §10.6 traceability contract
+ *      depends on every transition being on the log, even failed ones.
+ *
+ *   2. **No-op rejection at the service boundary.** If `current_tier` is
+ *      already `to_tier`, the service throws before touching the DB. The
+ *      migration-078 `(from_tier <> to_tier)` CHECK on `tier_promotion_log`
+ *      would reject a no-op INSERT anyway, but throwing earlier produces a
+ *      cleaner error for the MCP caller and avoids polluting the audit log
+ *      with would-be-failures.
+ *
+ * The reason text format is fixed to start with `'operator-pinned'` so
+ * downstream review tooling (dashboard, REM audit) can distinguish operator
+ * overrides from §10.6 evidence-driven promotions ('§10.6 corroborated…')
+ * and §10.5 falsifications. An optional caller-supplied note is appended
+ * after a `:` separator.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+export type LessonTier = "A" | "B";
+
+export interface PinLessonOutcome {
+  lesson_id: string;
+  from_tier: LessonTier;
+  to_tier: LessonTier;
+  reason: string;
+}
+
+/**
+ * Side-effect bag — every DB write goes through one of these so the
+ * orchestrator is testable without a live Supabase. Same pattern as
+ * `RemPromotionDeps`.
+ */
+export interface SwarmPinDeps {
+  /** SELECT lesson_tier FROM swarm_lessons WHERE id = lessonId. Returns
+   * null when the row does not exist (caller maps to a "not found" error). */
+  fetchCurrentTier(lessonId: string): Promise<LessonTier | null>;
+  /** INSERT INTO tier_promotion_log — append-only per migration 078.
+   * evidence_ids is empty for operator-pinned transitions; the *reason*
+   * is the human-supplied justification. */
+  recordTierTransition(
+    lessonId: string,
+    fromTier: LessonTier,
+    toTier: LessonTier,
+    reason: string,
+  ): Promise<void>;
+  /** UPDATE swarm_lessons SET lesson_tier = toTier WHERE id = lessonId. */
+  updateLessonTier(lessonId: string, toTier: LessonTier): Promise<void>;
+}
+
+/**
+ * Build the `tier_promotion_log.reason` for an operator pin. Caps the
+ * caller note so the combined string fits the migration-078 reason CHECK
+ * (octet_length <= 512). The `'operator-pinned'` prefix is the
+ * machine-readable distinguisher that lets dashboards filter operator
+ * overrides out of (or specifically into) audit views.
+ */
+export function buildPinReason(note?: string): string {
+  const prefix = "operator-pinned";
+  if (!note || note.trim().length === 0) return prefix;
+  const trimmed = note.trim();
+  // 512 octet budget on the column; reserve ~20 octets for prefix + ": " + ellipsis.
+  const MAX_NOTE_OCTETS = 480;
+  const truncated = truncateToOctets(trimmed, MAX_NOTE_OCTETS);
+  return `${prefix}: ${truncated}`;
+}
+
+/**
+ * UTF-8-safe truncation by octet length. Avoids splitting a multi-byte
+ * code unit in the middle (Postgres rejects non-UTF-8 input).
+ */
+function truncateToOctets(text: string, maxOctets: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= maxOctets) return text;
+  // Walk back from the cap until we hit a UTF-8 boundary (top two bits not 10).
+  let cut = maxOctets;
+  while (cut > 0 && (buf[cut] & 0xc0) === 0x80) cut--;
+  return buf.slice(0, cut).toString("utf8") + "…";
+}
+
+export class SwarmPinService {
+  private db: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.db = createClient(supabaseUrl, supabaseKey);
+  }
+
+  /**
+   * Pin a lesson to the requested tier. Throws on:
+   *   - lesson not found
+   *   - current tier already equals target tier (no-op)
+   *   - audit-log INSERT failure (the tier UPDATE is skipped — see header)
+   *   - tier UPDATE failure
+   *
+   * Returns the from/to/reason on success so the tool layer can echo it
+   * back to the caller and (optionally) write a memory-bus row.
+   */
+  async pinLesson(
+    lessonId: string,
+    toTier: LessonTier,
+    note: string | undefined,
+    deps: SwarmPinDeps,
+  ): Promise<PinLessonOutcome> {
+    const currentTier = await deps.fetchCurrentTier(lessonId);
+    if (currentTier === null) {
+      throw new Error(`swarm_lesson ${lessonId} not found`);
+    }
+    if (currentTier === toTier) {
+      throw new Error(
+        `swarm_lesson ${lessonId} is already at tier ${toTier} — no-op`,
+      );
+    }
+    const reason = buildPinReason(note);
+    await deps.recordTierTransition(lessonId, currentTier, toTier, reason);
+    await deps.updateLessonTier(lessonId, toTier);
+    return {
+      lesson_id: lessonId,
+      from_tier: currentTier,
+      to_tier:   toTier,
+      reason,
+    };
+  }
+
+  /**
+   * Default deps wired against the service's own SupabaseClient. The MCP
+   * tool uses this when running in-process; tests inject mocks instead.
+   */
+  defaultDeps(): SwarmPinDeps {
+    const db = this.db;
+    return {
+      async fetchCurrentTier(lessonId) {
+        const { data, error } = await db
+          .from("swarm_lessons")
+          .select("lesson_tier")
+          .eq("id", lessonId)
+          .maybeSingle();
+        if (error) {
+          throw new Error(
+            `swarm_lessons fetch failed: ${error.message ?? String(error)}`,
+          );
+        }
+        if (!data) return null;
+        const tier = (data as { lesson_tier: string }).lesson_tier;
+        if (tier !== "A" && tier !== "B") {
+          throw new Error(
+            `swarm_lesson ${lessonId} has unexpected tier ${tier}`,
+          );
+        }
+        return tier;
+      },
+      async recordTierTransition(lessonId, fromTier, toTier, reason) {
+        const { error } = await db.from("tier_promotion_log").insert({
+          lesson_id:    lessonId,
+          from_tier:    fromTier,
+          to_tier:      toTier,
+          reason,
+          evidence_ids: [],
+        });
+        if (error) {
+          throw new Error(
+            `tier_promotion_log insert failed: ${error.message ?? String(error)}`,
+          );
+        }
+      },
+      async updateLessonTier(lessonId, toTier) {
+        const { error } = await db
+          .from("swarm_lessons")
+          .update({ lesson_tier: toTier })
+          .eq("id", lessonId);
+        if (error) {
+          throw new Error(
+            `swarm_lessons tier update failed: ${error.message ?? String(error)}`,
+          );
+        }
+      },
+    };
+  }
+}

--- a/mcp-server/src/tools/swarm-pin.ts
+++ b/mcp-server/src/tools/swarm-pin.ts
@@ -1,0 +1,188 @@
+/**
+ * `swarm_pin_lesson` MCP tool — first write-side slice of issue #143.
+ *
+ * Manual operator-side override of `swarm_lessons.lesson_tier`. Behind the
+ * `OPENCLAW_ALLOW_SWARM_WRITE=1` ethics-gate (mirrors `OPENCLAW_ALLOW_BREEDING`):
+ * an LLM agent cannot silently grow or pin into the swarm without an
+ * explicit operator opt-in.
+ *
+ * Tier semantics (SWARM_SPEC.md §10.6):
+ *   - "A" → broadcast-eligible (after promotion via §10.5 corroboration OR
+ *           operator pin). Visible in `swarm_lessons_broadcast_eligible`.
+ *   - "B" → tentative. NOT broadcast. Default for newly-ingested swarm
+ *           lessons; also set by §10.3 contradiction demotions.
+ *
+ * Audit trail: every successful pin appends a row to `tier_promotion_log`
+ * with `reason` prefixed `'operator-pinned'`. The migration-078 firebreak
+ * is therefore preserved — operator overrides are visible alongside REM-
+ * driven promotions in the same log.
+ *
+ * Memory-bus side-effect (issue #143 acceptance): on success the tool also
+ * writes a `decisions`-category memory tagged `swarm` so the agent's own
+ * tier-pinning decisions become recallable. This is best-effort — if the
+ * embedding provider is unreachable the tool still succeeds (the audit log
+ * already records the operation; the memory row is convenience, not
+ * compliance).
+ */
+
+import { z } from "zod";
+import { MemoryService } from "../services/supabase.js";
+import { SwarmPinService, type LessonTier } from "../services/swarm-pin.js";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const swarmPinLessonSchema = z.object({
+  lesson_id: z
+    .string()
+    .regex(UUID_REGEX, "lesson_id must be a UUID")
+    .describe("UUID of the swarm_lessons row to pin."),
+  tier: z
+    .enum(["A", "B"])
+    .describe(
+      "Target tier. 'A' = broadcast-eligible (manual promotion). " +
+        "'B' = tentative (manual demotion / firebreak).",
+    ),
+  reason: z
+    .string()
+    .max(480)
+    .optional()
+    .describe(
+      "Optional human-readable justification appended to the audit log " +
+        "after the 'operator-pinned' prefix. Capped at 480 chars to fit " +
+        "the migration-078 reason CHECK (octet_length <= 512).",
+    ),
+});
+
+export type SwarmPinLessonInput = z.infer<typeof swarmPinLessonSchema>;
+
+export interface SwarmPinLessonOutput {
+  ok: boolean;
+  lesson_id?: string;
+  from_tier?: LessonTier;
+  to_tier?: LessonTier;
+  reason?: string;
+  memory_recorded?: boolean;
+  memory_error?: string;
+  error?: string;
+  fix_hint?: string;
+}
+
+export interface McpToolResult {
+  content: { type: "text"; text: string }[];
+}
+
+function asMcpResult(payload: SwarmPinLessonOutput): McpToolResult {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+/**
+ * Ethics-gate check. Mirrors the OPENCLAW_ALLOW_BREEDING pattern documented
+ * in vector-memory under "engram-mcp Ethik-Gate 1: Keine autonome
+ * Reproduktion." For pin_lesson the surface is smaller (a single lesson's
+ * broadcast eligibility) but the principle is the same: a write into the
+ * §10 trust substrate requires explicit operator consent expressed via env.
+ */
+function isSwarmWriteAllowed(): boolean {
+  return process.env.OPENCLAW_ALLOW_SWARM_WRITE === "1";
+}
+
+/**
+ * Pure handler — returns the structured output. Exposed for unit tests so
+ * they don't have to unwrap the MCP `content` envelope. The MCP-facing
+ * adapter `swarmPinLessonHandler` wraps this in the `{ content: [...] }`
+ * shape that `withErrorHandling` expects.
+ */
+export async function swarmPinLesson(
+  pinService: SwarmPinService,
+  memoryService: MemoryService,
+  input: SwarmPinLessonInput,
+): Promise<SwarmPinLessonOutput> {
+  if (!isSwarmWriteAllowed()) {
+    return {
+      ok: false,
+      error: "swarm_pin_lesson requires OPENCLAW_ALLOW_SWARM_WRITE=1",
+      fix_hint:
+        "Operator must opt in by setting OPENCLAW_ALLOW_SWARM_WRITE=1 in " +
+        "the MCP server environment. Without it, no MCP tool can write to " +
+        "the swarm trust substrate (§3.4 / §10.6 firebreak).",
+    };
+  }
+
+  let outcome;
+  try {
+    outcome = await pinService.pinLesson(
+      input.lesson_id,
+      input.tier,
+      input.reason,
+      pinService.defaultDeps(),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok:    false,
+      error: message,
+      fix_hint:
+        message.includes("not found")
+          ? "Verify the lesson_id exists in swarm_lessons. Check spelling/case."
+          : message.includes("already at tier")
+            ? "Lesson is already at the requested tier. Pass the opposite tier or skip."
+            : "Inspect the swarm_lessons / tier_promotion_log tables for the underlying DB error.",
+    };
+  }
+
+  // Memory-bus side-effect — best-effort. The audit row in tier_promotion_log
+  // is the durable record; the memory row is a recall convenience for the
+  // agent's own future introspection ("did I pin anything in the last hour?").
+  let memory_recorded = false;
+  let memory_error: string | undefined;
+  try {
+    const direction = outcome.from_tier === "B" ? "promoted" : "demoted";
+    await memoryService.create({
+      content:
+        `Operator pinned swarm_lesson ${outcome.lesson_id}: ` +
+        `${direction} ${outcome.from_tier} → ${outcome.to_tier}. ${outcome.reason}`,
+      category: "decisions",
+      tags:     ["swarm", "tier-pin", `tier-${outcome.to_tier.toLowerCase()}`],
+      metadata: {
+        lesson_id: outcome.lesson_id,
+        from_tier: outcome.from_tier,
+        to_tier:   outcome.to_tier,
+        source:    "swarm_pin_lesson",
+      },
+      source: "swarm_pin_lesson",
+    });
+    memory_recorded = true;
+  } catch (err) {
+    memory_error = err instanceof Error ? err.message : String(err);
+  }
+
+  return {
+    ok:        true,
+    lesson_id: outcome.lesson_id,
+    from_tier: outcome.from_tier,
+    to_tier:   outcome.to_tier,
+    reason:    outcome.reason,
+    memory_recorded,
+    ...(memory_error ? { memory_error } : {}),
+  };
+}
+
+/**
+ * MCP-facing adapter — wraps the pure handler's result in the
+ * `{ content: [{ type, text }] }` envelope that `withErrorHandling`
+ * expects. Returning structured JSON-as-text matches the convention used
+ * by recall.ts and the rest of the tool surface.
+ */
+export async function swarmPinLessonHandler(
+  pinService: SwarmPinService,
+  memoryService: MemoryService,
+  input: SwarmPinLessonInput,
+): Promise<McpToolResult> {
+  const output = await swarmPinLesson(pinService, memoryService, input);
+  return asMcpResult(output);
+}


### PR DESCRIPTION
## Summary

First **write-side** slice of issue #143's MCP-tool surface. Companion to PR #149's read-only `swarm_list_peers`. Manual operator override of `swarm_lessons.lesson_tier` ('A' = broadcast-eligible, 'B' = tentative firebreak), audited via `tier_promotion_log` with reason prefix `'operator-pinned'`.

Refs #143. Other write tools from #143 (`swarm_publish_tier_a_lesson`, `swarm_admit_lesson`, `swarm_resolve_contradict`) ship in follow-up PRs.

## Why a thin slice

Issue #143 names five tools. `swarm_pin_lesson` is the only one that depends on **zero** open PRs:

| Tool                             | Dependency                                                    |
|----------------------------------|---------------------------------------------------------------|
| `swarm_list_peers`               | none → PR #149 (open)                                         |
| **`swarm_pin_lesson`**           | **migrations 071+078, both in main → this PR**                |
| `swarm_publish_tier_a_lesson`    | producer-side lesson_chain hook (#136 → PR #146 open)         |
| `swarm_admit_lesson`             | inbound POST `/swarm/lessons` (#138 → no PR yet)              |
| `swarm_resolve_contradict`       | dashboard pair table maintenance (#142 → no PR yet)           |

Shipping the operator-pin path first unlocks Reed's manual-override authority over the §10.6 firebreak without waiting on the rest.

## Design points (pinned by tests)

1. **Audit-first ordering.** `tier_promotion_log` INSERT runs BEFORE the `swarm_lessons.lesson_tier` UPDATE. If the UPDATE fails, the audit row still records the operator's intent. The §10.6 traceability contract requires every transition attempt on the log — losing the audit is worse than a stuck tier.

2. **No-op rejection at the service boundary.** If `current_tier` already equals target tier, the service throws BEFORE any DB write. The migration-078 `(from_tier <> to_tier)` CHECK would reject a no-op INSERT anyway, but throwing earlier produces a cleaner error and avoids audit-log noise.

3. **Ethics-gate.** `OPENCLAW_ALLOW_SWARM_WRITE=1` mirrors `OPENCLAW_ALLOW_BREEDING`. Without it the tool returns a structured `{ ok:false, error, fix_hint }` — an LLM agent without operator consent learns from the hint instead of crashing the session. Only literal `'1'` opens the gate (truthy strings like `'true'` are explicitly rejected).

4. **UTF-8-safe reason truncation.** `buildPinReason` caps at 480 chars + 'operator-pinned: ' prefix to fit migration-078's `octet_length(reason) <= 512` CHECK. Truncation walks back to a UTF-8 codepoint boundary so a 4-byte emoji never gets split (Postgres rejects partial codepoints).

5. **Memory-bus side-effect.** Per #143 acceptance: successful pins write a `decisions`-category memory tagged `swarm`. **Best-effort** — if the embedding provider is unreachable the tool still succeeds; the audit log is the durable record.

## Files

- `mcp-server/src/services/swarm-pin.ts` — pure orchestrator with injectable deps, mirrors the rem-promotion.ts pattern.
- `mcp-server/src/tools/swarm-pin.ts` — MCP tool with ethics-gate + Zod schema + memory-bus wiring.
- `mcp-server/src/__tests__/swarm-pin.test.ts` — 14 tests covering reason builder, orchestrator ordering, ethics-gate, schema validation.
- `mcp-server/src/index.ts` — register the tool (+25 lines, no other changes).

## Test plan

- [x] `npm run build` clean (TypeScript strict)
- [x] `npm test` green (660 tests pass; +14 new)
- [x] Audit-first ordering verified (UPDATE skipped when audit-log INSERT fails)
- [x] No-op rejection verified (throws before DB calls)
- [x] Ethics-gate verified (refuses without env, accepts only `'1'`)
- [x] UTF-8 boundary verified (4-byte emoji truncation produces clean ellipsis)
- [x] Schema rejects malformed UUIDs and out-of-enum tiers
- [ ] Integration test against a live DB — deferred to a follow-up since this PR's pure-handler tests already cover the orchestrator contract; live-DB testing belongs with the rest of the #143 write-tool suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)