### PR TITLE
feat(swarm): wire GET /swarm/lessons/{id}/proof into dashboard-server (#105)

### DIFF
--- a/mcp-server/src/__tests__/dashboard-server-lesson-proof-wiring.test.ts
+++ b/mcp-server/src/__tests__/dashboard-server-lesson-proof-wiring.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Contract test for the wiring of GET /swarm/lessons/{id}/proof into
+ * scripts/dashboard-server.mjs (Swarm sub-phase 4e, issue #105).
+ *
+ * The handler module `swarm/endpoints/lesson-proof.ts` shipped in PR #128
+ * with full unit + integration coverage of its own logic. What the
+ * integration test in `lesson-proof-endpoint.test.ts` does NOT prove is
+ * that any HTTP host actually mounts the handler — and indeed for several
+ * weeks no host did. This file pins the wiring at the source-text level so
+ * a future refactor of dashboard-server.mjs cannot silently regress it
+ * without flipping a test red.
+ *
+ * Same shape-pin discipline as the migration contract tests (070..082):
+ * scripts/dashboard-server.mjs is not part of the tsc test loop, so we
+ * read it as text and assert structural facts rather than booting it.
+ * Comments are stripped before keyword matches so an explanatory comment
+ * cannot satisfy a structural assertion.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, repo root is three levels up.
+const DASHBOARD_PATH = resolve(
+  __dirname,
+  "../../..",
+  "scripts/dashboard-server.mjs",
+);
+const RAW = readFileSync(DASHBOARD_PATH, "utf8");
+const NO_COMMENTS = RAW.replace(/\/\/[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+
+// ---------------------------------------------------------------------------
+// (1) The handler module is imported.
+// ---------------------------------------------------------------------------
+
+test("dashboard-server imports buildLessonProofResponse from the compiled handler", () => {
+  // Match the dynamic import — the dashboard uses await import() because
+  // the FED dist path is computed at runtime from ROOT.
+  const importRe =
+    /buildLessonProofResponse[^}]*\}\s*=\s*await\s+import\([^)]*lesson-proof\.js[^)]*\)/;
+  assert.match(
+    NO_COMMENTS,
+    importRe,
+    "dashboard-server.mjs must import buildLessonProofResponse from " +
+      "mcp-server/dist/swarm/endpoints/lesson-proof.js",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) The route regex pins the SWARM_SPEC §4.6 path shape.
+// Anchored UUID match keeps a stray /swarm/lessons/foo/proof from reaching
+// the handler with a malformed id (the handler would 400 anyway, but
+// the regex turns the rejection into a clean 404 falling through to the
+// static handler instead — same discipline as PROOF_PATH_RE in the test).
+// ---------------------------------------------------------------------------
+
+test("dashboard-server defines a UUID-anchored proof path regex", () => {
+  // Whitespace-tolerant — the source uses multi-line formatting.
+  const compact = NO_COMMENTS.replace(/\s+/g, "");
+  assert.match(
+    compact,
+    /constPROOF_PATH_RE\s*=\s*\/\^\\\/swarm\\\/lessons\\\/\(/,
+    "PROOF_PATH_RE must anchor on /swarm/lessons/ and capture a UUID",
+  );
+  assert.ok(
+    /\\\/proof\$/.test(compact),
+    "PROOF_PATH_RE must terminate at /proof",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) The router registers the proof route BEFORE the static fall-through
+// so /swarm/lessons/{id}/proof never gets served as a file path.
+// ---------------------------------------------------------------------------
+
+test("dashboard-server registers handleLessonProof before the static handler", () => {
+  // Find the request dispatcher — it's inside http.createServer((req,res)=>{...}).
+  const proofMatchIdx = NO_COMMENTS.indexOf("PROOF_PATH_RE");
+  assert.ok(
+    proofMatchIdx > 0,
+    "PROOF_PATH_RE must be referenced in the dispatcher",
+  );
+  // The route must invoke handleLessonProof.
+  assert.match(
+    NO_COMMENTS,
+    /handleLessonProof\s*\(/,
+    "Dispatcher must call handleLessonProof when PROOF_PATH_RE matches",
+  );
+  // And the dispatch must precede the /api/ proxy fall-through, which is
+  // the first generic prefix match in the router.
+  const dispatcherStart = NO_COMMENTS.indexOf(
+    "http.createServer((req, res)",
+  );
+  assert.ok(dispatcherStart > 0, "createServer dispatcher must exist");
+  const proofRouteIdx = NO_COMMENTS.indexOf(
+    "PROOF_PATH_RE",
+    dispatcherStart,
+  );
+  const apiPrefixIdx = NO_COMMENTS.indexOf('"/api/"', dispatcherStart);
+  assert.ok(
+    proofRouteIdx > 0 && apiPrefixIdx > 0 && proofRouteIdx < apiPrefixIdx,
+    "Proof route registration must come before the /api/ proxy " +
+      "fall-through so a malformed UUID doesn't get treated as an API " +
+      "path",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) Loaders are wired against the substrate tables, NOT the broken
+// get_lesson_evidence RPC. Issue #135 / PR #140 fixes the RPC; until that
+// migration lands, the dashboard-server MUST read the table directly to
+// avoid a hard dependency on a function that doesn't exist on PG16.
+// ---------------------------------------------------------------------------
+
+test("loadLeaves reads lesson_evidence_origin directly (not the broken RPC)", () => {
+  assert.match(
+    NO_COMMENTS,
+    /lesson_evidence_origin\?select=hashed_experience_id/,
+    "loadLeaves must SELECT from lesson_evidence_origin to bypass the " +
+      "PG16-broken get_lesson_evidence function (issue #135)",
+  );
+  assert.ok(
+    !/\/rpc\/get_lesson_evidence/.test(NO_COMMENTS),
+    "dashboard-server must NOT call /rpc/get_lesson_evidence — that " +
+      "function fails to be created on PG16 until migration 084 lands",
+  );
+});
+
+test("loadLesson and wasPublishedByThisNode read the expected substrate tables", () => {
+  assert.match(
+    NO_COMMENTS,
+    /swarm_lessons\?select=origin_node_id,signed_at,spec_version/,
+    "loadLesson must SELECT origin_node_id,signed_at,spec_version " +
+      "from swarm_lessons",
+  );
+  assert.match(
+    NO_COMMENTS,
+    /lesson_chain\?select=lesson_id/,
+    "wasPublishedByThisNode must check lesson_chain for the lesson_id " +
+      "to disambiguate 404 vs 410 per SWARM_SPEC §4.6",
+  );
+});

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -60,6 +60,12 @@ const SWARM_ENDPOINTS_DIST = path.join(ROOT, "mcp-server", "dist", "swarm", "end
 const { buildNodeAdvertisementResponse } = await import(
   path.join(SWARM_ENDPOINTS_DIST, "node-advertisement.js")
 );
+// Swarm sub-phase 4e (issue #105): GET /swarm/lessons/{id}/proof. The
+// handler module shipped in PR #128 but never got wired into an HTTP host,
+// so the endpoint was unreachable. Wiring it here closes that gap.
+const { buildLessonProofResponse } = await import(
+  path.join(SWARM_ENDPOINTS_DIST, "lesson-proof.js")
+);
 
 // --- load JWT_SECRET from docker/.env so we can mint a service_role JWT ---
 async function loadEnv() {
@@ -1803,6 +1809,77 @@ async function handleNodeAdvertisement(_req, res) {
   res.end(result.body);
 }
 
+// --- Swarm sub-phase 4e: GET /swarm/lessons/{id}/proof ------------------
+// SWARM_SPEC §4.6 Merkle-inclusion proof envelope. The handler is pure;
+// the loaders below adapt PostgREST table reads to its async surface.
+//
+// Loaders read directly from the substrate tables rather than the
+// `get_lesson_evidence` RPC: that RPC is broken on PG16 until migration
+// 084 lands (issue #135 / PR #140) — the table read works regardless.
+const PROOF_PATH_RE =
+  /^\/swarm\/lessons\/([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\/proof$/i;
+
+async function pgSelect(query) {
+  const r = await fetch(new URL(`/${query}`, UPSTREAM), {
+    method: "GET",
+    headers: {
+      "Accept":        "application/json",
+      "Authorization": `Bearer ${SERVICE_JWT}`,
+      "apikey":        SERVICE_JWT,
+    },
+  });
+  if (!r.ok) {
+    throw new Error(`postgrest GET /${query} failed: HTTP ${r.status}`);
+  }
+  return r.json();
+}
+
+async function handleLessonProof(_req, res, lessonId) {
+  try {
+    const result = await buildLessonProofResponse({
+      lessonId,
+      loadSelf: async () => {
+        const self = await nodeIdentityService.getSelf();
+        if (!self) return null;
+        return { node_id: self.node_id, pubkey_b64: self.pubkey_b64 };
+      },
+      loadLesson: async (id) => {
+        const rows = await pgSelect(
+          `swarm_lessons?select=origin_node_id,signed_at,spec_version&id=eq.${encodeURIComponent(id)}&limit=1`,
+        );
+        if (!Array.isArray(rows) || rows.length === 0) return null;
+        const r = rows[0];
+        return {
+          origin_node_id: r.origin_node_id,
+          signed_at: r.signed_at,
+          spec_version: r.spec_version,
+        };
+      },
+      loadLeaves: async (id) => {
+        const rows = await pgSelect(
+          `lesson_evidence_origin?select=hashed_experience_id,position&lesson_id=eq.${encodeURIComponent(id)}&order=position.asc`,
+        );
+        if (!Array.isArray(rows)) return [];
+        return rows.map((r) => r.hashed_experience_id);
+      },
+      wasPublishedByThisNode: async (id) => {
+        const rows = await pgSelect(
+          `lesson_chain?select=lesson_id&lesson_id=eq.${encodeURIComponent(id)}&limit=1`,
+        );
+        return Array.isArray(rows) && rows.length > 0;
+      },
+    });
+    res.writeHead(result.status, result.headers);
+    res.end(result.body);
+  } catch (e) {
+    res.writeHead(503, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(JSON.stringify({
+      error: "lesson-proof handler failed",
+      detail: String(e?.message || e),
+    }));
+  }
+}
+
 const server = http.createServer((req, res) => {
   // Tiny access log.
   const t = new Date().toISOString();
@@ -1817,6 +1894,11 @@ const server = http.createServer((req, res) => {
   if (req.url === "/swarm/contradict-resolve")  return handleSwarmContradictResolve(req, res);
   if (req.url === "/swarm/peer-trust-override") return handleSwarmPeerTrustOverride(req, res);
   if (req.url === "/swarm/lesson-pin")          return handleSwarmLessonPin(req, res);
+  // Swarm sub-phase 4e (issue #105): inclusion-proof endpoint.
+  if (req.method === "GET" && req.url) {
+    const proofMatch = req.url.match(PROOF_PATH_RE);
+    if (proofMatch) return handleLessonProof(req, res, proofMatch[1]);
+  }
   if (req.url.startsWith("/api/"))            return proxyApi(req, res);
   if (req.url.startsWith("/belief"))          return proxyBelief(req, res);
   if (req.url.startsWith("/guard"))           return proxyGuard(req, res);


### PR DESCRIPTION
## Summary

- Mounts \`buildLessonProofResponse\` (PR #128, sub-phase 4e) onto \`scripts/dashboard-server.mjs\` so the SWARM_SPEC §4.6 inclusion-proof endpoint is finally reachable. Until this lands, the handler module has been correctly tested in isolation but no HTTP host invoked it — peers asking for a proof got a 404 from the static fall-through.
- Loaders read \`lesson_evidence_origin\` and \`swarm_lessons\` directly via PostgREST instead of the \`get_lesson_evidence\` RPC, since that RPC fails to be created on PG16 until migration 084 lands (issue #135 / PR #140). The contract test pins this so a future refactor cannot regress it without flipping a test red.
- The route regex anchors on a v1–v8 UUID so a malformed id falls through to static-handler 404 instead of reaching the proof handler. UUID validation is also enforced inside \`buildLessonProofResponse\` — the regex is defense-in-depth.

Closes the wiring half of issue #105.

## Diff shape

\`\`\`
mcp-server/src/__tests__/dashboard-server-lesson-proof-wiring.test.ts | 153 ++++++++++++++++++
scripts/dashboard-server.mjs                                          |  77 ++++++++++
2 files changed, 230 insertions(+)
\`\`\`

No mcp-server/src or migration changes — purely an HTTP-host wire-up.

## Why now

- PR #128 has been merged for ~12 hours but the §4.6 endpoint is unreachable; this is the smallest, most surgical fix.
- Doesn't conflict with any open PR. PR #133 also touches \`scripts/dashboard-server.mjs\` but in completely different sections (federation lazy-load near line 35, /swarm-overview around line 943); rebase will be trivial whichever lands first.
- Substrate already on main: migrations 071 (\`swarm_lessons\`), 074 (\`lesson_chain\`), 077 (\`lesson_evidence_origin\`).

## Test plan

- [x] \`npm test\` — 665 pass (was 660; this PR adds 5 wiring contract tests)
- [x] \`node --check scripts/dashboard-server.mjs\` — clean
- [ ] After merge + apply migrations: \`curl http://localhost:8787/swarm/lessons/<known-locally-published-id>/proof\` returns 200 with a valid \`{lesson_id, evidence_count, evidence_root, inclusion_proofs[], spec_version, signed_at, signature}\` envelope (handler module already covered by \`lesson-proof-endpoint.test.ts\`).
- [ ] After merge: \`curl http://localhost:8787/swarm/lessons/00000000-0000-4000-8000-000000000000/proof\` returns 404 (unknown id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)