### PR TITLE
feat(swarm): inbound /swarm/lessons admission handler — substrate (#138)

### DIFF
--- a/mcp-server/src/__tests__/lesson-admission.test.ts
+++ b/mcp-server/src/__tests__/lesson-admission.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Tests for admitSwarmLesson — Swarm sub-phase 4j (issue #138).
+ *
+ * Substrate-only: the handler returns an HttpResponseShape and takes every
+ * side-effect via injected callbacks. So we test the handler in isolation
+ * (no HTTP server, no DB) by passing in-memory deps and asserting on the
+ * triple's status / body / headers, plus on what the deps observed.
+ *
+ * Coverage (one assertion per branch in admitSwarmLesson):
+ *   - 400 on non-object body
+ *   - 400 on missing origin_node_id
+ *   - 400 on malformed lesson id
+ *   - 400 on self-loop (origin == self.node_id)
+ *   - 401 on unknown peer (no quarantine — no edge to write to)
+ *   - 403 on already-quarantined origin
+ *   - 401 + quarantine on bad signature (rule 5)
+ *   - 401 + quarantine on broken chain (rule 19)
+ *   - 400 + quarantine on PoK count rule (rule 16)
+ *   - 400 + quarantine on PoK shape rule (rule 20)
+ *   - 400 plain on missing required field (rule 2)
+ *   - 503 on insertSwarmLesson throw (validation passed but persist failed)
+ *   - 201 happy path: row inserted with lesson_tier='B', trust +0.05 logged,
+ *     gate ran, response carries the lesson_id and contradiction count
+ *   - Trust-edge throw is non-fatal (still 201)
+ *   - Gate throw is non-fatal (still 201)
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+
+import {
+  admitSwarmLesson,
+  type LessonAdmissionDeps,
+} from "../swarm/endpoints/lesson-admission.js";
+import { sign } from "../services/signature.js";
+import { computeNodeId } from "../services/node-identity.js";
+import { WIRE_SPEC_VERSION } from "../services/wire-types.js";
+import type { ContradictionFinding, SwarmLessonRow } from "../services/lesson-contradiction-gate.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirror wire-validator.test.ts so failure modes match)
+// ---------------------------------------------------------------------------
+
+interface Identity {
+  pem: string;
+  pubkeyRaw: Uint8Array;
+  pubkeyB64: string;
+  nodeId: string;
+}
+
+function freshIdentity(): Identity {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ type: "spki", format: "der" });
+  const pubkeyRaw = new Uint8Array(spki.subarray(spki.length - 32));
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  return {
+    pem,
+    pubkeyRaw,
+    pubkeyB64: Buffer.from(pubkeyRaw).toString("base64"),
+    nodeId: computeNodeId(Buffer.from(pubkeyRaw)),
+  };
+}
+
+function full768Embedding(seed = 0): number[] {
+  const out = new Array<number>(768);
+  for (let i = 0; i < 768; i++) out[i] = (seed + i) / 1000;
+  return out;
+}
+
+const FIXED_NOW = new Date("2026-04-28T12:00:00.000Z");
+
+function buildValidLessonRecord(
+  producer: Identity,
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  const unsigned = {
+    id: "11111111-2222-4333-8444-555555555555",
+    content: "Receivers must firebreak admitted lessons at Tier-B by default.",
+    embedding: full768Embedding(),
+    synthesized_from_cluster_size: 4,
+    origin_node_id: producer.nodeId,
+    signed_at: "2026-04-28T11:00:00.000Z",
+    created_at: "2026-04-27T10:00:00.000Z",
+    tags: ["test", "swarm"],
+    spec_version: WIRE_SPEC_VERSION,
+    evidence_root: "1220" + "ab".repeat(32),
+    evidence_count: 4,
+    prev_lesson_hash: null,
+    maturity_age_days: 1,
+    useful_count: 0,
+    ...overrides,
+  };
+  return { ...unsigned, signature: sign(unsigned, producer.pem) };
+}
+
+interface DepsHarness {
+  deps: LessonAdmissionDeps;
+  inserted: Array<{ row: unknown; assigned_id: string }>;
+  trustEdges: Array<{ node_id: string; delta: number; reason: string }>;
+  quarantines: Array<{ node_id: string; until_ms: number; reason: string }>;
+  gateInputs: SwarmLessonRow[];
+}
+
+interface HarnessOptions {
+  body: unknown;
+  self: Identity;
+  knownPeers?: Map<string, Identity>;
+  quarantinedUntil?: Map<string, string>;
+  expectedPrevHash?: Map<string, string>;
+  failInsert?: boolean;
+  failTrust?: boolean;
+  failGate?: boolean;
+  gateFindings?: ContradictionFinding[];
+  withGate?: boolean;
+  loadSelfThrows?: boolean;
+}
+
+function buildHarness(opts: HarnessOptions): DepsHarness {
+  const inserted: DepsHarness["inserted"] = [];
+  const trustEdges: DepsHarness["trustEdges"] = [];
+  const quarantines: DepsHarness["quarantines"] = [];
+  const gateInputs: SwarmLessonRow[] = [];
+
+  const deps: LessonAdmissionDeps = {
+    body: opts.body,
+    ourSpecMajor: 1,
+    now: FIXED_NOW,
+    loadSelf: async () => {
+      if (opts.loadSelfThrows) throw new Error("loadSelf boom");
+      return { node_id: opts.self.nodeId, pubkey_b64: opts.self.pubkeyB64 };
+    },
+    getPubkeyForNode: async (nodeId) => {
+      const peer = opts.knownPeers?.get(nodeId);
+      return peer ? peer.pubkeyRaw : null;
+    },
+    getQuarantinedUntil: async (nodeId) =>
+      opts.quarantinedUntil?.get(nodeId) ?? null,
+    getExpectedPrevLessonHash: opts.expectedPrevHash
+      ? async (nodeId) => opts.expectedPrevHash!.get(nodeId) ?? null
+      : undefined,
+    insertSwarmLesson: async (row) => {
+      if (opts.failInsert) throw new Error("insert boom");
+      const assigned_id = row.id; // honour the wire id (validator already enforced UUID)
+      inserted.push({ row, assigned_id });
+      return { lesson_id: assigned_id };
+    },
+    setQuarantine: async (node_id, until_ms, reason) => {
+      quarantines.push({ node_id, until_ms, reason });
+    },
+    recordTrustEdgeChange: async (node_id, delta, reason) => {
+      if (opts.failTrust) throw new Error("trust boom");
+      trustEdges.push({ node_id, delta, reason });
+    },
+    runContradictionGate: opts.withGate
+      ? async (incoming) => {
+          gateInputs.push(incoming);
+          if (opts.failGate) throw new Error("gate boom");
+          return { findings: opts.gateFindings ?? [] };
+        }
+      : undefined,
+  };
+
+  return { deps, inserted, trustEdges, quarantines, gateInputs };
+}
+
+async function readJson(body: string): Promise<Record<string, unknown>> {
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// 400 / 401 / 403 — pre-validation guards
+// ---------------------------------------------------------------------------
+
+test("rejects 400 when body is not a JSON object", async () => {
+  const self = freshIdentity();
+  const h = buildHarness({ body: "this is a string", self });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.match(body.error as string, /JSON object/);
+  assert.equal(h.inserted.length, 0);
+  assert.equal(h.quarantines.length, 0);
+});
+
+test("rejects 400 when origin_node_id is missing or empty", async () => {
+  const self = freshIdentity();
+  const h = buildHarness({ body: { content: "no origin" }, self });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 2);
+  assert.equal(h.inserted.length, 0);
+});
+
+test("rejects 400 when lesson id is not a UUID", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer, { id: "not-a-uuid" });
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 3);
+  assert.equal(h.inserted.length, 0);
+});
+
+test("rejects 400 on self-loop (origin == self.node_id)", async () => {
+  const self = freshIdentity();
+  const record = buildValidLessonRecord(self);
+  const h = buildHarness({ body: record, self });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.match(body.error as string, /self-published/);
+  assert.equal(body.origin_node_id, self.nodeId);
+});
+
+test("rejects 401 with no quarantine when peer is unknown", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map(), // peer not registered
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 401);
+  const body = await readJson(res.body);
+  assert.match(body.error as string, /unknown peer/);
+  // No edge to quarantine — the firebreak only applies once we know who they are.
+  assert.equal(h.quarantines.length, 0);
+});
+
+test("rejects 403 when origin is currently quarantined", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const futureIso = new Date(FIXED_NOW.getTime() + 30 * 60 * 1000).toISOString();
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    quarantinedUntil: new Map([[peer.nodeId, futureIso]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 403);
+  const body = await readJson(res.body);
+  assert.equal(body.quarantined_until, futureIso);
+  // Pre-check is decision-only — does not re-quarantine.
+  assert.equal(h.quarantines.length, 0);
+  // And we never reached the persist layer.
+  assert.equal(h.inserted.length, 0);
+});
+
+test("admits 201 when an expired quarantine is in the past", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const pastIso = new Date(FIXED_NOW.getTime() - 60 * 1000).toISOString();
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    quarantinedUntil: new Map([[peer.nodeId, pastIso]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 201);
+  assert.equal(h.inserted.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Single-strike rules: 5, 19 (-> 401 + quarantine), 16, 20 (-> 400 + quarantine)
+// ---------------------------------------------------------------------------
+
+test("rejects 401 + quarantine on bad signature (rule 5)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  // Sign as `peer`, then mutate a field after signing — signature no longer matches.
+  const tampered = {
+    ...buildValidLessonRecord(peer),
+    content: "MUTATED AFTER SIGNING",
+  };
+  const h = buildHarness({
+    body: tampered,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 401);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 5);
+  assert.equal(body.quarantined, true);
+  assert.equal(h.quarantines.length, 1);
+  assert.equal(h.quarantines[0].node_id, peer.nodeId);
+  assert.equal(
+    h.quarantines[0].until_ms,
+    FIXED_NOW.getTime() + 60 * 60 * 1000,
+  );
+  assert.equal(h.inserted.length, 0);
+});
+
+test("rejects 401 + quarantine on broken commitment chain (rule 19)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  // Producer claims their predecessor was hash A, but our cache says hash B.
+  const record = buildValidLessonRecord(peer, {
+    prev_lesson_hash: "Qm" + "z".repeat(44),
+  });
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    expectedPrevHash: new Map([[peer.nodeId, "Qm" + "x".repeat(44)]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 401);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 19);
+  assert.equal(body.quarantined, true);
+  assert.equal(h.quarantines.length, 1);
+});
+
+test("rejects 400 + quarantine on PoK count rule (rule 16)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  // evidence_count=0 trips rule 16 (must be integer >= 1).
+  const record = buildValidLessonRecord(peer, { evidence_count: 0 });
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 16);
+  assert.equal(body.quarantined, true);
+  assert.equal(h.quarantines.length, 1);
+});
+
+test("rejects 400 + quarantine on PoK shape rule (rule 20, smuggling on 1.0)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  // v1.0 record carrying v1.1 PoK fields trips rule 20 (third leg).
+  const record = buildValidLessonRecord(peer, {
+    spec_version: "1.0",
+    // PoK fields stay attached from the base fixture — illegal on v1.0.
+  });
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 20);
+  assert.equal(body.quarantined, true);
+});
+
+// ---------------------------------------------------------------------------
+// Plain rejections — validator failures that do NOT pull a quarantine
+// ---------------------------------------------------------------------------
+
+test("rejects 400 plain on missing required field (rule 2)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  // Drop `content` AFTER signing — but we have to re-sign without it so
+  // rule 5 doesn't fire first. So drop content from the unsigned base
+  // and re-sign.
+  const valid = buildValidLessonRecord(peer);
+  const { content, signature, ...withoutContent } = valid as Record<
+    string,
+    unknown
+  >;
+  void content;
+  void signature;
+  const resigned = { ...withoutContent, signature: sign(withoutContent, peer.pem) };
+  const h = buildHarness({
+    body: resigned,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 400);
+  const body = await readJson(res.body);
+  assert.equal(body.rule, 2);
+  assert.equal(body.quarantined, false);
+  assert.equal(h.quarantines.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Persistence-layer failures
+// ---------------------------------------------------------------------------
+
+test("rejects 503 when insertSwarmLesson throws", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    failInsert: true,
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 503);
+  const body = await readJson(res.body);
+  assert.match(body.error as string, /insertSwarmLesson failed/);
+  // Trust update must NOT have run — the lesson never persisted.
+  assert.equal(h.trustEdges.length, 0);
+});
+
+test("rejects 503 when loadSelf throws", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    loadSelfThrows: true,
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 503);
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+test("admits 201 and writes the row, trust edge, and runs gate", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const finding: ContradictionFinding = {
+    new_lesson_id: "11111111-2222-4333-8444-555555555555",
+    prior_lesson_id: "99999999-8888-4777-8666-555555555555",
+    cosine: 0.91,
+    confidence: 0.91,
+    reason: "polarity inversion",
+  };
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    withGate: true,
+    gateFindings: [finding],
+  });
+  const res = await admitSwarmLesson(h.deps);
+
+  assert.equal(res.status, 201);
+  assert.equal(
+    res.headers["Content-Type"],
+    "application/json; charset=utf-8",
+  );
+  const body = await readJson(res.body);
+  assert.equal(body.lesson_id, "11111111-2222-4333-8444-555555555555");
+  assert.equal(body.lesson_tier, "B");
+  assert.equal(body.contradictions, 1);
+  assert.equal(body.origin_node_id, peer.nodeId);
+
+  // Row persisted with the §10.6 firebreak default.
+  assert.equal(h.inserted.length, 1);
+  const persisted = h.inserted[0].row as Record<string, unknown>;
+  assert.equal(persisted.lesson_tier, "B");
+  assert.equal(persisted.origin_node_id, peer.nodeId);
+
+  // Trust edge: §10.1 +0.05 'admitted'.
+  assert.equal(h.trustEdges.length, 1);
+  assert.equal(h.trustEdges[0].node_id, peer.nodeId);
+  assert.equal(h.trustEdges[0].delta, 0.05);
+  assert.equal(h.trustEdges[0].reason, "admitted");
+
+  // Gate received the freshly-admitted row.
+  assert.equal(h.gateInputs.length, 1);
+  assert.equal(h.gateInputs[0].id, body.lesson_id);
+  assert.equal(h.gateInputs[0].lesson_tier, "B");
+
+  // No quarantine on the happy path.
+  assert.equal(h.quarantines.length, 0);
+});
+
+test("admits 201 even when trust-edge bookkeeping throws", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    failTrust: true,
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 201);
+  // Lesson still persisted; trust failure is non-fatal.
+  assert.equal(h.inserted.length, 1);
+  assert.equal(h.trustEdges.length, 0);
+});
+
+test("admits 201 even when contradiction gate throws", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    withGate: true,
+    failGate: true,
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 201);
+  const body = await readJson(res.body);
+  // Findings default to 0 when the gate threw.
+  assert.equal(body.contradictions, 0);
+  assert.equal(h.inserted.length, 1);
+});
+
+test("admits 201 with no gate dep wired (gate is optional)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const record = buildValidLessonRecord(peer);
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    withGate: false,
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 201);
+  const body = await readJson(res.body);
+  assert.equal(body.contradictions, 0);
+  assert.equal(h.gateInputs.length, 0);
+});
+
+test("forwards prev-hash chain into the validator (happy chain)", async () => {
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const expected = "Qm" + "y".repeat(44);
+  const record = buildValidLessonRecord(peer, { prev_lesson_hash: expected });
+  const h = buildHarness({
+    body: record,
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    expectedPrevHash: new Map([[peer.nodeId, expected]]),
+  });
+  const res = await admitSwarmLesson(h.deps);
+  assert.equal(res.status, 201);
+});

--- a/mcp-server/src/swarm/endpoints/lesson-admission.ts
+++ b/mcp-server/src/swarm/endpoints/lesson-admission.ts
@@ -1,0 +1,458 @@
+/**
+ * POST /swarm/lessons — Swarm sub-phase 4j (issue #138).
+ *
+ * Receiver-side admission pipeline for incoming v1.1 Lesson envelopes:
+ *
+ *   1. Pre-checks (cheap, before signature work):
+ *        - body shape, origin_node_id present
+ *        - self-loop guard (origin_node_id != our own node_id)
+ *        - peer-known guard (we hold a pubkey for the origin)
+ *        - quarantine guard (origin not currently quarantined)
+ *   2. Wire validation: rules 1-13 + 16/19/20 from SWARM_SPEC §5 via
+ *      validateWireRecord (the same canonical-bytes verifier the rest of
+ *      the swarm uses).
+ *   3. Side-effects (only after validation passes):
+ *        - INSERT into swarm_lessons with lesson_tier='B' (§10.6 firebreak default)
+ *        - +0.05 trust-edge bump for `origin_node_id` (§10.1 'admitted')
+ *        - run §10.3 LessonContradictionGate against existing priors
+ *
+ * Error mapping (issue #138 acceptance):
+ *   - 400 plain — non-quarantine validator failures (rules 2/3/4/7/8/9/11/12/13).
+ *   - 400 + quarantine — single-strike PoK rules 16 + 20 (§5/§10.2).
+ *   - 401 + quarantine — bad signature (rule 5).
+ *   - 401 + quarantine — broken commitment chain (rule 19).
+ *   - 401 plain — unknown peer (no pubkey held; nothing to quarantine).
+ *   - 403 — origin currently quarantined (cheap pre-check, before signature).
+ *   - 503 — dependency threw (DB, signature lookup) — operator-readable detail.
+ *
+ * Substrate split (issue #138 — first slice):
+ *   - This module is a pure handler that takes injected callbacks for every
+ *     side effect. No HTTP host, no PostgREST, no Supabase client. The
+ *     follow-up wiring PR mounts it onto dashboard-server.mjs (mirror of the
+ *     #128 → #152 split that worked for the proof endpoint).
+ *   - Tests in `lesson-admission.test.ts` exercise every branch with a real
+ *     Ed25519 signer (via signWithSelfKey + freshIdentity) and in-memory
+ *     deps; no DB and no HTTP server are needed because the handler returns
+ *     an HttpResponseShape triple that any host can serialize verbatim.
+ */
+import { validateWireRecord, type ValidationResult } from "../../services/wire-validator.js";
+import type { ContradictionFinding, SwarmLessonRow } from "../../services/lesson-contradiction-gate.js";
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+export interface HttpResponseShape {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Self-row from `nodes` (`is_self = true`). Only `node_id` is consulted —
+ * the self-loop guard refuses to admit a record whose origin claims to be
+ * us. Match the proof-endpoint shape so deps line up cleanly.
+ */
+export interface SelfNode {
+  node_id: string;
+  pubkey_b64: string;
+}
+
+export interface LessonAdmissionDeps {
+  /** Already-parsed JSON body. The HTTP host owns the JSON.parse step. */
+  body: unknown;
+
+  /** Spec major to negotiate against (1 in v1.x). */
+  ourSpecMajor: number;
+
+  /** Injected clock — tests pass a fixed Date. */
+  now: Date;
+
+  /** Self-row from `nodes`. Used for the self-loop guard. */
+  loadSelf: () => Promise<SelfNode | null>;
+
+  /**
+   * Lookup the producer's raw 32-byte Ed25519 pubkey. Returning null
+   * collapses to a 401 unknown-peer rejection (no quarantine — we have
+   * no edge to write to).
+   */
+  getPubkeyForNode: (nodeId: string) => Promise<Uint8Array | null>;
+
+  /**
+   * Returns the current `quarantined_until` for the node as an ISO-8601
+   * string, or null if the node is not quarantined. Used as a cheap
+   * pre-check before any signature work.
+   */
+  getQuarantinedUntil: (nodeId: string) => Promise<string | null>;
+
+  /**
+   * Optional. Returns the multihash this receiver expects to see in
+   * `prev_lesson_hash` for the next Lesson from `originId`, or null when
+   * the receiver holds no prior lesson from this origin (fresh-peer case
+   * — rule 19 cannot fire). Forwarded verbatim into validateWireRecord.
+   */
+  getExpectedPrevLessonHash?: (nodeId: string) => Promise<string | null>;
+
+  /**
+   * INSERT the validated lesson into `swarm_lessons` with
+   * `lesson_tier='B'` and return the canonical lesson_id. Throws on DB
+   * error — handler maps to 503.
+   */
+  insertSwarmLesson: (lesson: AdmittedLesson) => Promise<{ lesson_id: string }>;
+
+  /**
+   * Set `nodes.quarantined_until = untilMs` (single-strike per §5/§10.2).
+   * Best-effort — handler does not abort the rejection if this throws.
+   */
+  setQuarantine: (nodeId: string, untilMs: number, reason: string) => Promise<void>;
+
+  /**
+   * Append `{node_id, delta, reason}` to `trust_edge_log` (§10.1).
+   * Best-effort — handler still returns 201 on bookkeeping failure
+   * because the lesson is already persisted at that point.
+   */
+  recordTrustEdgeChange: (nodeId: string, delta: number, reason: string) => Promise<void>;
+
+  /**
+   * Run §10.3 contradiction gate against this node's existing swarm_lessons.
+   * Optional — if omitted, admission still succeeds and the gate is left
+   * to a separate batch path. Forwarded findings go in the 201 body so
+   * the caller can correlate.
+   */
+  runContradictionGate?: (incoming: SwarmLessonRow) => Promise<{ findings: ContradictionFinding[] }>;
+}
+
+/**
+ * Shape of the row we hand to `insertSwarmLesson` after rules 1-20
+ * have all returned ok. The wiring layer can pass this straight to a
+ * PostgREST insert — column names match `swarm_lessons` (migration 071
+ * + 074 + 077 + 078). `lesson_tier` is fixed to 'B' because §10.6
+ * mandates the firebreak default for any externally-admitted lesson.
+ */
+export interface AdmittedLesson {
+  id: string;
+  content: string;
+  embedding: number[];
+  synthesized_from_cluster_size: number;
+  origin_node_id: string;
+  signed_at: string;
+  signature: string;
+  created_at: string;
+  spec_version: string;
+  tags?: string[];
+  // v1.1 PoK fields — required because validateWireRecord enforces
+  // their presence on spec_version >= 1.1, and v1.0 is a write
+  // configuration that #138 declines to support (the receiver pipeline
+  // is v1.1-only).
+  evidence_root: string;
+  evidence_count: number;
+  prev_lesson_hash: string | null;
+  maturity_age_days: number;
+  useful_count: number;
+  /** Receiver-pinned tier — always 'B' per §10.6 admission firebreak. */
+  lesson_tier: "B";
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const RESPONSE_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+});
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+// Rules whose rejection pulls the producer into a 1-hour quarantine. The set
+// is the union of §5 rule 5 (signature failure), rule 19 (broken chain), and
+// rules 16/20 (PoK shape — single-strike per §10.2). Any other rejection is a
+// 400/401 plain — a malformed v1.0 record from a legitimate peer should not
+// burn an hour of admission for the rest of the batch.
+const SINGLE_STRIKE_RULES: ReadonlySet<number> = new Set([5, 16, 19, 20]);
+
+// UUID v1-v8, lowercase or uppercase. Used to sanity-check `id` before it
+// becomes the canonical lesson_id of the admitted row. The full validator
+// catches malformed strings via rule 3 (typeof string), but a UUID-shape
+// check here keeps the failure mode at "400 bad-id" rather than "500
+// constraint violation" if someone slips an arbitrary string past the
+// type guard upstream.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export async function admitSwarmLesson(
+  deps: LessonAdmissionDeps,
+): Promise<HttpResponseShape> {
+  // 1. Body must be a JSON object.
+  if (deps.body === null || typeof deps.body !== "object" || Array.isArray(deps.body)) {
+    return jsonResponse(400, { error: "body must be a JSON object" });
+  }
+  const record = deps.body as Record<string, unknown>;
+
+  // 2. origin_node_id must at least be a non-empty string before we can
+  //    route quarantine logic. This is also rule 2 territory in the
+  //    validator, but we need the origin string before the validator call
+  //    in order to do the cheap quarantine pre-check.
+  const originId = record.origin_node_id;
+  if (typeof originId !== "string" || originId.length === 0) {
+    return jsonResponse(400, {
+      error: "origin_node_id is required and must be a non-empty string",
+      rule: 2,
+    });
+  }
+
+  // id presence + UUID shape — validator's rule 3 will also catch type
+  // mismatches, but admitting a row whose `id` will later violate
+  // `swarm_lessons.id` PRIMARY KEY would surface as 503 from the DB; we
+  // keep that as a 400 here.
+  const lessonId = record.id;
+  if (typeof lessonId !== "string" || !UUID_RE.test(lessonId)) {
+    return jsonResponse(400, {
+      error: "id must be a UUID",
+      rule: 3,
+    });
+  }
+
+  // 3. Self-loop guard. We refuse to admit a row whose origin claims to
+  //    be us — that path lets a peer overwrite our own lesson chain
+  //    with arbitrary content. Self-published lessons go through the
+  //    producer path, never the admission endpoint.
+  let self: SelfNode | null;
+  try {
+    self = await deps.loadSelf();
+  } catch (e) {
+    return jsonResponse(503, {
+      error: "loadSelf failed",
+      detail: detailOf(e),
+    });
+  }
+  if (!self) {
+    return jsonResponse(503, {
+      error:
+        "node identity not initialized; run scripts/init-node-identity.mjs first",
+    });
+  }
+  if (originId === self.node_id) {
+    return jsonResponse(400, {
+      error: "admission of self-published lesson refused (use producer path)",
+      origin_node_id: originId,
+    });
+  }
+
+  // 4. Peer-known guard. The validator collapses unknown-peer to rule 5
+  //    (signature failure) because it has no pubkey to verify against,
+  //    but we want to distinguish "we know this peer and they sent a bad
+  //    signature" (single-strike quarantine) from "we don't know who
+  //    this is" (no-edge, plain 401).
+  let pubkey: Uint8Array | null;
+  try {
+    pubkey = await deps.getPubkeyForNode(originId);
+  } catch (e) {
+    return jsonResponse(503, {
+      error: "getPubkeyForNode failed",
+      detail: detailOf(e),
+      origin_node_id: originId,
+    });
+  }
+  if (!pubkey) {
+    return jsonResponse(401, {
+      error: "unknown peer; pubkey not held for origin_node_id",
+      origin_node_id: originId,
+    });
+  }
+
+  // 5. Quarantine pre-check. Cheaper than a signature verify and avoids
+  //    burning admission budget on a peer we've already firebreaked.
+  let quarantinedUntil: string | null;
+  try {
+    quarantinedUntil = await deps.getQuarantinedUntil(originId);
+  } catch (e) {
+    return jsonResponse(503, {
+      error: "getQuarantinedUntil failed",
+      detail: detailOf(e),
+      origin_node_id: originId,
+    });
+  }
+  if (quarantinedUntil) {
+    const untilMs = Date.parse(quarantinedUntil);
+    if (Number.isFinite(untilMs) && untilMs > deps.now.getTime()) {
+      return jsonResponse(403, {
+        error: "origin is currently quarantined",
+        origin_node_id: originId,
+        quarantined_until: quarantinedUntil,
+      });
+    }
+  }
+
+  // 6. Pre-resolve the expected prev-lesson hash, if a lookup was supplied.
+  //    validateWireRecord's `getExpectedPrevLessonHashForOrigin` is sync
+  //    (returns `string | null`), but our injected dep is async — so we
+  //    fetch once here and hand the resolved value into the validator
+  //    via a sync closure. Same trade-off the rest of the swarm services
+  //    take when crossing the sync-validator / async-IO boundary.
+  let expectedPrevHash: string | null = null;
+  if (deps.getExpectedPrevLessonHash) {
+    try {
+      expectedPrevHash = (await deps.getExpectedPrevLessonHash(originId)) ?? null;
+    } catch (e) {
+      return jsonResponse(503, {
+        error: "getExpectedPrevLessonHash failed",
+        detail: detailOf(e),
+        origin_node_id: originId,
+      });
+    }
+  }
+
+  // Wire validation. validateWireRecord is the canonical §5 check — we
+  // don't re-implement any rule here, only map the result into our HTTP
+  // shape. The pubkey lookup is constrained to the origin we already
+  // resolved above, so a record whose internal origin field differs
+  // from the path-level origin (none here, but defensive) cannot smuggle
+  // a different verifier key.
+  let validation: ValidationResult;
+  try {
+    validation = await validateWireRecord(deps.body, "lesson", {
+      ourSpecMajor: deps.ourSpecMajor,
+      now: deps.now,
+      getPubkeyForNode: (id) => (id === originId ? pubkey : null),
+      getExpectedPrevLessonHashForOrigin: deps.getExpectedPrevLessonHash
+        ? () => expectedPrevHash
+        : undefined,
+    });
+  } catch (e) {
+    return jsonResponse(503, {
+      error: "wire validation threw",
+      detail: detailOf(e),
+    });
+  }
+
+  if (!validation.ok) {
+    const status =
+      validation.rule === 5 || validation.rule === 19 ? 401 : 400;
+    const quarantine = SINGLE_STRIKE_RULES.has(validation.rule);
+    if (quarantine) {
+      try {
+        await deps.setQuarantine(
+          originId,
+          deps.now.getTime() + ONE_HOUR_MS,
+          `wire-rule-${validation.rule}`,
+        );
+      } catch (e) {
+        // Quarantine bookkeeping failure is non-fatal — the rejection
+        // still returns to the caller; an unquarantined-but-rejected
+        // peer is recoverable, a missed rejection is not.
+        console.error(
+          `[lesson-admission] setQuarantine failed for ${originId}: ${detailOf(e)}`,
+        );
+      }
+    }
+    return jsonResponse(status, {
+      error: "wire validation rejected record",
+      rule: validation.rule,
+      reason: validation.reason,
+      origin_node_id: originId,
+      quarantined: quarantine,
+    });
+  }
+
+  // 7. Build the row to insert. By this point validation has guaranteed
+  //    every field below is present and the right type, so the cast is
+  //    safe. lesson_tier is hard-pinned to 'B' (§10.6 firebreak).
+  const lessonRow: AdmittedLesson = {
+    id: record.id as string,
+    content: record.content as string,
+    embedding: record.embedding as number[],
+    synthesized_from_cluster_size: record.synthesized_from_cluster_size as number,
+    origin_node_id: originId,
+    signed_at: record.signed_at as string,
+    signature: record.signature as string,
+    created_at: record.created_at as string,
+    spec_version: record.spec_version as string,
+    tags: Array.isArray(record.tags) ? (record.tags as string[]) : undefined,
+    evidence_root: record.evidence_root as string,
+    evidence_count: record.evidence_count as number,
+    prev_lesson_hash: (record.prev_lesson_hash as string | null) ?? null,
+    maturity_age_days: record.maturity_age_days as number,
+    useful_count: record.useful_count as number,
+    lesson_tier: "B",
+  };
+
+  // 8. INSERT. Failure here is the one place we abort hard — the lesson
+  //    is otherwise valid and the receiver pipeline cannot proceed
+  //    without it being persisted (the gate, the trust-edge update, and
+  //    a future REM self-audit all key off swarm_lessons.id).
+  let insertResult: { lesson_id: string };
+  try {
+    insertResult = await deps.insertSwarmLesson(lessonRow);
+  } catch (e) {
+    return jsonResponse(503, {
+      error: "insertSwarmLesson failed",
+      detail: detailOf(e),
+      origin_node_id: originId,
+    });
+  }
+
+  // 9. Trust edge: §10.1 "+0.05 admitted". Best-effort — the lesson is
+  //    already persisted; a dropped trust update degrades reputation
+  //    accuracy, not correctness.
+  try {
+    await deps.recordTrustEdgeChange(originId, 0.05, "admitted");
+  } catch (e) {
+    console.error(
+      `[lesson-admission] recordTrustEdgeChange failed for ${originId}: ${detailOf(e)}`,
+    );
+  }
+
+  // 10. §10.3 contradiction gate. Best-effort — gate findings demote
+  //     both sides to Tier-B (already our default) and append edges to
+  //     swarm_lesson_contradictions. Failure here means a pair we should
+  //     have flagged stays unflagged; REM self-audit (§10.5) is the
+  //     fallback discovery path.
+  let gateFindings: ContradictionFinding[] = [];
+  if (deps.runContradictionGate) {
+    try {
+      const gate = await deps.runContradictionGate({
+        id: insertResult.lesson_id,
+        content: lessonRow.content,
+        embedding: lessonRow.embedding,
+        lesson_tier: "B",
+      });
+      gateFindings = gate.findings;
+    } catch (e) {
+      console.error(
+        `[lesson-admission] runContradictionGate failed for ${insertResult.lesson_id}: ${detailOf(e)}`,
+      );
+    }
+  }
+
+  return {
+    status: 201,
+    headers: { ...RESPONSE_HEADERS },
+    body: JSON.stringify({
+      lesson_id: insertResult.lesson_id,
+      lesson_tier: "B",
+      contradictions: gateFindings.length,
+      origin_node_id: originId,
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(status: number, body: unknown): HttpResponseShape {
+  return {
+    status,
+    headers: { ...RESPONSE_HEADERS },
+    body: JSON.stringify(body),
+  };
+}
+
+function detailOf(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}


### PR DESCRIPTION
## Summary

- Pure handler module \`mcp-server/src/swarm/endpoints/lesson-admission.ts\` that runs the §10.6 admission firebreak for incoming v1.1 Lesson envelopes. All side-effects (DB writes, signature lookups, gate orchestration) are injected via callbacks so the handler is unit-testable in isolation.
- 19 contract tests covering every status-code branch in issue #138 acceptance — bad signature, broken chain, PoK shape, unknown peer, quarantine pre-check, persistence-layer failure, and the happy path with trust-edge + gate side-effects.
- This is the **substrate slice only** — no HTTP host wire-up, no migration, no \`dashboard-server.mjs\` touch. Follow-up PR mounts \`admitSwarmLesson\` onto the dashboard host (mirror of the #128 → #152 split that worked for the proof endpoint).

## Status mapping

Per issue #138 acceptance + SWARM_SPEC §5 / §10.2:

| Code | Trigger | Quarantine? |
|------|---------|-------------|
| 400 | rules 2/3/4/7/8/9/11/12/13 | no |
| 400 | rule 16 (PoK count) or 20 (PoK shape) | **yes** (single-strike, §10.2) |
| 401 | rule 5 (bad signature) | **yes** (single-strike) |
| 401 | rule 19 (broken commitment chain) | **yes** (single-strike) |
| 401 | unknown peer (no pubkey held) | no — no edge to write to |
| 403 | origin currently quarantined | no — pre-check, decision-only |
| 503 | dependency threw (DB, sig lookup) | no |
| 201 | admitted at \`lesson_tier='B'\` | no |

201 body shape: \`{ lesson_id, lesson_tier: 'B', contradictions: N, origin_node_id }\`.

## Why a substrate-only first slice

The receiver pipeline has multiple touchpoints (DB, signature key lookup, contradiction gate, trust-edge log) — bundling them all into one PR with HTTP wire-up would (a) collide with PRs #133 / #142 / #152 which all touch \`dashboard-server.mjs\`, and (b) make the contract test surface harder to keep tight. Splitting the handler from the wire-up follows the proven proof-endpoint split:

- #128 (handler module) → tested in isolation, merged
- #152 (HTTP wire-up onto \`scripts/dashboard-server.mjs\`) → 5 wiring contract tests, merged

Same shape here: this PR ships the pure pipeline + tests; a follow-up PR will mount it on the HTTP host once one of the open dashboard-server PRs lands and the rebase target is stable.

## Diff shape

\`\`\`
mcp-server/src/__tests__/lesson-admission.test.ts  | 555 +++++++++++++++++++++
mcp-server/src/swarm/endpoints/lesson-admission.ts | 458 +++++++++++++++++
2 files changed, 1013 insertions(+)
\`\`\`

No migration changes, no \`mcp-server/src/index.ts\` touches, no \`scripts/dashboard-server.mjs\` touches.

## Test plan

- [x] \`npm run build\` clean (strict TS).
- [x] \`npm test\` — 665 pass (was 646; this PR adds 19 admission contract tests).
- [x] All 19 tests cover one branch each: 400 non-object, 400 missing origin, 400 bad UUID, 400 self-loop, 401 unknown peer (no quarantine), 403 already quarantined, 201 expired-quarantine bypass, 401+Q rule 5, 401+Q rule 19, 400+Q rule 16, 400+Q rule 20, 400 plain rule 2, 503 insert-throw, 503 loadSelf-throw, 201 happy path with row+trust+gate, 201 trust-throw is non-fatal, 201 gate-throw is non-fatal, 201 gate-optional, 201 prev-hash chain forwards.
- [ ] After wiring PR + admission migration: \`curl -X POST /swarm/lessons -d <signed v1.1 envelope>\` returns 201 with \`{ lesson_id, lesson_tier: 'B', contradictions, origin_node_id }\`.

## Why now

PR #134/#140 fixes that unblocked phase-4 SQL are in flight; PR #131 / #129 / #119 / #118 / #120 / #121 / #122 / #123 / #124 / #125 substrate is on main; the proof endpoint is wired (#152). The receiver-side admission handler is the next foundation piece — the inbound complement to the producer-side proof endpoint, and a prerequisite for any multi-node testing of trust-edge dynamics, contradiction detection, or REM self-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)