### PR TITLE
feat(swarm): operator-actions backend — issue #142 (substrate slice)

### DIFF
--- a/mcp-server/src/__tests__/migration-086-swarm-operator-actions.test.ts
+++ b/mcp-server/src/__tests__/migration-086-swarm-operator-actions.test.ts
@@ -1,0 +1,227 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Migration 086 — Swarm operator-action substrate (issue #142 backend slice)
+//
+// The dashboard's POST handlers (handleSwarmContradictResolve,
+// handleSwarmPeerTrustOverride, handleSwarmLessonPin) depend on three
+// on-disk contracts that this test pins:
+//
+//   1. swarm_lesson_contradictions has resolved_at + resolution_decision
+//      columns. The §10.3 "operator decision" branch can't move a pair
+//      out of the active list without these — and a future edit that
+//      drops or renames either column would silently turn the active-
+//      list view into a no-op.
+//   2. The active-list view exists and reads `resolved_at IS NULL`.
+//      A view definition that omits this filter would re-expose every
+//      historical contradiction pair to the operator UI.
+//   3. The two operator RPCs exist with the expected signatures and
+//      whitelist their decision parameter to {'a','b','park'}. A widening
+//      to accept arbitrary strings would let the UI write rows that the
+//      column-level CHECK then rejects — confusing UX, hidden bug.
+//
+// We can't run the migration here (the autonomy loop is forbidden from
+// executing migrations, Reed runs them by hand after merge), but we CAN
+// regex-pin the structural contract so a future edit can never silently
+// weaken any of the three.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, so the repo root is three
+// levels up (dist/__tests__ -> dist -> mcp-server -> repo-root).
+const MIGRATION_PATH = resolve(
+  __dirname,
+  "../../..",
+  "supabase/migrations/086_swarm_operator_actions.sql",
+);
+const SQL_RAW = readFileSync(MIGRATION_PATH, "utf8");
+// Strip line and block comments BEFORE keyword checks so a phrase like
+// "no DROP" inside a comment cannot satisfy or violate a structural
+// assertion.
+const SQL_NO_COMMENTS = SQL_RAW.replace(/--[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+// Lowercase + collapsed whitespace makes the assertions robust to indent
+// or keyword-case drift without weakening the structural contracts.
+const SQL = SQL_NO_COMMENTS.toLowerCase().replace(/\s+/g, " ");
+
+// ---------------------------------------------------------------------------
+// (1) swarm_lesson_contradictions adds the two operator-resolution columns
+// ---------------------------------------------------------------------------
+
+test("migration 086 adds resolved_at and resolution_decision columns", () => {
+  assert.match(
+    SQL,
+    /alter table swarm_lesson_contradictions\s+add column if not exists resolved_at timestamptz/,
+  );
+  assert.match(
+    SQL,
+    /alter table swarm_lesson_contradictions\s+add column if not exists resolution_decision text/,
+  );
+});
+
+test("resolution_decision is whitelisted to a / b / park", () => {
+  // Operator UI can produce only these three outcomes; widening the
+  // whitelist requires also extending the dashboard handler validator
+  // and the operator_resolve_contradict RPC body.
+  assert.match(
+    SQL,
+    /resolution_decision is null\s+or resolution_decision in\s*\(\s*'a'\s*,\s*'b'\s*,\s*'park'\s*\)/,
+  );
+});
+
+test("resolved_at and resolution_decision must travel together", () => {
+  // Either both NULL (still active) or both set (resolved with a known
+  // outcome). Splitting them would let a partial write produce a row in
+  // the resolved set with no decision, which the UI can't display.
+  assert.match(
+    SQL,
+    /resolved_at is null and resolution_decision is null.*or.*resolved_at is not null and resolution_decision is not null/,
+  );
+});
+
+test("partial index speeds up the active-list scan", () => {
+  // The dashboard re-reads the active list on every operator action.
+  // Without a partial index on resolved_at IS NULL the scan walks the
+  // full historical contradictions table once it grows past a few rows.
+  assert.match(
+    SQL,
+    /create index if not exists swarm_lesson_contradictions_active_idx[\s\S]*?where resolved_at is null/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) swarm_lesson_contradictions_active view filters on resolved_at IS NULL
+// ---------------------------------------------------------------------------
+
+test("active-pairs view exists and filters on resolved_at IS NULL", () => {
+  assert.match(
+    SQL,
+    /create or replace view swarm_lesson_contradictions_active as\s+select \*\s+from swarm_lesson_contradictions\s+where resolved_at is null/,
+  );
+});
+
+test("active-pairs view is granted SELECT to anon and service_role", () => {
+  // The dashboard reads through anon (no service-role JWT in the
+  // browser), so dropping the anon grant would break the operator UI.
+  assert.match(
+    SQL,
+    /grant select on swarm_lesson_contradictions_active to anon, service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) operator_resolve_contradict RPC — atomic resolve + audit
+// ---------------------------------------------------------------------------
+
+test("operator_resolve_contradict signature pins (UUID, TEXT) -> JSONB", () => {
+  assert.match(
+    SQL,
+    /create or replace function operator_resolve_contradict\(\s*p_pair_id\s+uuid\s*,\s*p_decision\s+text\s*\)\s+returns jsonb/,
+  );
+});
+
+test("operator_resolve_contradict rejects decisions outside a/b/park", () => {
+  // A widening here would accept arbitrary input that the column-level
+  // CHECK then rejects — confusing UX, the dashboard would show
+  // "rpc returned 200" but nothing actually happened.
+  assert.match(
+    SQL,
+    /if p_decision not in\s*\(\s*'a'\s*,\s*'b'\s*,\s*'park'\s*\)/,
+  );
+});
+
+test("operator_resolve_contradict refuses to double-resolve", () => {
+  // The active-list filter is the operator's safety surface — it MUST
+  // be impossible to re-resolve a row that was already resolved (which
+  // would write a second tier_promotion_log row for the same lesson).
+  assert.match(SQL, /if v_pair\.resolved_at is not null then\s+raise exception/);
+});
+
+test("operator_resolve_contradict writes a tier_promotion_log row only when tier actually changes", () => {
+  // §10.6 audit rule: every B->A transition writes a log row. But if the
+  // kept lesson was already 'A' (e.g. promoted by §10.5 between detection
+  // and resolution), writing another row would be a no-op log spam.
+  // The kept_id selection inside the IF block guards against that.
+  assert.match(
+    SQL,
+    /if\s*\(\s*select lesson_tier from swarm_lessons where id\s*=\s*v_keep_id\s*\)\s*=\s*'b'\s*then[\s\S]*?insert into tier_promotion_log/,
+  );
+});
+
+test("operator_resolve_contradict deletes the losing lesson on a/b decisions", () => {
+  // FK ON DELETE CASCADE on swarm_lesson_contradictions(b_id) handles the
+  // edge cleanup; we just need the explicit delete on the lesson row.
+  assert.match(SQL, /delete from swarm_lessons where id\s*=\s*v_drop_id/);
+});
+
+test("operator_resolve_contradict park branch keeps both lessons", () => {
+  // Park = "both stay at Tier-B until more evidence arrives." No DELETE,
+  // no tier change, no tier_promotion_log row — only the resolved_at
+  // stamp moves the pair out of the active view.
+  assert.match(
+    SQL,
+    /if p_decision = 'park' then[\s\S]*?update swarm_lesson_contradictions[\s\S]*?set resolved_at[\s\S]*?resolution_decision = 'park'/,
+  );
+});
+
+test("operator_resolve_contradict is granted EXECUTE to anon and service_role", () => {
+  // Dashboard handler runs through the service_role JWT; anon grant is
+  // included for parity with the rest of the swarm RPC surface.
+  assert.match(
+    SQL,
+    /grant execute on function operator_resolve_contradict\(uuid, text\)\s+to anon, service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) operator_pin_swarm_lesson RPC — manual Tier-B → Tier-A override
+// ---------------------------------------------------------------------------
+
+test("operator_pin_swarm_lesson signature pins (UUID) -> JSONB", () => {
+  assert.match(
+    SQL,
+    /create or replace function operator_pin_swarm_lesson\(\s*p_lesson_id\s+uuid\s*\)\s+returns jsonb/,
+  );
+});
+
+test("operator_pin_swarm_lesson is idempotent on already-Tier-A lessons", () => {
+  // The dashboard may double-fire the pin button (network retry, double
+  // click). The idempotent branch returns ok=true with noop=true so the
+  // UI doesn't show an error for a benign repeat.
+  assert.match(SQL, /if v_prior_tier = 'a' then\s+return jsonb_build_object/);
+});
+
+test("operator_pin_swarm_lesson logs the override with reason 'operator-pinned'", () => {
+  // A future audit query can split automated promotions (rem-* reasons)
+  // from manual overrides with a simple LIKE filter — only if the
+  // reason string is stable.
+  assert.match(
+    SQL,
+    /insert into tier_promotion_log[\s\S]*?'operator-pinned'/,
+  );
+});
+
+test("operator_pin_swarm_lesson is granted EXECUTE to anon and service_role", () => {
+  assert.match(
+    SQL,
+    /grant execute on function operator_pin_swarm_lesson\(uuid\)\s+to anon, service_role/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (5) Scope-discipline assertions — no destructive ops on existing tables
+// ---------------------------------------------------------------------------
+
+test("migration 086 contains no DROP / DELETE / REVOKE on existing tables", () => {
+  // Mirrors 075/078/080 discipline: this migration extends, never
+  // rewrites. A DROP or REVOKE here would suggest schema drift that
+  // belongs in a separate migration with its own review.
+  assert.doesNotMatch(SQL, /drop\s+(table|column|view|function|index|constraint)/);
+  assert.doesNotMatch(SQL, /\brevoke\b/);
+});

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -1455,6 +1455,186 @@ async function handleTeacherEscalationResolve(req, res, escId) {
   res.end(JSON.stringify(data));
 }
 
+// --- Swarm Phase 4: operator actions (issue #142 backend slice) ----------
+// Three POST endpoints that let an operator resolve §10.3 contradictions,
+// override a peer's TrustEdge state, and manually pin a Tier-B swarm
+// lesson to Tier-A. The frontend buttons that call these land in a
+// follow-up that depends on the schwarm tab from PR #133. The migration
+// behind these handlers is supabase/migrations/086_swarm_operator_actions.sql.
+
+async function readJsonPostBody(req, res) {
+  if (req.method !== "POST") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "POST only" }));
+    return null;
+  }
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid JSON body" }));
+    return null;
+  }
+}
+
+// POST /swarm/contradict-resolve {pair_id, decision: 'a'|'b'|'park'}
+// Wraps operator_resolve_contradict() — atomic resolve + tier promotion +
+// audit row. The RPC raises on unknown pair_id, double-resolve, or invalid
+// decision; we surface those as 4xx with the RPC error string.
+async function handleSwarmContradictResolve(req, res) {
+  const body = await readJsonPostBody(req, res);
+  if (body == null) return;
+  if (!body.pair_id || typeof body.pair_id !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "pair_id (UUID string) required" }));
+    return;
+  }
+  if (!["a", "b", "park"].includes(body.decision)) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "decision must be 'a' | 'b' | 'park'" }));
+    return;
+  }
+  try {
+    const result = await callRpc("operator_resolve_contradict", {
+      p_pair_id:  body.pair_id,
+      p_decision: body.decision,
+    });
+    res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+    res.end(JSON.stringify(result));
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "contradict-resolve failed", detail: String(e?.message || e) }));
+  }
+}
+
+// POST /swarm/peer-trust-override {node_id, action: 'distrust'|'restore', days?}
+// Composes record_trust_edge_change (audit + weight) with quarantine_origin
+// (state machine) — both from migration 075. No new RPC; operator-override
+// is just a specific sequence of the existing operator-safe primitives.
+//
+// distrust → weight=0.0, quarantine 30 days (or `days` override).
+// restore  → weight=0.5 (default new-peer trust from migration 071),
+//            and clear quarantined_until via a fresh quarantine_origin
+//            call with days=0... no wait, quarantine_origin enforces days>0.
+//            Instead we issue an UPDATE through PostgREST to clear the
+//            column directly. That's the only path that doesn't require
+//            inventing a clear_quarantine RPC for this single use site.
+async function handleSwarmPeerTrustOverride(req, res) {
+  const body = await readJsonPostBody(req, res);
+  if (body == null) return;
+  if (!body.node_id || typeof body.node_id !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "node_id (string) required" }));
+    return;
+  }
+  if (!["distrust", "restore"].includes(body.action)) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "action must be 'distrust' | 'restore'" }));
+    return;
+  }
+
+  try {
+    if (body.action === "distrust") {
+      const days = Number.isInteger(body.days) && body.days > 0 ? body.days : 30;
+      // Trust drop first (the audit log row records the operator reason).
+      await callRpc("record_trust_edge_change", {
+        p_node_id:    body.node_id,
+        p_new_weight: 0.0,
+        p_reason:     "operator-override-distrust",
+      });
+      await callRpc("quarantine_origin", {
+        p_node_id: body.node_id,
+        p_days:    days,
+        p_reason:  "operator-override-distrust",
+      });
+      res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+      res.end(JSON.stringify({
+        ok:                  true,
+        node_id:             body.node_id,
+        action:              "distrust",
+        new_trust_weight:    0.0,
+        quarantine_days:     days,
+      }));
+      return;
+    }
+
+    // restore — weight back to default 0.5 + clear quarantined_until.
+    await callRpc("record_trust_edge_change", {
+      p_node_id:    body.node_id,
+      p_new_weight: 0.5,
+      p_reason:     "operator-override-restore",
+    });
+    // Clear quarantine + reset rejection streak via direct UPDATE through
+    // PostgREST (no clear-quarantine RPC exists; quarantine_origin enforces
+    // days > 0 so we can't reuse it). The service_role JWT we already mint
+    // for callRpc is sufficient.
+    const r = await fetch(
+      new URL(
+        `/nodes?node_id=eq.${encodeURIComponent(body.node_id)}`,
+        UPSTREAM,
+      ),
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type":  "application/json",
+          "Accept":        "application/json",
+          "Prefer":        "return=representation",
+          "Authorization": `Bearer ${SERVICE_JWT}`,
+          "apikey":        SERVICE_JWT,
+        },
+        body: JSON.stringify({
+          quarantined_until:      null,
+          consecutive_rejections: 0,
+          decay_reason:           "operator-override-restore",
+        }),
+      },
+    );
+    if (!r.ok) throw new Error(`PATCH /nodes failed: HTTP ${r.status}`);
+    res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+    res.end(JSON.stringify({
+      ok:               true,
+      node_id:          body.node_id,
+      action:           "restore",
+      new_trust_weight: 0.5,
+      quarantine_cleared: true,
+    }));
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "peer-trust-override failed", detail: String(e?.message || e) }));
+  }
+}
+
+// POST /swarm/lesson-pin {lesson_id}
+// Manual operator-override of the §10.6 promotion path. Idempotent on
+// already-Tier-A lessons (RPC returns noop=true). Local-lesson pin
+// (lessons.tier='pinned') is intentionally NOT supported here — local
+// lessons have no append-only audit table mirroring tier_promotion_log,
+// so a lessons.tier UPDATE would lose the operator decision. That slice
+// lands separately when a local-pin audit table exists.
+async function handleSwarmLessonPin(req, res) {
+  const body = await readJsonPostBody(req, res);
+  if (body == null) return;
+  if (!body.lesson_id || typeof body.lesson_id !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "lesson_id (UUID string) required" }));
+    return;
+  }
+  try {
+    const result = await callRpc("operator_pin_swarm_lesson", {
+      p_lesson_id: body.lesson_id,
+    });
+    res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+    res.end(JSON.stringify(result));
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "lesson-pin failed", detail: String(e?.message || e) }));
+  }
+}
+
 // --- Swarm Phase 3c: GET /.well-known/mycelium-node ----------------------
 // Serves the local node's self-signed NodeAdvertisement (SWARM_SPEC §3.3 +
 // §4.1). Unauthenticated and idempotent on purpose — discovery starts here.
@@ -1480,6 +1660,12 @@ const server = http.createServer((req, res) => {
   // Swarm discovery — must precede the static fall-through so the
   // .well-known path doesn't get rewritten as a file lookup.
   if (req.url === "/.well-known/mycelium-node") return handleNodeAdvertisement(req, res);
+  // Swarm Phase 4 operator actions (issue #142 backend slice). Frontend
+  // buttons that POST these endpoints land in a follow-up PR that builds
+  // on the schwarm tab from PR #133.
+  if (req.url === "/swarm/contradict-resolve")  return handleSwarmContradictResolve(req, res);
+  if (req.url === "/swarm/peer-trust-override") return handleSwarmPeerTrustOverride(req, res);
+  if (req.url === "/swarm/lesson-pin")          return handleSwarmLessonPin(req, res);
   if (req.url.startsWith("/api/"))            return proxyApi(req, res);
   if (req.url.startsWith("/belief"))          return proxyBelief(req, res);
   if (req.url.startsWith("/guard"))           return proxyGuard(req, res);

--- a/supabase/migrations/086_swarm_operator_actions.sql
+++ b/supabase/migrations/086_swarm_operator_actions.sql
@@ -1,0 +1,288 @@
+-- 086_swarm_operator_actions.sql — Swarm Phase 4, issue #142 (backend slice)
+--
+-- Operator-decision substrate for SWARM_SPEC §10.3 (Contradicts) and §10.6
+-- (Tier-A pinning). Without an operator path, contradicted lessons sit in
+-- swarm_lesson_contradictions forever (the §10.3 firebreak resolves only
+-- "by new evidence, operator decision, or §10.5 REM falsification" — the
+-- middle clause was never wired). This migration ships the DB-level
+-- structure + RPCs that the dashboard's POST endpoints (issue #142
+-- frontend slice) will call. The frontend buttons themselves land in a
+-- follow-up that depends on PR #133 (schwarm tab scaffolding).
+--
+-- Three operator surfaces, one PR — same packaging as 075/078/080:
+--   1. resolve a contradict pair → "behalten A" / "behalten B" / "beide parken"
+--   2. override peer trust → "vertrauen aufheben" / "vertrauen wiederherstellen"
+--      (composes existing record_trust_edge_change + quarantine_origin from
+--       migration 075 — no new RPC; the dashboard POST handler chains them)
+--   3. pin a Tier-B swarm lesson to Tier-A → operator-override of §10.6 path
+--
+-- Scope discipline:
+--   * No DROP, no DELETE on existing tables, no GRANT revocations.
+--   * Two new nullable columns on swarm_lesson_contradictions, one new view,
+--     two new SECURITY-INVOKER RPCs.
+--   * Local-lesson pin (lessons.tier='pinned' override) is OUT OF SCOPE
+--     here — local lessons have no append-only audit table to mirror
+--     tier_promotion_log, and bolting one on would expand this PR beyond
+--     "operator backend for the existing audit-logged surfaces."
+--   * Reed runs the migration manually after merge — the autonomy loop is
+--     forbidden from executing migrations (075–085 discipline).
+
+-- ---------------------------------------------------------------------------
+-- (1) swarm_lesson_contradictions.resolved_at + resolution_decision
+--
+-- Both nullable so existing rows keep working without backfill. NULL means
+-- "still active, awaiting decision". The §10.3 active-list view (below)
+-- filters on resolved_at IS NULL so a row resolved by ANY mechanism (the
+-- §10.5 REM-audit can also stamp these in a future migration) drops out.
+--
+-- resolution_decision is whitelisted to {'a','b','park'} — the three
+-- operator outcomes from issue #142 acceptance. A future REM-audit
+-- resolution path can extend the whitelist with 'rem-falsified' without
+-- breaking this column's contract.
+-- ---------------------------------------------------------------------------
+ALTER TABLE swarm_lesson_contradictions
+  ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ;
+ALTER TABLE swarm_lesson_contradictions
+  ADD COLUMN IF NOT EXISTS resolution_decision TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'swarm_lesson_contradictions_resolution_decision_whitelist'
+  ) THEN
+    ALTER TABLE swarm_lesson_contradictions
+      ADD CONSTRAINT swarm_lesson_contradictions_resolution_decision_whitelist
+      CHECK (resolution_decision IS NULL
+             OR resolution_decision IN ('a', 'b', 'park'));
+  END IF;
+  -- Both columns travel together — a row with one set and the other NULL
+  -- would mean "resolved without saying how" or "decision recorded without
+  -- a timestamp," neither of which the operator UI can produce.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'swarm_lesson_contradictions_resolution_paired'
+  ) THEN
+    ALTER TABLE swarm_lesson_contradictions
+      ADD CONSTRAINT swarm_lesson_contradictions_resolution_paired
+      CHECK ((resolved_at IS NULL AND resolution_decision IS NULL)
+             OR (resolved_at IS NOT NULL AND resolution_decision IS NOT NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS swarm_lesson_contradictions_active_idx
+  ON swarm_lesson_contradictions (detected_at DESC)
+  WHERE resolved_at IS NULL;
+
+COMMENT ON COLUMN swarm_lesson_contradictions.resolved_at IS
+  'SWARM_SPEC §10.3 resolution timestamp. NULL = still active. Set by operator_resolve_contradict (operator decision) or by future §10.5 REM-audit falsification path.';
+COMMENT ON COLUMN swarm_lesson_contradictions.resolution_decision IS
+  'Discriminator for resolved_at: ''a'' = kept lesson a (b deleted), ''b'' = kept lesson b (a deleted), ''park'' = both kept at Tier-B. Whitelist extensible for future REM-audit reasons.';
+
+-- ---------------------------------------------------------------------------
+-- (2) swarm_lesson_contradictions_active — the dashboard's read view
+--
+-- The /swarm-overview handler (PR #133) currently SELECTs straight from
+-- swarm_lesson_contradictions and would keep showing resolved pairs after
+-- this migration ships. The follow-up dashboard PR switches the read to
+-- this view; in the meantime existing reads continue to work unchanged
+-- (resolved_at defaults to NULL, so historical rows stay visible).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW swarm_lesson_contradictions_active AS
+  SELECT *
+    FROM swarm_lesson_contradictions
+   WHERE resolved_at IS NULL;
+
+GRANT SELECT ON swarm_lesson_contradictions_active TO anon, service_role;
+
+COMMENT ON VIEW swarm_lesson_contradictions_active IS
+  'docs/SWARM_SPEC.md §10.3 active-pairs view. Filters out rows resolved by operator decision or REM-audit. Dashboard /swarm-overview should switch to this view in the issue #142 frontend slice.';
+
+-- ---------------------------------------------------------------------------
+-- (3) operator_resolve_contradict — atomic resolve + audit
+--
+-- One round-trip from POST /swarm/contradict-resolve. Three branches:
+--
+--   * 'a' → keep lesson a, delete lesson b. Promote a to Tier-A and write
+--     a tier_promotion_log row (B->A) with the operator reason. The
+--     swarm_lessons FK ON DELETE CASCADE means the contradiction edge
+--     itself disappears with b — but we still need to stamp resolved_at
+--     BEFORE the delete so the audit row order is correct (delete fires
+--     CASCADE cleanup, not an UPDATE).
+--   * 'b' → mirror.
+--   * 'park' → keep both at Tier-B, just mark the pair resolved with
+--     decision='park'. No tier_promotion_log entry (no tier change).
+--
+-- §10.6 audit invariant: every B->A transition MUST have a tier_promotion_log
+-- row with non-empty justification. Operator path provides
+-- evidence_ids='{}' (no §10.5 cluster — the operator IS the evidence) and
+-- a reason that begins with 'operator-resolved-contradict'. The empty
+-- evidence_ids array is allowed by the column DEFAULT '{}' from migration
+-- 078 — application-level non-empty enforcement was for §10.5 promotions
+-- only.
+--
+-- Returns JSONB with the action taken so the caller can render an
+-- operator-visible confirmation without a re-fetch.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION operator_resolve_contradict(
+  p_pair_id  UUID,
+  p_decision TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_pair      swarm_lesson_contradictions%ROWTYPE;
+  v_keep_id   UUID;
+  v_drop_id   UUID;
+  v_now       TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_decision NOT IN ('a', 'b', 'park') THEN
+    RAISE EXCEPTION 'operator_resolve_contradict: decision must be a/b/park, got %', p_decision;
+  END IF;
+
+  SELECT * INTO v_pair FROM swarm_lesson_contradictions WHERE id = p_pair_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'operator_resolve_contradict: unknown pair_id %', p_pair_id;
+  END IF;
+  IF v_pair.resolved_at IS NOT NULL THEN
+    RAISE EXCEPTION 'operator_resolve_contradict: pair % already resolved at %',
+      p_pair_id, v_pair.resolved_at;
+  END IF;
+
+  IF p_decision = 'park' THEN
+    -- §10.3 "beide parken": no lesson modifications, no audit row in
+    -- tier_promotion_log (no tier change happened). The resolved_at stamp
+    -- alone moves the row out of the active view; operator can re-open
+    -- by setting resolved_at back to NULL via DB if needed (UI surface
+    -- for un-park is out of scope here).
+    UPDATE swarm_lesson_contradictions
+       SET resolved_at = v_now,
+           resolution_decision = 'park'
+     WHERE id = p_pair_id;
+
+    RETURN jsonb_build_object(
+      'ok',          true,
+      'pair_id',     p_pair_id,
+      'decision',    'park',
+      'a_id',        v_pair.a_id,
+      'b_id',        v_pair.b_id,
+      'resolved_at', v_now
+    );
+  END IF;
+
+  -- 'a' or 'b' → keep one, delete the other, promote the kept one to A.
+  IF p_decision = 'a' THEN
+    v_keep_id := v_pair.a_id;
+    v_drop_id := v_pair.b_id;
+  ELSE
+    v_keep_id := v_pair.b_id;
+    v_drop_id := v_pair.a_id;
+  END IF;
+
+  -- Stamp the resolution BEFORE the delete so the row state reflects the
+  -- operator decision even if the delete fires CASCADE cleanup. Once the
+  -- losing lesson is gone, the contradiction row goes with it (FK ON
+  -- DELETE CASCADE from migration 080) — but the kept lesson's audit row
+  -- in tier_promotion_log preserves the full history.
+  UPDATE swarm_lesson_contradictions
+     SET resolved_at = v_now,
+         resolution_decision = p_decision
+   WHERE id = p_pair_id;
+
+  -- Tier promotion for the kept lesson. Only emit a log row if the lesson
+  -- actually changes tier — operator may have resolved a pair where the
+  -- kept side was already Tier-A (e.g. a §10.5 REM-audit promoted it
+  -- between detection and resolution).
+  IF (SELECT lesson_tier FROM swarm_lessons WHERE id = v_keep_id) = 'B' THEN
+    UPDATE swarm_lessons SET lesson_tier = 'A' WHERE id = v_keep_id;
+    INSERT INTO tier_promotion_log (lesson_id, from_tier, to_tier, reason, evidence_ids)
+    VALUES (
+      v_keep_id, 'B', 'A',
+      'operator-resolved-contradict (kept-' || p_decision || ', dropped peer ' || v_drop_id || ')',
+      ARRAY[]::UUID[]
+    );
+  END IF;
+
+  -- Delete the losing lesson. CASCADE removes the contradiction row and
+  -- any other FKs into swarm_lessons(id) (chain hashes, evidence rows).
+  -- The dropped lesson's tier_promotion_log entries are preserved (the FK
+  -- there is ON DELETE CASCADE too — but operator audit-of-deletion is
+  -- captured by the kept lesson's row above).
+  DELETE FROM swarm_lessons WHERE id = v_drop_id;
+
+  RETURN jsonb_build_object(
+    'ok',          true,
+    'pair_id',     p_pair_id,
+    'decision',    p_decision,
+    'kept_id',     v_keep_id,
+    'dropped_id',  v_drop_id,
+    'resolved_at', v_now,
+    'promoted_to_a', (SELECT lesson_tier FROM swarm_lessons WHERE id = v_keep_id) = 'A'
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION operator_resolve_contradict(UUID, TEXT)
+  TO anon, service_role;
+
+COMMENT ON FUNCTION operator_resolve_contradict(UUID, TEXT) IS
+  'docs/SWARM_SPEC.md §10.3 operator-decision branch. Atomically resolves a contradict pair with one of three outcomes (kept-a / kept-b / park) and writes the §10.6 tier_promotion_log audit row when a tier change actually occurs. Backend for issue #142.';
+
+-- ---------------------------------------------------------------------------
+-- (4) operator_pin_swarm_lesson — manual Tier-B → Tier-A override
+--
+-- Bypasses the §10.6 REM promotion path (rem_promote_swarm_lessons) for
+-- cases where the operator has out-of-band evidence the cluster algorithm
+-- can't see. evidence_ids stays empty (operator IS the evidence), and the
+-- reason is fixed to 'operator-pinned' so a future audit query can split
+-- automated promotions from manual ones with a simple LIKE filter.
+--
+-- Idempotent: pinning an already-Tier-A lesson is a no-op + ok=true with
+-- a `noop` flag, so the operator UI can treat double-clicks gracefully.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION operator_pin_swarm_lesson(
+  p_lesson_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_prior_tier TEXT;
+BEGIN
+  SELECT lesson_tier INTO v_prior_tier
+    FROM swarm_lessons
+   WHERE id = p_lesson_id;
+
+  IF v_prior_tier IS NULL THEN
+    RAISE EXCEPTION 'operator_pin_swarm_lesson: unknown lesson_id %', p_lesson_id;
+  END IF;
+
+  IF v_prior_tier = 'A' THEN
+    RETURN jsonb_build_object(
+      'ok',         true,
+      'noop',       true,
+      'lesson_id',  p_lesson_id,
+      'lesson_tier', 'A'
+    );
+  END IF;
+
+  UPDATE swarm_lessons SET lesson_tier = 'A' WHERE id = p_lesson_id;
+  INSERT INTO tier_promotion_log (lesson_id, from_tier, to_tier, reason, evidence_ids)
+  VALUES (p_lesson_id, 'B', 'A', 'operator-pinned', ARRAY[]::UUID[]);
+
+  RETURN jsonb_build_object(
+    'ok',         true,
+    'noop',       false,
+    'lesson_id',  p_lesson_id,
+    'from_tier',  'B',
+    'to_tier',    'A'
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION operator_pin_swarm_lesson(UUID)
+  TO anon, service_role;
+
+COMMENT ON FUNCTION operator_pin_swarm_lesson(UUID) IS
+  'docs/SWARM_SPEC.md §10.6 manual operator-override of the Tier-B → Tier-A promotion path. Skips the rem_promote_swarm_lessons cluster requirement for cases where the operator has out-of-band evidence. Logged with reason=''operator-pinned'' so a query can split automated vs manual promotions. Backend for issue #142.';


### PR DESCRIPTION
## Summary

- Adds the backend slice for issue #142 (operator actions on the schwarm tab): three `POST /swarm/*` dashboard endpoints + migration 086 with two RPCs and the `swarm_lesson_contradictions_active` view.
- Frontend buttons that POST these endpoints land in a follow-up that depends on the schwarm tab from PR #133 — split here so the substrate can land independently.
- Closes the §10.3 firebreak's "operator decision" branch, which was the only one of the three resolution paths still unwired (REM-falsification and new-evidence already exist).

## What's in the PR

**Migration `086_swarm_operator_actions.sql`**
- `swarm_lesson_contradictions.{resolved_at, resolution_decision}` columns with a whitelist CHECK on decision (`a` / `b` / `park`) and a paired-NULL CHECK so a half-resolved row can't exist.
- Partial index on `resolved_at IS NULL` for the active-list scan.
- `swarm_lesson_contradictions_active` view + `GRANT SELECT TO anon, service_role`.
- `operator_resolve_contradict(uuid, text) RETURNS jsonb` — atomic resolve + optional `B->A` tier promotion + `tier_promotion_log` audit row. Skips the log row when the kept lesson was already Tier-A (e.g. promoted by §10.5 between detection and resolution). Refuses double-resolve.
- `operator_pin_swarm_lesson(uuid) RETURNS jsonb` — manual §10.6 override. Idempotent on already-Tier-A lessons (returns `noop=true`). Logged with `reason='operator-pinned'` so a future audit can split automated promotions from manual ones with a `LIKE` filter.

**Dashboard handlers** in `scripts/dashboard-server.mjs`
- `POST /swarm/contradict-resolve {pair_id, decision}` → `operator_resolve_contradict` RPC.
- `POST /swarm/peer-trust-override {node_id, action: 'distrust'|'restore', days?}` — composes the existing `record_trust_edge_change` + `quarantine_origin` primitives from migration 075. The restore path PATCHes `nodes.quarantined_until = NULL` directly through PostgREST because `quarantine_origin` enforces `days > 0`; introducing a `clear_quarantine` RPC for one call site felt like over-fit.
- `POST /swarm/lesson-pin {lesson_id}` → `operator_pin_swarm_lesson` RPC.

**Migration slot**: 086 (083 is contested between #145 and #147/#148, 084 by #140 — picking 086 dodges the same-slot collision pattern from earlier ticks).

## Out of scope

- **Frontend buttons** — depend on the schwarm tab from PR #133. Will be a separate small PR once #133 lands.
- **Local-lesson pin** (`lessons.tier='pinned'` override) — local lessons have no append-only audit table mirroring `tier_promotion_log`, so a `lessons.tier` UPDATE would lose the operator decision. That slice waits for a local-pin audit table.
- **Bulk operations** — explicit non-goal in the issue body.
- **Un-park** (re-opening a parked pair) — operator can do this manually via SQL today; UI surface is a follow-up.

## Test plan

- [x] `npm test` — 681/681 green (full suite, no regressions in any of the existing 18 migration tests).
- [x] `node --check scripts/dashboard-server.mjs` — passes (dispatcher routing, body parsing, all three handlers).
- [x] New `migration-086-swarm-operator-actions.test.ts` pins 18 structural contracts on the SQL (column shapes, CHECK whitelists, view filter clause, RPC signatures, grant lines, and a no-DROP/no-REVOKE discipline assertion).
- [ ] Manual smoke after Reed runs the migration: POST each endpoint with a known pair_id / node_id / lesson_id, verify the audit rows appear in `tier_promotion_log` / `trust_edge_log` and the row drops out of `swarm_lesson_contradictions_active`.
- [ ] Manual smoke that idempotency works: POST `/swarm/lesson-pin` twice on the same lesson, second call returns `noop=true`.
- [ ] Manual smoke that the double-resolve guard fires: POST `/swarm/contradict-resolve` twice on the same pair_id, second call returns 400 with the RPC error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)