### PR TITLE
feat(swarm): outbound /swarm/lessons feed handler — substrate (#139)

### DIFF
--- a/mcp-server/src/__tests__/lesson-feed.test.ts
+++ b/mcp-server/src/__tests__/lesson-feed.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Contract tests for the GET /swarm/lessons handler — issue #139, slice 1.
+ *
+ * Pure handler-level tests. The loader is injected, so no DB / HTTP is
+ * required; the integration test that exercises the full URL → SQL path
+ * ships with the wiring PR.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildLessonFeedResponse,
+  computeNextSince,
+  resolveLimit,
+  resolveSince,
+  DEFAULT_SINCE_LOOKBACK_MS,
+  LIMIT_DEFAULT,
+  LIMIT_MAX,
+  LIMIT_MIN,
+  type LessonFeedDeps,
+  type LessonFeedResponseBody,
+} from "../swarm/endpoints/lesson-feed.js";
+import { WIRE_SPEC_VERSION, type Lesson } from "../services/wire-types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FROZEN_NOW = new Date("2026-05-01T12:00:00.000Z");
+
+function lesson(overrides: Partial<Lesson> = {}): Lesson {
+  return {
+    id: "11111111-2222-4333-8444-555555555555",
+    content: "If A then B because C.",
+    embedding: new Array(768).fill(0),
+    synthesized_from_cluster_size: 3,
+    origin_node_id:
+      "QmTfCejgo2wTwqnDJs8Lu1pCNeCrCDuE4GAwkna93zdd7d",
+    signed_at: "2026-04-30T10:00:00.000Z",
+    signature: "sig-base64-placeholder==",
+    created_at: "2026-04-30T09:00:00.000Z",
+    spec_version: WIRE_SPEC_VERSION,
+    ...overrides,
+  };
+}
+
+function freshDeps(over: Partial<LessonFeedDeps>): LessonFeedDeps {
+  return {
+    now: () => FROZEN_NOW,
+    loadEligibleLessons: async () => [],
+    ...over,
+  };
+}
+
+async function readBody(res: { body: string }): Promise<unknown> {
+  return JSON.parse(res.body);
+}
+
+// ---------------------------------------------------------------------------
+// resolveSince — pure helper
+// ---------------------------------------------------------------------------
+
+test("resolveSince defaults to now − 24h when no value supplied", () => {
+  for (const raw of [null, undefined, ""] as const) {
+    const r = resolveSince(raw, FROZEN_NOW);
+    assert.equal(r.ok, true, `expected ok for ${JSON.stringify(raw)}`);
+    if (!r.ok) return;
+    assert.equal(
+      r.since.getTime(),
+      FROZEN_NOW.getTime() - DEFAULT_SINCE_LOOKBACK_MS
+    );
+  }
+});
+
+test("resolveSince accepts strict ISO8601 with Z", () => {
+  const r = resolveSince("2026-04-30T10:20:30Z", FROZEN_NOW);
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.since.toISOString(), "2026-04-30T10:20:30.000Z");
+});
+
+test("resolveSince accepts strict ISO8601 with milliseconds + Z", () => {
+  const r = resolveSince("2026-04-30T10:20:30.123Z", FROZEN_NOW);
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.since.toISOString(), "2026-04-30T10:20:30.123Z");
+});
+
+test("resolveSince accepts strict ISO8601 with offset timezone", () => {
+  const r = resolveSince("2026-04-30T12:20:30+02:00", FROZEN_NOW);
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  // Same instant as 10:20:30Z.
+  assert.equal(r.since.toISOString(), "2026-04-30T10:20:30.000Z");
+});
+
+test("resolveSince rejects ISO8601 without timezone designator", () => {
+  const r = resolveSince("2026-04-30T10:20:30", FROZEN_NOW);
+  assert.equal(r.ok, false);
+});
+
+test("resolveSince rejects date-only strings", () => {
+  const r = resolveSince("2026-04-30", FROZEN_NOW);
+  assert.equal(r.ok, false);
+});
+
+test("resolveSince rejects garbage strings", () => {
+  for (const raw of ["yesterday", "tomorrow", "1714478400", "not-a-date"]) {
+    const r = resolveSince(raw, FROZEN_NOW);
+    assert.equal(r.ok, false, `expected reject for ${JSON.stringify(raw)}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// resolveLimit — pure helper
+// ---------------------------------------------------------------------------
+
+test("resolveLimit defaults when no value supplied", () => {
+  for (const raw of [null, undefined, ""] as const) {
+    const r = resolveLimit(raw);
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.equal(r.limit, LIMIT_DEFAULT);
+  }
+});
+
+test("resolveLimit accepts string-of-digits in range", () => {
+  const r = resolveLimit("75");
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.limit, 75);
+});
+
+test("resolveLimit accepts numeric integer in range", () => {
+  const r = resolveLimit(42);
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.limit, 42);
+});
+
+test("resolveLimit clamps values above LIMIT_MAX", () => {
+  const r = resolveLimit("9999");
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.limit, LIMIT_MAX);
+});
+
+test("resolveLimit clamps values below LIMIT_MIN (zero / negative)", () => {
+  for (const raw of ["0", "-5", 0, -1] as const) {
+    const r = resolveLimit(raw);
+    assert.equal(r.ok, true, `expected ok for ${raw}`);
+    if (!r.ok) return;
+    assert.equal(r.limit, LIMIT_MIN, `for ${raw}`);
+  }
+});
+
+test("resolveLimit rejects decimals, scientific, hex, and trailing garbage", () => {
+  for (const raw of ["1.5", "1e2", "0x10", "10abc", "abc"] as const) {
+    const r = resolveLimit(raw);
+    assert.equal(r.ok, false, `expected reject for ${JSON.stringify(raw)}`);
+  }
+});
+
+test("resolveLimit rejects non-integer numbers", () => {
+  const r = resolveLimit(1.5);
+  assert.equal(r.ok, false);
+});
+
+test("resolveLimit rejects NaN and Infinity", () => {
+  for (const raw of [Number.NaN, Number.POSITIVE_INFINITY] as const) {
+    const r = resolveLimit(raw);
+    assert.equal(r.ok, false, `expected reject for ${raw}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// computeNextSince — pure helper
+// ---------------------------------------------------------------------------
+
+test("computeNextSince returns null for empty page", () => {
+  assert.equal(computeNextSince([]), null);
+});
+
+test("computeNextSince returns null when input is non-array", () => {
+  // @ts-expect-error — defensive against malformed loaders.
+  assert.equal(computeNextSince(null), null);
+});
+
+test("computeNextSince returns max(signed_at)+1ms for one row", () => {
+  const r = computeNextSince([lesson({ signed_at: "2026-04-30T10:00:00.000Z" })]);
+  assert.equal(r, "2026-04-30T10:00:00.001Z");
+});
+
+test("computeNextSince returns max(signed_at)+1ms across rows", () => {
+  const r = computeNextSince([
+    lesson({ id: "a", signed_at: "2026-04-29T10:00:00.000Z" }),
+    lesson({ id: "b", signed_at: "2026-04-30T11:30:00.500Z" }),
+    lesson({ id: "c", signed_at: "2026-04-30T08:00:00.000Z" }),
+  ]);
+  assert.equal(r, "2026-04-30T11:30:00.501Z");
+});
+
+// ---------------------------------------------------------------------------
+// buildLessonFeedResponse — happy path
+// ---------------------------------------------------------------------------
+
+test("returns 200 + empty page when no rows match", async () => {
+  const res = await buildLessonFeedResponse(freshDeps({}));
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["Content-Type"], "application/json; charset=utf-8");
+  assert.equal(res.headers["Cache-Control"], "no-store");
+  const body = (await readBody(res)) as LessonFeedResponseBody;
+  assert.deepEqual(body.lessons, []);
+  assert.equal(body.next_since, null);
+});
+
+test("returns 200 + page envelope with rows + cursor", async () => {
+  const a = lesson({
+    id: "aaaaaaaa-1111-4111-8111-111111111111",
+    signed_at: "2026-04-30T10:00:00.000Z",
+  });
+  const b = lesson({
+    id: "bbbbbbbb-2222-4222-8222-222222222222",
+    signed_at: "2026-04-30T11:00:00.250Z",
+  });
+  const res = await buildLessonFeedResponse(
+    freshDeps({ loadEligibleLessons: async () => [a, b] })
+  );
+  assert.equal(res.status, 200);
+  const body = (await readBody(res)) as LessonFeedResponseBody;
+  assert.equal(body.lessons.length, 2);
+  assert.equal(body.lessons[0].id, a.id);
+  assert.equal(body.lessons[1].id, b.id);
+  assert.equal(body.next_since, "2026-04-30T11:00:00.251Z");
+});
+
+test("relays loader rows verbatim — handler does not re-shape envelopes", async () => {
+  // Receiver re-validates the producer signature over JCS(record − signature),
+  // so any field rename / drop / re-order would break verification. Handler
+  // MUST pass rows through untouched.
+  const v11 = lesson({
+    id: "aaaaaaaa-1111-4111-8111-111111111111",
+    spec_version: "1.1",
+    evidence_root: "QmTestRootRootRootRootRootRootRootRootRootRoo",
+    evidence_count: 5,
+    prev_lesson_hash: "QmTestPrevPrevPrevPrevPrevPrevPrevPrevPrevPre",
+    maturity_age_days: 7,
+    useful_count: 2,
+    tags: ["test", "v1.1"],
+  });
+  const res = await buildLessonFeedResponse(
+    freshDeps({ loadEligibleLessons: async () => [v11] })
+  );
+  assert.equal(res.status, 200);
+  const body = (await readBody(res)) as LessonFeedResponseBody;
+  const got = body.lessons[0];
+  assert.equal(got.spec_version, "1.1");
+  assert.equal(got.evidence_root, v11.evidence_root);
+  assert.equal(got.evidence_count, 5);
+  assert.equal(got.prev_lesson_hash, v11.prev_lesson_hash);
+  assert.equal(got.maturity_age_days, 7);
+  assert.equal(got.useful_count, 2);
+  assert.deepEqual(got.tags, ["test", "v1.1"]);
+  assert.equal(got.signature, v11.signature);
+});
+
+// ---------------------------------------------------------------------------
+// buildLessonFeedResponse — defaulting behaviour passed to loader
+// ---------------------------------------------------------------------------
+
+test("defaults since to now − 24h when omitted", async () => {
+  let captured: { since: Date; limit: number } | null = null;
+  await buildLessonFeedResponse(
+    freshDeps({
+      loadEligibleLessons: async (args) => {
+        captured = args;
+        return [];
+      },
+    })
+  );
+  assert.ok(captured, "loader must be called");
+  const args = captured as unknown as { since: Date; limit: number };
+  assert.equal(
+    args.since.getTime(),
+    FROZEN_NOW.getTime() - DEFAULT_SINCE_LOOKBACK_MS
+  );
+  assert.equal(args.limit, LIMIT_DEFAULT);
+});
+
+test("forwards a valid since to the loader", async () => {
+  let captured: { since: Date; limit: number } | null = null;
+  await buildLessonFeedResponse(
+    freshDeps({
+      since: "2026-04-29T08:00:00.000Z",
+      loadEligibleLessons: async (args) => {
+        captured = args;
+        return [];
+      },
+    })
+  );
+  assert.ok(captured, "loader must be called");
+  const args = captured as unknown as { since: Date; limit: number };
+  assert.equal(args.since.toISOString(), "2026-04-29T08:00:00.000Z");
+});
+
+test("forwards a clamped limit to the loader", async () => {
+  let captured: { since: Date; limit: number } | null = null;
+  await buildLessonFeedResponse(
+    freshDeps({
+      limit: "9999",
+      loadEligibleLessons: async (args) => {
+        captured = args;
+        return [];
+      },
+    })
+  );
+  assert.ok(captured, "loader must be called");
+  const args = captured as unknown as { since: Date; limit: number };
+  assert.equal(args.limit, LIMIT_MAX);
+});
+
+// ---------------------------------------------------------------------------
+// buildLessonFeedResponse — input validation (400 mappings)
+// ---------------------------------------------------------------------------
+
+test("returns 400 on malformed since", async () => {
+  let loaderCalled = false;
+  const res = await buildLessonFeedResponse(
+    freshDeps({
+      since: "yesterday",
+      loadEligibleLessons: async () => {
+        loaderCalled = true;
+        return [];
+      },
+    })
+  );
+  assert.equal(res.status, 400);
+  assert.equal(loaderCalled, false, "loader MUST NOT be called on bad input");
+  const body = (await readBody(res)) as { error: string; since: string };
+  assert.match(body.error, /since/);
+  assert.equal(body.since, "yesterday");
+});
+
+test("returns 400 on malformed limit (string)", async () => {
+  let loaderCalled = false;
+  const res = await buildLessonFeedResponse(
+    freshDeps({
+      limit: "abc",
+      loadEligibleLessons: async () => {
+        loaderCalled = true;
+        return [];
+      },
+    })
+  );
+  assert.equal(res.status, 400);
+  assert.equal(loaderCalled, false);
+  const body = (await readBody(res)) as { error: string; limit: string };
+  assert.match(body.error, /limit/);
+  assert.equal(body.limit, "abc");
+});
+
+test("returns 400 on malformed limit (decimal)", async () => {
+  const res = await buildLessonFeedResponse(
+    freshDeps({ limit: "1.5" })
+  );
+  assert.equal(res.status, 400);
+});
+
+// ---------------------------------------------------------------------------
+// buildLessonFeedResponse — loader failure (503)
+// ---------------------------------------------------------------------------
+
+test("returns 503 with operator-readable detail when loader throws", async () => {
+  const res = await buildLessonFeedResponse(
+    freshDeps({
+      loadEligibleLessons: async () => {
+        throw new Error("connection refused: postgres at localhost:54322");
+      },
+    })
+  );
+  assert.equal(res.status, 503);
+  const body = (await readBody(res)) as { error: string; detail: string };
+  assert.equal(body.error, "loadEligibleLessons failed");
+  assert.match(body.detail, /connection refused/);
+});
+
+test("returns 503 with stringified non-Error rejections", async () => {
+  const res = await buildLessonFeedResponse(
+    freshDeps({
+      loadEligibleLessons: async () => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw "loader exploded with a plain string";
+      },
+    })
+  );
+  assert.equal(res.status, 503);
+  const body = (await readBody(res)) as { detail: string };
+  assert.match(body.detail, /loader exploded/);
+});
+
+// ---------------------------------------------------------------------------
+// buildLessonFeedResponse — response-shape pin (regression guard)
+// ---------------------------------------------------------------------------
+
+test("response body has only `lessons` and `next_since` at the top level", async () => {
+  const res = await buildLessonFeedResponse(
+    freshDeps({ loadEligibleLessons: async () => [lesson()] })
+  );
+  assert.equal(res.status, 200);
+  const body = (await readBody(res)) as Record<string, unknown>;
+  assert.deepEqual(
+    Object.keys(body).sort(),
+    ["lessons", "next_since"].sort(),
+    "extra fields would force receivers to update — pin the contract"
+  );
+});
+
+test("Cache-Control disables caching on every response (200, 400, 503)", async () => {
+  const ok = await buildLessonFeedResponse(freshDeps({}));
+  const bad = await buildLessonFeedResponse(
+    freshDeps({ since: "yesterday" })
+  );
+  const fail = await buildLessonFeedResponse(
+    freshDeps({
+      loadEligibleLessons: async () => {
+        throw new Error("x");
+      },
+    })
+  );
+  for (const r of [ok, bad, fail]) {
+    assert.equal(r.headers["Cache-Control"], "no-store");
+  }
+});

--- a/mcp-server/src/swarm/endpoints/lesson-feed.ts
+++ b/mcp-server/src/swarm/endpoints/lesson-feed.ts
@@ -1,0 +1,359 @@
+/**
+ * GET /swarm/lessons — Swarm Phase 4 (issue #139 — first slice).
+ *
+ * Pull-based broadcast feed over Tier-A lessons (SWARM_SPEC §10.6 + §3.1).
+ * A peer polls `GET /swarm/lessons?since=<iso8601>&limit=N` and receives
+ * the v1.x envelopes that have been promoted to Tier-A and not §10.4-
+ * diversity-dampened. Receivers re-validate every envelope with
+ * `wire-validator` — this endpoint adds no out-of-band trust claim of
+ * its own.
+ *
+ * Substrate-only: pure handler module + contract tests, no HTTP wiring,
+ * no migration, no dashboard-server.mjs touch. Mirrors the #138 → wiring
+ * follow-up split that worked for the admission handler and the
+ * #128 → #152 split that worked for the proof endpoint.
+ *
+ * Issue #139 splits into three pieces; this PR ships piece 1 only:
+ *
+ *   1. THIS — the GET handler reading from broadcast_eligible. Pure
+ *      shape / pagination / clamping. The loader is injected so contract
+ *      tests run with no DB.
+ *   2. Active publish at promotion time (lesson_chain append + producer-
+ *      side signing on B → A flip). Future PR; depends on #136 producer
+ *      hook landing first.
+ *   3. Self-broadcasting safety (CHECK / trigger preventing a self-row
+ *      from carrying a foreign-looking origin_node_id). Future PR;
+ *      substrate-only.
+ *
+ * Substrate filter contract:
+ *
+ *   - The loader MUST read FROM `swarm_lessons_broadcast_eligible` (the
+ *     §10.6 firebreak view from migration 078). Reading directly from
+ *     `swarm_lessons` would re-broadcast Tier-B (un-vetted) lessons.
+ *   - The loader MUST also apply the §10.4 anti-echo-chamber filter
+ *     (`local_weight >= 0.3` from migration 082). Diversity-dampened
+ *     lessons stay local — re-broadcasting them would amplify the
+ *     concentration the §10.4 pass already pulled back from.
+ *   - The handler does NOT re-apply either filter. The substrate IS the
+ *     contract; this module verifies shape + pagination + clamping only.
+ *     A loader that violates the contract is caught by the integration
+ *     test that ships with the wiring PR, not by this unit-level slice.
+ *
+ * Privacy / replay invariant:
+ *
+ *   The response relays each row's existing producer signature byte-for-
+ *   byte. This handler MUST NOT re-sign — re-signing would let any node
+ *   forge a producer attestation for any lesson it has merely seen,
+ *   which is the same trust break the lesson-proof handler's relay-guard
+ *   prevents at §4.6. Re-shaping the row (renaming fields, dropping
+ *   optional fields, re-ordering keys in a way that affects the bytes
+ *   under signature) would also break receiver validation; the handler
+ *   passes Lesson rows through verbatim.
+ */
+import type { Lesson } from "../../services/wire-types.js";
+
+// ---------------------------------------------------------------------------
+// Constants — defaults + bounds.
+// ---------------------------------------------------------------------------
+
+/**
+ * Default lookback when no `since` is supplied. Matches the spec text in
+ * issue #139: "Default: last 24h". A 24h window is small enough that a
+ * fresh peer can bootstrap without a one-shot dump, large enough that an
+ * hourly poll never misses a Tier-A promotion under normal cadence.
+ */
+export const DEFAULT_SINCE_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+/** Issue #139: limit "clamped to [1, 200], default 50". */
+export const LIMIT_DEFAULT = 50;
+export const LIMIT_MIN = 1;
+export const LIMIT_MAX = 200;
+
+/**
+ * §10.4 anti-echo-chamber threshold for local_weight. Documented on the
+ * loader contract — the SUBSTRATE applies the filter, not the handler —
+ * so this constant is exported for the wiring PR's loader to import and
+ * to give the contract test a single shared symbol.
+ */
+export const MIN_LOCAL_WEIGHT_FOR_BROADCAST = 0.3;
+
+/**
+ * Strict ISO8601 with required timezone designator. `Date.parse` is too
+ * permissive (it accepts e.g. "2026-04-30 10:00:00" without zone info),
+ * which would silently change cursor semantics across calls. Receivers
+ * MUST send a timezone-anchored value or get a 400.
+ *
+ * Allowed: 2026-04-30T10:20:30Z, 2026-04-30T10:20:30.123Z,
+ *          2026-04-30T10:20:30.123456+02:00, …
+ * Rejected: 2026-04-30, 2026-04-30T10:20:30, 2026-04-30 10:20:30Z, …
+ */
+const ISO8601_TZ_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const RESPONSE_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+});
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+export interface LessonFeedDeps {
+  /**
+   * Raw query-string `since` value (or null/undefined when the caller
+   * omitted it). When provided, MUST be a strict ISO8601 timestamp with
+   * timezone — anything else returns 400 rather than silently re-baselining
+   * the cursor under the receiver.
+   */
+  since?: string | null;
+  /**
+   * Raw query-string `limit` value (or null/undefined when omitted).
+   * Accepted as a string-of-digits or a number. Negative / non-integer
+   * / non-numeric values return 400 — silently mapping bad input to a
+   * default would let a misconfigured client poll with the wrong page
+   * size and never notice. Valid integers outside [1, 200] are silently
+   * clamped (per issue spec).
+   */
+  limit?: string | number | null;
+  /**
+   * Clock injection for deterministic tests. Defaults to `() => new Date()`.
+   * The handler resolves `since` against this clock when no `since` is
+   * supplied, so a frozen-clock test can assert the exact 24h-lookback Date
+   * the loader receives.
+   */
+  now?: () => Date;
+  /**
+   * Load Tier-A broadcast-eligible lessons, ordered by signed_at ASC,
+   * capped at `limit`. See module docstring for the substrate contract
+   * the loader MUST satisfy (read FROM the firebreak view + apply the
+   * §10.4 local_weight filter). The handler trusts this contract — it
+   * is the substrate, not a re-validation surface.
+   */
+  loadEligibleLessons: (args: {
+    since: Date;
+    limit: number;
+  }) => Promise<Lesson[]>;
+}
+
+export interface HttpResponseShape {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Response body shape served on 200. `lessons` is the page; `next_since`
+ * is the cursor a polling client passes back as `?since=<next_since>` on
+ * the next call.
+ *
+ * `next_since` is `null` when `lessons` is empty (no progress was made;
+ * the caller can poll again with the same `since`). Otherwise it is the
+ * largest `signed_at` in the page, advanced by 1ms. The +1ms keeps the
+ * next call from re-fetching the last row at the cost of skipping any
+ * row signed within the same millisecond — a documented at-least-once
+ * cursor; bit-exact deduplication, if a receiver needs it, is its own
+ * concern (track `id` set per page) and out of scope for this slice.
+ */
+export interface LessonFeedResponseBody {
+  lessons: Lesson[];
+  next_since: string | null;
+}
+
+/**
+ * Build the response for `GET /swarm/lessons`.
+ *
+ * Returns an HTTP-shaped triple so the surrounding HTTP server can write
+ * it without further policy. Every error mode is operator-readable rather
+ * than opaque — same discipline as `buildNodeAdvertisementResponse` and
+ * `buildLessonProofResponse`.
+ *
+ * Status mapping:
+ *   - 400: malformed `since` (not ISO8601 with timezone) or malformed
+ *     `limit` (not a positive integer / NaN / negative).
+ *   - 503: loader threw. Body carries the error message so the operator
+ *     can debug a substrate failure without grepping logs.
+ *   - 200: page envelope `{ lessons, next_since }`. Always returned for
+ *     well-formed input even when the page is empty.
+ */
+export async function buildLessonFeedResponse(
+  deps: LessonFeedDeps
+): Promise<HttpResponseShape> {
+  const now = (deps.now ?? (() => new Date()))();
+
+  const sinceResult = resolveSince(deps.since, now);
+  if (!sinceResult.ok) {
+    return jsonResponse(400, {
+      error: sinceResult.error,
+      since: deps.since,
+    });
+  }
+
+  const limitResult = resolveLimit(deps.limit);
+  if (!limitResult.ok) {
+    return jsonResponse(400, {
+      error: limitResult.error,
+      limit: deps.limit,
+    });
+  }
+
+  let lessons: Lesson[];
+  try {
+    lessons = await deps.loadEligibleLessons({
+      since: sinceResult.since,
+      limit: limitResult.limit,
+    });
+  } catch (e) {
+    return jsonResponse(503, {
+      error: "loadEligibleLessons failed",
+      detail: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  const body: LessonFeedResponseBody = {
+    lessons,
+    next_since: computeNextSince(lessons),
+  };
+  return {
+    status: 200,
+    headers: { ...RESPONSE_HEADERS },
+    body: JSON.stringify(body),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported so the contract test can pin them independently.
+// ---------------------------------------------------------------------------
+
+export type SinceResolution =
+  | { ok: true; since: Date }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the cursor `since`:
+ *   - null / undefined / "" → DEFAULT_SINCE_LOOKBACK_MS before `now`.
+ *   - Strict ISO8601 with timezone → that instant.
+ *   - Anything else → 400-shaped error.
+ *
+ * `now` is taken as a parameter so callers can inject a fixed clock; the
+ * handler does so via `deps.now`.
+ */
+export function resolveSince(
+  raw: string | null | undefined,
+  now: Date
+): SinceResolution {
+  if (raw === null || raw === undefined || raw === "") {
+    return {
+      ok: true,
+      since: new Date(now.getTime() - DEFAULT_SINCE_LOOKBACK_MS),
+    };
+  }
+  if (typeof raw !== "string" || !ISO8601_TZ_RE.test(raw)) {
+    return {
+      ok: false,
+      error:
+        "since must be an ISO8601 timestamp with timezone (e.g. 2026-04-30T10:20:30Z)",
+    };
+  }
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) {
+    return {
+      ok: false,
+      error:
+        "since must be an ISO8601 timestamp with timezone (e.g. 2026-04-30T10:20:30Z)",
+    };
+  }
+  return { ok: true, since: new Date(ms) };
+}
+
+export type LimitResolution =
+  | { ok: true; limit: number }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the page size `limit`:
+ *   - null / undefined / "" → LIMIT_DEFAULT.
+ *   - Integer in [LIMIT_MIN, LIMIT_MAX] → that integer.
+ *   - Integer outside the range → silently clamped.
+ *   - Non-integer / NaN / negative → 400-shaped error.
+ *
+ * Clamping is silent (per issue spec wording: "clamped to [1, 200]") but
+ * unparseable input gets a 400 — silently substituting a default for a
+ * caller's typo would let a misconfigured client poll with the wrong
+ * page size and never see the bug.
+ */
+export function resolveLimit(
+  raw: string | number | null | undefined
+): LimitResolution {
+  if (raw === null || raw === undefined || raw === "") {
+    return { ok: true, limit: LIMIT_DEFAULT };
+  }
+  let n: number;
+  if (typeof raw === "number") {
+    n = raw;
+  } else if (typeof raw === "string") {
+    // Strict integer-only parse. Reject scientific notation, decimals,
+    // hex prefixes, leading +, and trailing garbage. The dedicated regex
+    // is loud about WHY a value was rejected so an operator with a
+    // suspicious limit value sees the rule that cut it.
+    if (!/^-?\d+$/.test(raw)) {
+      return {
+        ok: false,
+        error: "limit must be an integer",
+      };
+    }
+    n = Number.parseInt(raw, 10);
+  } else {
+    return {
+      ok: false,
+      error: "limit must be an integer",
+    };
+  }
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    return {
+      ok: false,
+      error: "limit must be an integer",
+    };
+  }
+  if (n < 1) {
+    // Clamp to the floor — but only when the value is at least zero or
+    // negative-but-syntactically-valid. A literal "limit=0" is a request
+    // for the smallest legal page; we honour the spec's clamping rule
+    // rather than 400-ing on a value the spec text explicitly covers.
+    return { ok: true, limit: LIMIT_MIN };
+  }
+  if (n > LIMIT_MAX) {
+    return { ok: true, limit: LIMIT_MAX };
+  }
+  return { ok: true, limit: n };
+}
+
+/**
+ * Compute the pagination cursor from a returned page.
+ *
+ * - Empty page → null (no progress).
+ * - Non-empty → max(signed_at) + 1ms in ISO8601 with millisecond
+ *   precision, suffixed `Z`.
+ *
+ * The +1ms increment is the at-least-once cursor's duplicate avoider;
+ * it intentionally drops same-millisecond ties from the next call (the
+ * receiver already has them in this page). See LessonFeedResponseBody.
+ */
+export function computeNextSince(lessons: Lesson[]): string | null {
+  if (!Array.isArray(lessons) || lessons.length === 0) return null;
+  let maxMs = -Infinity;
+  for (const l of lessons) {
+    const t = Date.parse(l.signed_at);
+    if (Number.isFinite(t) && t > maxMs) maxMs = t;
+  }
+  if (!Number.isFinite(maxMs)) return null;
+  return new Date(maxMs + 1).toISOString();
+}
+
+function jsonResponse(status: number, body: unknown): HttpResponseShape {
+  return {
+    status,
+    headers: { ...RESPONSE_HEADERS },
+    body: JSON.stringify(body),
+  };
+}


### PR DESCRIPTION
## Summary

First slice of issue #139 — pure handler module + 32 contract tests for the §10.6 outbound broadcast feed (`GET /swarm/lessons?since=…&limit=…`). Mirrors the #138 / #154 substrate-vs-wiring split.

- `mcp-server/src/swarm/endpoints/lesson-feed.ts` — pure response builder. The loader is injected so contract tests run with no DB / HTTP.
- `mcp-server/src/__tests__/lesson-feed.test.ts` — 32 tests covering input validation, defaulting, clamping, cursor math, and shape-pin regression guards.

## Status mapping

- **400** — malformed `since` (must be ISO8601 with timezone) or malformed `limit` (must be an integer; clamped silently if outside `[1, 200]`, rejected if non-numeric / decimal / NaN).
- **503** — loader threw; operator-readable `detail` field in the body.
- **200** — `{ lessons: Lesson[], next_since: string | null }`. `next_since = max(signed_at) + 1ms`; `null` on empty page.

## Substrate filter contract

Documented on the loader signature: it **MUST** read `FROM swarm_lessons_broadcast_eligible` (the §10.6 firebreak view from migration 078) **AND** apply `local_weight >= 0.3` (the §10.4 anti-echo-chamber filter from migration 082). The handler deliberately does **NOT** re-filter — the substrate IS the contract; the integration test that verifies this lands with the wiring PR.

## Privacy invariant

Rows are relayed verbatim — the handler never re-signs. Re-signing would let any node forge producer attestations for lessons it has merely seen (the same trust break the proof handler's relay-guard prevents at §4.6).

## Out of scope (issue #139 pieces 2 + 3)

- Active publish at REM B→A promotion (`lesson_chain` append + producer-side signing). Depends on #136 producer hook.
- Self-broadcast safety CHECK / trigger preventing a self-row from carrying a foreign-looking `origin_node_id`.
- HTTP wiring into `dashboard-server.mjs` — follow-up PR (mirror of #128 → #152).

## Test plan

- [x] `npm test` — 678 pass (baseline 646; this PR adds 32 tests)
- [x] `tsc --build` clean
- [ ] Reed merges; integration test ships with the wiring PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)