### PR TITLE
feat(swarm): self-broadcast safety triggers — PR #155 follow-up

### DIFF
--- a/mcp-server/src/__tests__/migration-085-self-broadcast-safety.test.ts
+++ b/mcp-server/src/__tests__/migration-085-self-broadcast-safety.test.ts
@@ -1,0 +1,239 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 085 — self-broadcast safety guard (PR #155 follow-up, issue #139)
+//
+// PR #155 (substrate for outbound /swarm/lessons feed handler) listed this
+// as out-of-scope. The migration adds two triggers that converge on the
+// invariant: a row whose id appears in lesson_chain (074) — definitionally a
+// self-row — MUST carry origin_node_id equal to the local self identity.
+//
+// Three structural surfaces this test pins:
+//
+//   1. The shared helper self_broadcast_assert_origin(UUID, TEXT) raises
+//      when (a) no is_self row exists, or (b) p_origin differs from the
+//      local self id. Both directions must RAISE — silently returning on
+//      either branch would gut the invariant.
+//
+//   2. lesson_chain BEFORE INSERT trigger uses the helper. Without it, a
+//      chain insert that lands AFTER a swarm_lessons row with foreign
+//      origin would never be checked.
+//
+//   3. swarm_lessons BEFORE INSERT OR UPDATE OF origin_node_id trigger
+//      uses the helper, gated on lesson_chain existence so foreign-row
+//      admission via /swarm/lessons (PR #154 substrate) still works.
+//      The UPDATE OF clause is critical — a blanket BEFORE UPDATE would
+//      fire on every signature_verified_at touch, multiplying overhead
+//      on the receiver hot path.
+//
+// Contract-test pattern mirrors migration-070..082: the autonomy loop
+// cannot execute migrations (Reed runs them by hand after merge), so we
+// pin shape at the SQL-text level. Stripping comments before keyword
+// matching prevents an explanatory phrase from satisfying a structural
+// assertion below.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/085_self_broadcast_safety.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) Shared assertion helper
+// ---------------------------------------------------------------------------
+
+test("self_broadcast_assert_origin helper exists with the (UUID, TEXT) signature", () => {
+  // Both triggers funnel through this helper — pinning the signature
+  // catches a refactor that drops the lesson_id arg (which would lose
+  // the lesson context from the error message).
+  assert.match(
+    SQL,
+    /create or replace function self_broadcast_assert_origin\(\s*p_lesson_id\s+uuid\s*,\s*p_origin\s+text\s*\)\s+returns void/,
+  );
+});
+
+test("helper raises when no is_self row exists (identity-not-bootstrapped path)", () => {
+  // Without this branch, a fresh DB before phase 1b would silently admit
+  // chain inserts whose origin can't be resolved — defeating §3.7.2.
+  assert.match(
+    SQL,
+    /raise exception\s+'self_broadcast_safety: no is_self row in nodes — node identity not bootstrapped/,
+  );
+});
+
+test("helper raises when p_origin differs from local self (misattribution path)", () => {
+  // The core invariant. IS DISTINCT FROM (not <>) handles the NULL-origin
+  // edge case — a row with origin_node_id = NULL would slip past a plain
+  // <> comparison since (NULL <> 'self') is NULL, not TRUE.
+  assert.match(SQL, /if p_origin is distinct from v_self then/);
+  assert.match(
+    SQL,
+    /raise exception\s+'self_broadcast_safety: lesson % carries origin_node_id=% but local self is %/,
+  );
+});
+
+test("helper is STABLE (planner can hoist within a statement)", () => {
+  // STABLE is the right volatility class: the function reads but does
+  // not mutate. IMMUTABLE would be wrong (depends on table state);
+  // VOLATILE would block any planner reuse on bulk inserts.
+  assert.match(
+    SQL,
+    /create or replace function self_broadcast_assert_origin.+?\$\$\s+language plpgsql stable/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) lesson_chain BEFORE INSERT trigger
+// ---------------------------------------------------------------------------
+
+test("lesson_chain_assert_self_origin trigger function returns TRIGGER", () => {
+  assert.match(
+    SQL,
+    /create or replace function lesson_chain_assert_self_origin\(\)\s+returns trigger/,
+  );
+});
+
+test("lesson_chain trigger looks up swarm_lessons.origin_node_id by NEW.lesson_id", () => {
+  // Pin the SELECT — a refactor that swaps NEW.lesson_id for NEW.id
+  // would silently miss every check (NEW.id doesn't exist on lesson_chain).
+  assert.match(
+    SQL,
+    /select origin_node_id into v_origin\s+from swarm_lessons\s+where id = new\.lesson_id/,
+  );
+});
+
+test("lesson_chain trigger raises when identity is unbootstrapped on the no-row path", () => {
+  // The "swarm_lessons row not yet present" branch must still verify
+  // identity bootstrap. Allowing a chain insert without ANY check would
+  // create an unattributable chain entry that no later swarm_lessons
+  // insert can repair.
+  assert.match(
+    SQL,
+    /raise exception\s+'self_broadcast_safety: no is_self row in nodes — refusing lesson_chain insert for lesson %/,
+  );
+});
+
+test("lesson_chain trigger calls the shared helper on the row-exists path", () => {
+  // The cross-row check must funnel through the helper. A locally-inlined
+  // re-implementation would drift from the swarm_lessons trigger over
+  // time and the two would diverge on edge cases.
+  assert.match(
+    SQL,
+    /perform self_broadcast_assert_origin\(new\.lesson_id, v_origin\)/,
+  );
+});
+
+test("lesson_chain trigger fires BEFORE INSERT, not AFTER", () => {
+  // BEFORE is load-bearing: AFTER would commit the chain row before
+  // the check runs, requiring a transaction rollback to undo.
+  assert.match(
+    SQL,
+    /drop trigger if exists lesson_chain_assert_self_origin_trg on lesson_chain/,
+  );
+  assert.match(
+    SQL,
+    /create trigger lesson_chain_assert_self_origin_trg\s+before insert on lesson_chain\s+for each row execute function lesson_chain_assert_self_origin\(\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) swarm_lessons BEFORE INSERT OR UPDATE OF origin_node_id trigger
+// ---------------------------------------------------------------------------
+
+test("swarm_lessons_assert_self_origin trigger function returns TRIGGER", () => {
+  assert.match(
+    SQL,
+    /create or replace function swarm_lessons_assert_self_origin\(\)\s+returns trigger/,
+  );
+});
+
+test("swarm_lessons trigger gates on lesson_chain existence (foreign-row passthrough)", () => {
+  // Without this gate, every receiver-side admission of a foreign lesson
+  // would fail — the entire /swarm/lessons inbound path (PR #154 substrate)
+  // would be blocked. The EXISTS check is the firebreak.
+  assert.match(
+    SQL,
+    /select exists \(\s*select 1 from lesson_chain where lesson_id = new\.id\s*\) into v_in_chain/,
+  );
+  assert.match(SQL, /if not v_in_chain then\s+return new;/);
+});
+
+test("swarm_lessons trigger calls the shared helper for self-rows", () => {
+  assert.match(
+    SQL,
+    /perform self_broadcast_assert_origin\(new\.id, new\.origin_node_id\)/,
+  );
+});
+
+test("swarm_lessons trigger fires only on origin_node_id changes (UPDATE OF clause)", () => {
+  // A blanket BEFORE UPDATE would fire on every signature_verified_at
+  // backfill and lesson_tier promotion in the receiver hot path. Narrowing
+  // to UPDATE OF origin_node_id keeps the check tight without touching
+  // unrelated column writes.
+  assert.match(
+    SQL,
+    /drop trigger if exists swarm_lessons_assert_self_origin_trg on swarm_lessons/,
+  );
+  assert.match(
+    SQL,
+    /create trigger swarm_lessons_assert_self_origin_trg\s+before insert or update of origin_node_id on swarm_lessons\s+for each row execute function swarm_lessons_assert_self_origin\(\)/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) Migration discipline — purely additive, no destructive ops
+// ---------------------------------------------------------------------------
+
+test("migration 085 does not DROP swarm_lessons, lesson_chain, or nodes", () => {
+  // The follow-up is purely additive — two trigger functions, two triggers,
+  // one shared helper. A silent DROP TABLE in a fresh-DB migration would
+  // still apply cleanly but blow away production data on an upgrade run.
+  assert.doesNotMatch(SQL, /drop table\s+(?:if exists\s+)?swarm_lessons\b/);
+  assert.doesNotMatch(SQL, /drop table\s+(?:if exists\s+)?lesson_chain\b/);
+  assert.doesNotMatch(SQL, /drop table\s+(?:if exists\s+)?nodes\b/);
+});
+
+test("migration 085 does not modify the swarm_lessons or lesson_chain column set", () => {
+  // The §10.6 firebreak view (migration 078) and the §3.7.2 chain
+  // structure (074) are downstream contracts. An ALTER TABLE in 085
+  // would couple the safety guard to schema evolution — not the right
+  // separation of concerns for a pure invariant trigger.
+  assert.doesNotMatch(SQL, /alter table\s+swarm_lessons\s+(?:add|drop|alter|rename) column/);
+  assert.doesNotMatch(SQL, /alter table\s+lesson_chain\s+(?:add|drop|alter|rename) column/);
+});
+
+test("migration 085 does not touch the swarm_lessons_broadcast_eligible firebreak view", () => {
+  // The §10.6 view from migration 078 is the single source of truth for
+  // broadcast eligibility. Re-defining it here would split the contract
+  // across two migrations and invite drift on upgrade.
+  assert.doesNotMatch(
+    SQL,
+    /create (?:or replace )?view\s+swarm_lessons_broadcast_eligible\b/,
+  );
+  assert.doesNotMatch(
+    SQL,
+    /drop view\s+(?:if exists\s+)?swarm_lessons_broadcast_eligible\b/,
+  );
+});
+
+test("migration 085 does not re-grant lesson_chain or swarm_lessons", () => {
+  // Triggers run in the privileges of the invoking role. A GRANT change
+  // here would suggest a privilege coupling that this migration does not
+  // create — pin the absence to make that explicit.
+  assert.doesNotMatch(SQL, /grant\s+\w+\s+on\s+swarm_lessons\b/);
+  assert.doesNotMatch(SQL, /grant\s+\w+\s+on\s+lesson_chain\b/);
+});

--- a/supabase/migrations/085_self_broadcast_safety.sql
+++ b/supabase/migrations/085_self_broadcast_safety.sql
@@ -1,0 +1,179 @@
+-- 085_self_broadcast_safety.sql — Swarm self-broadcast safety guard
+--
+-- Closes the "Self-broadcast safety CHECK / trigger preventing a self-row from
+-- carrying a foreign-looking origin_node_id" follow-up listed as out-of-scope
+-- in PR #155 (issue #139, outbound /swarm/lessons feed handler substrate).
+--
+-- Bug class being prevented:
+--   1. A producer-side typo, copy-paste, or variable swap stores a locally
+--      produced lesson with origin_node_id = some_peer.node_id.
+--   2. The row gets indexed at lesson_tier='A' (locally-produced shortcut from
+--      §10.6 — locally-generated lessons skip Tier-B audit) and ends up in
+--      swarm_lessons_broadcast_eligible (migration 078 firebreak view).
+--   3. The /swarm/lessons feed serves the foreign-attributed row, falsely
+--      claiming a peer's authorship and corrupting the swarm trust graph at
+--      the receiver side.
+--
+-- The wire-validator and §10.2 quarantine handle the receiver-side trust
+-- breach AFTER the row escapes; this trigger denies it at the source. Defense
+-- in depth — the producer-side hook (PR #146) is supposed to set origin
+-- correctly, but a SQL-side invariant catches the class of bugs that
+-- application code alone cannot.
+--
+-- Identification of "self-row" at SQL level:
+--   * A row whose id appears in lesson_chain (migration 074) IS by definition
+--     a self-row. The 074 comment is explicit: "This table holds OUR
+--     locally-published lessons only."
+--   * Cross-checking origin_node_id against (SELECT node_id FROM nodes
+--     WHERE is_self) closes the data-integrity gap.
+--
+-- Two triggers — symmetric, covers both insert orderings:
+--   1. lesson_chain BEFORE INSERT — if the corresponding swarm_lessons row
+--      already exists, its origin must match self.
+--   2. swarm_lessons BEFORE INSERT OR UPDATE OF origin_node_id — if a
+--      lesson_chain row already exists for this id, the origin must match
+--      self.
+--
+-- Why both: the producer flow is allowed to insert in either order. A single
+-- trigger on either table only catches inserts that come AFTER the other
+-- side. Two triggers, one per table, converge on the invariant regardless of
+-- ordering. In practice the producer should run both inserts in one
+-- transaction so a rollback on either side rolls back the other.
+--
+-- Identity bootstrap requirement: in the bootstrap window before phase 1b
+-- runs, `nodes WHERE is_self = TRUE` returns no row. We RAISE in that case
+-- to force an explicit identity bootstrap before any self-publish. §3.7.2
+-- semantics demand the producer flow run only after node identity exists,
+-- so refusing here is preferable to silently allowing an unattributable
+-- chain entry.
+--
+-- Foreign-row passthrough: rows that arrive via /swarm/lessons admission
+-- (PR #154 substrate, future wiring PR) carry foreign origin_node_id by
+-- design. They are NEVER added to lesson_chain (074 comment), so the
+-- swarm_lessons trigger's "in_chain" check returns FALSE and admits them
+-- unchanged. The wire-validator and §10.2 quarantine already vet those.
+--
+-- This migration is purely additive: two trigger functions, two triggers,
+-- one shared assertion helper. No DDL on existing tables, no DML, no GRANT
+-- changes. Reed runs the migration manually after merge — the autonomy
+-- loop is forbidden from executing it (migration discipline from 070-082).
+
+-- ---------------------------------------------------------------------------
+-- (1) Shared assertion helper — single source of truth for the rule
+--
+-- Both triggers funnel through this helper so the error message stays
+-- identical and the self-id lookup happens once per check. STABLE because
+-- the lookup against `nodes` doesn't mutate; the planner can hoist repeated
+-- calls within a statement (rare but possible on bulk INSERT).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION self_broadcast_assert_origin(
+  p_lesson_id UUID,
+  p_origin    TEXT
+) RETURNS VOID AS $$
+DECLARE
+  v_self TEXT;
+BEGIN
+  SELECT node_id INTO v_self FROM nodes WHERE is_self = TRUE LIMIT 1;
+
+  IF v_self IS NULL THEN
+    RAISE EXCEPTION
+      'self_broadcast_safety: no is_self row in nodes — node identity not bootstrapped, refusing self-publish for lesson %',
+      p_lesson_id;
+  END IF;
+
+  IF p_origin IS DISTINCT FROM v_self THEN
+    RAISE EXCEPTION
+      'self_broadcast_safety: lesson % carries origin_node_id=% but local self is % — refusing to mis-attribute a self-row to a foreign producer',
+      p_lesson_id, p_origin, v_self;
+  END IF;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION self_broadcast_assert_origin(UUID, TEXT) IS
+  'docs/SWARM_SPEC.md §3.1 + §10.6 self-broadcast safety: a row marked as self-published (id present in lesson_chain) MUST carry origin_node_id equal to the local self identity. Raises on misattribution. Called from the lesson_chain and swarm_lessons triggers in migration 085.';
+
+-- ---------------------------------------------------------------------------
+-- (2) lesson_chain trigger — chain-side self-row check
+--
+-- Fires BEFORE INSERT on lesson_chain. If the corresponding swarm_lessons
+-- row already exists, its origin_node_id must match self. If it doesn't
+-- exist yet, we still verify that node identity is bootstrapped — even a
+-- chain-leads insert order requires a known self-id, and the swarm_lessons
+-- trigger will then enforce the cross-row invariant on the later insert.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION lesson_chain_assert_self_origin() RETURNS TRIGGER AS $$
+DECLARE
+  v_origin TEXT;
+  v_has_self BOOLEAN;
+BEGIN
+  SELECT origin_node_id INTO v_origin
+    FROM swarm_lessons
+   WHERE id = NEW.lesson_id;
+
+  IF v_origin IS NULL THEN
+    -- No swarm_lessons row yet. Identity must still be bootstrapped — the
+    -- producer flow per §3.7.2 cannot run without a self-id, and admitting
+    -- a chain entry that has no resolvable origin would defeat the rule.
+    SELECT EXISTS (SELECT 1 FROM nodes WHERE is_self = TRUE) INTO v_has_self;
+    IF NOT v_has_self THEN
+      RAISE EXCEPTION
+        'self_broadcast_safety: no is_self row in nodes — refusing lesson_chain INSERT for lesson %',
+        NEW.lesson_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  PERFORM self_broadcast_assert_origin(NEW.lesson_id, v_origin);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION lesson_chain_assert_self_origin() IS
+  'BEFORE INSERT trigger function for lesson_chain (migration 085). Cross-checks origin_node_id against self identity if the corresponding swarm_lessons row already exists. Complementary swarm_lessons_assert_self_origin handles the reverse insert order.';
+
+DROP TRIGGER IF EXISTS lesson_chain_assert_self_origin_trg ON lesson_chain;
+CREATE TRIGGER lesson_chain_assert_self_origin_trg
+  BEFORE INSERT ON lesson_chain
+  FOR EACH ROW EXECUTE FUNCTION lesson_chain_assert_self_origin();
+
+-- ---------------------------------------------------------------------------
+-- (3) swarm_lessons trigger — storage-side self-row check
+--
+-- Fires BEFORE INSERT OR UPDATE OF origin_node_id on swarm_lessons. The
+-- UPDATE OF clause narrows the trigger to the only column whose change
+-- could break attribution; an UPDATE that touches signature_verified_at,
+-- received_at, or lesson_tier won't fire it.
+--
+-- The "in_chain" gate is what keeps this from breaking foreign-row admission
+-- via /swarm/lessons (PR #154 substrate). Foreign rows are never added to
+-- lesson_chain (074 comment), so v_in_chain = FALSE and they pass through
+-- unchanged. Only rows the producer claims as self-published — by also
+-- inserting into lesson_chain — get the origin check.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION swarm_lessons_assert_self_origin() RETURNS TRIGGER AS $$
+DECLARE
+  v_in_chain BOOLEAN;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM lesson_chain WHERE lesson_id = NEW.id
+  ) INTO v_in_chain;
+
+  -- Foreign rows (no chain entry) are out-of-scope for this trigger. The
+  -- wire-validator (PR #102 / #123) and §10.2 quarantine cover misattribution
+  -- on the receiver side.
+  IF NOT v_in_chain THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM self_broadcast_assert_origin(NEW.id, NEW.origin_node_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION swarm_lessons_assert_self_origin() IS
+  'BEFORE INSERT OR UPDATE OF origin_node_id trigger function for swarm_lessons (migration 085). If a lesson_chain row exists for NEW.id (the row IS a self-row), origin must equal local self. Foreign rows pass through — wire-validator and §10.2 quarantine cover that surface.';
+
+DROP TRIGGER IF EXISTS swarm_lessons_assert_self_origin_trg ON swarm_lessons;
+CREATE TRIGGER swarm_lessons_assert_self_origin_trg
+  BEFORE INSERT OR UPDATE OF origin_node_id ON swarm_lessons
+  FOR EACH ROW EXECUTE FUNCTION swarm_lessons_assert_self_origin();


### PR DESCRIPTION
## Summary

Closes the **Self-broadcast safety CHECK / trigger** follow-up listed as out-of-scope in PR #155 (issue #139, outbound `/swarm/lessons` feed handler substrate).

Adds migration 085 with two `BEFORE` triggers that converge on a single invariant: **a row whose id appears in `lesson_chain` (074) — definitionally a self-row — MUST carry `origin_node_id` equal to the local self identity.**

## Bug class being prevented

1. A producer-side typo, copy-paste, or variable swap stores a locally produced lesson with `origin_node_id = some_peer.node_id`.
2. The row gets indexed at `lesson_tier='A'` (locally-produced shortcut from §10.6) and ends up in `swarm_lessons_broadcast_eligible` (migration 078 firebreak view).
3. The `/swarm/lessons` feed serves the foreign-attributed row, falsely claiming a peer's authorship and corrupting the swarm trust graph at the receiver.

The wire-validator and §10.2 quarantine handle the receiver-side trust breach **after** a row escapes; this trigger denies it at the source.

## Design

Two BEFORE triggers, symmetric — covers both insert orderings:

1. **`lesson_chain BEFORE INSERT`** — if the corresponding `swarm_lessons` row exists, its origin must match self. If not, identity bootstrap is still verified.
2. **`swarm_lessons BEFORE INSERT OR UPDATE OF origin_node_id`** — if a `lesson_chain` row exists for `NEW.id`, origin must equal local self. The `UPDATE OF` clause is load-bearing: a blanket `BEFORE UPDATE` would fire on every `signature_verified_at` and `lesson_tier` write in the receiver hot path.

Both triggers funnel through a shared `self_broadcast_assert_origin(UUID, TEXT)` helper so error messages stay consistent and the misattribution / identity-unbootstrapped branches don't drift.

`IS DISTINCT FROM` (not `<>`) handles the `NULL`-origin edge case — a row with `origin_node_id = NULL` would slip past plain `<>` since `(NULL <> 'self')` is `NULL`, not `TRUE`.

## Foreign-row passthrough

Rows admitted via `/swarm/lessons` (PR #154 substrate, future wiring PR) carry foreign origin by design. They are never added to `lesson_chain` (074 comment), so the `swarm_lessons` trigger's `EXISTS` gate returns `FALSE` and they pass through unchanged. The wire-validator (PR #102 / #123) and §10.2 quarantine cover that surface.

## Files

```
supabase/migrations/085_self_broadcast_safety.sql                    | 168 ++++++
mcp-server/src/__tests__/migration-085-self-broadcast-safety.test.ts | 250 ++++++++
2 files changed, 418 insertions(+)
```

No DDL on existing tables, no DML, no GRANT changes, no touches to the §10.6 firebreak view from migration 078.

## Test plan

- [x] `npm run build` — clean (strict TS)
- [x] `npm test` — **663 pass** (baseline 646; this PR adds 17 contract tests)
- [x] All 17 tests cover one structural surface each: helper signature, STABLE volatility, both error-path RAISEs (`IS DISTINCT FROM` for NULL), both trigger gates, `UPDATE OF origin_node_id` clause, foreign-row passthrough EXISTS gate, migration-discipline negatives (no DROP, no ALTER on prior tables, no re-definition of the firebreak view).
- [ ] After Reed merges + applies migration: producer flow inserting a row with mis-attributed origin raises `self_broadcast_safety:` error with the lesson id and the divergent origin.

## Why now

Independent of every open PR — operates on tables already in main (`nodes` from 070, `swarm_lessons` from 071, `lesson_chain` from 074). Lands ahead of the producer-side hook in PR #146 so the moment that hook activates, the SQL invariant is already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)