### PR TITLE
feat(swarm): swarm_resolve_contradict MCP tool — issue #143 write slice

### DIFF
--- a/mcp-server/src/__tests__/swarm-resolve-contradict.test.ts
+++ b/mcp-server/src/__tests__/swarm-resolve-contradict.test.ts
@@ -1,0 +1,428 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SwarmResolveContradictService,
+  isValidDecision,
+  parseResolveOutcome,
+  type ResolveContradictDecision,
+  type SwarmResolveContradictDeps,
+} from "../services/swarm-resolve-contradict.js";
+import {
+  swarmResolveContradict,
+  swarmResolveContradictSchema,
+} from "../tools/swarm-resolve-contradict.js";
+
+// ---------------------------------------------------------------------------
+// swarm_resolve_contradict — second write-side slice of issue #143
+//
+// Covers four contracts the §10.3 operator-decision branch depends on:
+//   1. isValidDecision narrows the union before dispatch and rejects non-
+//      whitelist values BEFORE the RPC call, so postgrest's RAISE EXCEPTION
+//      text never leaks into the MCP caller's structured error.
+//   2. parseResolveOutcome maps the JSONB shape from migration 086's RPC
+//      onto the discriminated union — both branches (a/b vs park) — and
+//      throws on shape drift so a future migration edit fails loud.
+//   3. SwarmResolveContradictService.resolveContradict surfaces unknown
+//      pair / already-resolved RPC errors verbatim so the tool can map
+//      them to actionable fix_hints.
+//   4. The MCP tool's ethics-gate refuses without
+//      OPENCLAW_ALLOW_SWARM_WRITE=1 (mirrors swarm_pin_lesson).
+// ---------------------------------------------------------------------------
+
+const FAKE_PAIR_ID = "11111111-2222-3333-4444-555555555555";
+const FAKE_KEPT_ID = "22222222-3333-4444-5555-666666666666";
+const FAKE_DROPPED_ID = "33333333-4444-5555-6666-777777777777";
+
+// ---------------------------------------------------------------------------
+// (1) isValidDecision
+// ---------------------------------------------------------------------------
+
+test("isValidDecision accepts the three §10.3 outcomes", () => {
+  assert.equal(isValidDecision("a"), true);
+  assert.equal(isValidDecision("b"), true);
+  assert.equal(isValidDecision("park"), true);
+});
+
+test("isValidDecision rejects everything else", () => {
+  assert.equal(isValidDecision("c"), false);
+  assert.equal(isValidDecision("A"), false); // case-sensitive
+  assert.equal(isValidDecision(""), false);
+  assert.equal(isValidDecision("rem-falsified"), false);
+});
+
+// ---------------------------------------------------------------------------
+// (2) parseResolveOutcome
+// ---------------------------------------------------------------------------
+
+test("parseResolveOutcome maps an a-branch RPC body onto the keep variant", () => {
+  const out = parseResolveOutcome({
+    ok: true,
+    pair_id: FAKE_PAIR_ID,
+    decision: "a",
+    kept_id: FAKE_KEPT_ID,
+    dropped_id: FAKE_DROPPED_ID,
+    resolved_at: "2026-05-01T17:00:00Z",
+    promoted_to_a: true,
+  });
+  if (out.decision !== "a") {
+    assert.fail(`expected decision='a', got ${out.decision}`);
+  }
+  assert.equal(out.kept_id, FAKE_KEPT_ID);
+  assert.equal(out.dropped_id, FAKE_DROPPED_ID);
+  assert.equal(out.promoted_to_a, true);
+});
+
+test("parseResolveOutcome maps a b-branch RPC body onto the keep variant", () => {
+  const out = parseResolveOutcome({
+    ok: true,
+    pair_id: FAKE_PAIR_ID,
+    decision: "b",
+    kept_id: FAKE_KEPT_ID,
+    dropped_id: FAKE_DROPPED_ID,
+    resolved_at: "2026-05-01T17:00:00Z",
+    promoted_to_a: false,
+  });
+  if (out.decision !== "b") {
+    assert.fail(`expected decision='b', got ${out.decision}`);
+  }
+  assert.equal(out.promoted_to_a, false, "kept lesson was already at A");
+});
+
+test("parseResolveOutcome maps a park-branch RPC body onto the park variant", () => {
+  const out = parseResolveOutcome({
+    ok: true,
+    pair_id: FAKE_PAIR_ID,
+    decision: "park",
+    a_id: FAKE_KEPT_ID,
+    b_id: FAKE_DROPPED_ID,
+    resolved_at: "2026-05-01T17:00:00Z",
+  });
+  assert.equal(out.decision, "park");
+  if (out.decision !== "park") {
+    assert.fail("expected park variant");
+  }
+  assert.equal(out.a_id, FAKE_KEPT_ID);
+  assert.equal(out.b_id, FAKE_DROPPED_ID);
+});
+
+test("parseResolveOutcome throws on ok=false", () => {
+  assert.throws(
+    () =>
+      parseResolveOutcome({
+        ok: false,
+        pair_id: FAKE_PAIR_ID,
+        decision: "a",
+      }),
+    /ok=false/,
+  );
+});
+
+test("parseResolveOutcome throws on shape drift (missing kept_id on a/b)", () => {
+  // A future migration edit that drops kept_id from the RPC body would
+  // silently feed undefined into the memory-bus side-effect. We want a
+  // loud failure instead.
+  assert.throws(
+    () =>
+      parseResolveOutcome({
+        ok: true,
+        pair_id: FAKE_PAIR_ID,
+        decision: "a",
+        // kept_id missing
+        dropped_id: FAKE_DROPPED_ID,
+        resolved_at: "2026-05-01T17:00:00Z",
+      }),
+    /missing kept_id/,
+  );
+});
+
+test("parseResolveOutcome throws on non-object input", () => {
+  assert.throws(() => parseResolveOutcome(null), /expected JSONB object/);
+  assert.throws(() => parseResolveOutcome("a"), /expected JSONB object/);
+  assert.throws(() => parseResolveOutcome([1, 2]), /expected JSONB object/);
+});
+
+test("parseResolveOutcome throws on unknown decision value", () => {
+  assert.throws(
+    () =>
+      parseResolveOutcome({
+        ok: true,
+        pair_id: FAKE_PAIR_ID,
+        decision: "rem-falsified",
+        resolved_at: "2026-05-01T17:00:00Z",
+      }),
+    /decision must be a\/b\/park/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) SwarmResolveContradictService.resolveContradict — orchestration
+// ---------------------------------------------------------------------------
+
+interface RecordedCalls {
+  invoked: Array<{ pairId: string; decision: ResolveContradictDecision }>;
+}
+
+function makeDeps(
+  responseOrError: unknown | Error,
+): { deps: SwarmResolveContradictDeps; calls: RecordedCalls } {
+  const calls: RecordedCalls = { invoked: [] };
+  const deps: SwarmResolveContradictDeps = {
+    async callOperatorResolveContradict(pairId, decision) {
+      calls.invoked.push({ pairId, decision });
+      if (responseOrError instanceof Error) throw responseOrError;
+      return responseOrError;
+    },
+  };
+  return { deps, calls };
+}
+
+test("resolveContradict dispatches a-decision and parses the keep response", async () => {
+  const svc = new SwarmResolveContradictService("http://stub", "stub");
+  const { deps, calls } = makeDeps({
+    ok: true,
+    pair_id: FAKE_PAIR_ID,
+    decision: "a",
+    kept_id: FAKE_KEPT_ID,
+    dropped_id: FAKE_DROPPED_ID,
+    resolved_at: "2026-05-01T17:00:00Z",
+    promoted_to_a: true,
+  });
+
+  const out = await svc.resolveContradict(FAKE_PAIR_ID, "a", deps);
+  assert.equal(out.decision, "a");
+  assert.equal(out.pair_id, FAKE_PAIR_ID);
+  assert.equal(calls.invoked.length, 1);
+  assert.deepEqual(calls.invoked[0], {
+    pairId: FAKE_PAIR_ID,
+    decision: "a",
+  });
+});
+
+test("resolveContradict rejects an invalid decision BEFORE the RPC dispatch", async () => {
+  const svc = new SwarmResolveContradictService("http://stub", "stub");
+  const { deps, calls } = makeDeps({});
+  await assert.rejects(
+    svc.resolveContradict(
+      FAKE_PAIR_ID,
+      "rem-falsified" as ResolveContradictDecision,
+      deps,
+    ),
+    /decision must be a\/b\/park/i,
+  );
+  // CRITICAL: dispatch must NOT happen — postgrest's exception text would
+  // leak through and the MCP caller's structured error would lose the
+  // typed reason.
+  assert.equal(calls.invoked.length, 0, "RPC must not be called for invalid decision");
+});
+
+test("resolveContradict surfaces unknown-pair RPC errors verbatim", async () => {
+  const svc = new SwarmResolveContradictService("http://stub", "stub");
+  const { deps } = makeDeps(
+    new Error(
+      "operator_resolve_contradict RPC failed: operator_resolve_contradict: unknown pair_id 11111111-2222-3333-4444-555555555555",
+    ),
+  );
+  await assert.rejects(
+    svc.resolveContradict(FAKE_PAIR_ID, "a", deps),
+    /unknown pair_id/i,
+  );
+});
+
+test("resolveContradict surfaces already-resolved errors with the original timestamp", async () => {
+  const svc = new SwarmResolveContradictService("http://stub", "stub");
+  const { deps } = makeDeps(
+    new Error(
+      "operator_resolve_contradict RPC failed: operator_resolve_contradict: pair 11111111-2222-3333-4444-555555555555 already resolved at 2026-05-01T16:00:00Z",
+    ),
+  );
+  await assert.rejects(
+    svc.resolveContradict(FAKE_PAIR_ID, "park", deps),
+    /already resolved at 2026-05-01T16:00:00Z/i,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) MCP tool: ethics-gate + Zod schema
+// ---------------------------------------------------------------------------
+
+test("swarmResolveContradict refuses when OPENCLAW_ALLOW_SWARM_WRITE is unset", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  try {
+    const stubSvc = {} as unknown as SwarmResolveContradictService;
+    const stubMem = {} as unknown as Parameters<
+      typeof swarmResolveContradict
+    >[1];
+    const out = await swarmResolveContradict(stubSvc, stubMem, {
+      pair_id: FAKE_PAIR_ID,
+      decision: "a",
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+    assert.ok(out.fix_hint, "structured error must carry a fix_hint");
+  } finally {
+    if (original !== undefined)
+      process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmResolveContradict refuses with non-'1' env values", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "true";
+  try {
+    const stubSvc = {} as unknown as SwarmResolveContradictService;
+    const stubMem = {} as unknown as Parameters<
+      typeof swarmResolveContradict
+    >[1];
+    const out = await swarmResolveContradict(stubSvc, stubMem, {
+      pair_id: FAKE_PAIR_ID,
+      decision: "park",
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmResolveContradict surfaces unknown-pair errors with a precise fix_hint", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    // Build a real service with a deps stub that throws unknown-pair.
+    const svc = new SwarmResolveContradictService("http://stub", "stub");
+    const failingDeps: SwarmResolveContradictDeps = {
+      async callOperatorResolveContradict() {
+        throw new Error(
+          "operator_resolve_contradict RPC failed: operator_resolve_contradict: unknown pair_id ...",
+        );
+      },
+    };
+    // Override defaultDeps so the tool's call to service.defaultDeps()
+    // hands the stub back. Service-level test is enough to verify wiring;
+    // this exercises the tool's error mapping.
+    (svc as unknown as { defaultDeps: () => SwarmResolveContradictDeps }).defaultDeps =
+      () => failingDeps;
+    const stubMem = {} as unknown as Parameters<
+      typeof swarmResolveContradict
+    >[1];
+    const out = await swarmResolveContradict(svc, stubMem, {
+      pair_id: FAKE_PAIR_ID,
+      decision: "a",
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /unknown pair_id/);
+    assert.match(out.fix_hint ?? "", /swarm_lesson_contradictions/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmResolveContradict writes a memory row on success (best-effort)", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    const svc = new SwarmResolveContradictService("http://stub", "stub");
+    (svc as unknown as { defaultDeps: () => SwarmResolveContradictDeps }).defaultDeps =
+      () => ({
+        async callOperatorResolveContradict() {
+          return {
+            ok: true,
+            pair_id: FAKE_PAIR_ID,
+            decision: "a",
+            kept_id: FAKE_KEPT_ID,
+            dropped_id: FAKE_DROPPED_ID,
+            resolved_at: "2026-05-01T17:00:00Z",
+            promoted_to_a: true,
+          };
+        },
+      });
+
+    const memoryCalls: Array<Record<string, unknown>> = [];
+    const memStub = {
+      async create(input: Record<string, unknown>) {
+        memoryCalls.push(input);
+      },
+    } as unknown as Parameters<typeof swarmResolveContradict>[1];
+
+    const out = await swarmResolveContradict(svc, memStub, {
+      pair_id: FAKE_PAIR_ID,
+      decision: "a",
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.memory_recorded, true);
+    assert.equal(memoryCalls.length, 1);
+    assert.equal(memoryCalls[0].category, "decisions");
+    const tags = memoryCalls[0].tags as string[];
+    assert.ok(tags.includes("swarm"));
+    assert.ok(tags.includes("contradict-resolved"));
+    assert.ok(tags.includes("decision-a"));
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmResolveContradict succeeds even when memory-bus write fails (best-effort contract)", async () => {
+  // §10.6 + §10.3 traceability: the durable record is the RPC's audit row
+  // in tier_promotion_log + the resolved_at stamp in
+  // swarm_lesson_contradictions. The memory-bus row is a recall convenience —
+  // if the embedding provider is down, the resolve must still succeed.
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    const svc = new SwarmResolveContradictService("http://stub", "stub");
+    (svc as unknown as { defaultDeps: () => SwarmResolveContradictDeps }).defaultDeps =
+      () => ({
+        async callOperatorResolveContradict() {
+          return {
+            ok: true,
+            pair_id: FAKE_PAIR_ID,
+            decision: "park",
+            a_id: FAKE_KEPT_ID,
+            b_id: FAKE_DROPPED_ID,
+            resolved_at: "2026-05-01T17:00:00Z",
+          };
+        },
+      });
+
+    const memStub = {
+      async create() {
+        throw new Error("embedding-provider-down");
+      },
+    } as unknown as Parameters<typeof swarmResolveContradict>[1];
+
+    const out = await swarmResolveContradict(svc, memStub, {
+      pair_id: FAKE_PAIR_ID,
+      decision: "park",
+    });
+    assert.equal(out.ok, true, "resolve must still report ok=true");
+    assert.equal(out.memory_recorded, false);
+    assert.match(out.memory_error ?? "", /embedding-provider-down/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmResolveContradictSchema rejects malformed UUIDs and out-of-range decisions", () => {
+  const bad1 = swarmResolveContradictSchema.safeParse({
+    pair_id: "not-a-uuid",
+    decision: "a",
+  });
+  assert.equal(bad1.success, false);
+
+  const bad2 = swarmResolveContradictSchema.safeParse({
+    pair_id: FAKE_PAIR_ID,
+    decision: "rem-falsified",
+  });
+  assert.equal(bad2.success, false);
+
+  const ok = swarmResolveContradictSchema.safeParse({
+    pair_id: FAKE_PAIR_ID,
+    decision: "park",
+  });
+  assert.equal(ok.success, true);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -174,6 +174,10 @@ import { SwarmPublishService } from "./services/swarm-publish.js";
 import {
   swarmPublishTierAlessonSchema, swarmPublishTierAlessonHandler,
 } from "./tools/swarm-publish.js";
+import { SwarmResolveContradictService } from "./services/swarm-resolve-contradict.js";
+import {
+  swarmResolveContradictSchema, swarmResolveContradictHandler,
+} from "./tools/swarm-resolve-contradict.js";
 import {
   getSelfModelSchema, getSelfModel,
   updateSelfModelSchema, updateSelfModel,
@@ -247,6 +251,7 @@ const swarmPinService       = new SwarmPinService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPeersService     = new SwarmPeersService(SUPABASE_URL, SUPABASE_KEY);
 const swarmAdmitService     = new SwarmAdmitService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPublishService   = new SwarmPublishService(SUPABASE_URL, SUPABASE_KEY);
+const swarmResolveContradictService = new SwarmResolveContradictService(SUPABASE_URL, SUPABASE_KEY);
 const remAuditService       = new RemAuditService(SUPABASE_URL, SUPABASE_KEY);
 const remPromotionService   = new RemPromotionService(SUPABASE_URL, SUPABASE_KEY);
 const remDiversityService   = new RemDiversityService(SUPABASE_URL, SUPABASE_KEY);
@@ -957,6 +962,25 @@ server.tool(
       swarmPublishService,
       memoryService,
       swarmPublishTierAlessonSchema.parse(input),
+    ),
+  ),
+);
+
+// --- swarm phase 4 write: resolve contradict pair (issue #143 + #142 backend) -
+// Operator-side resolution of a §10.3 contradict pair via migration-086's
+// `operator_resolve_contradict(UUID, TEXT)` RPC. Three outcomes (a/b/park) —
+// a/b delete the losing lesson and promote the kept one to Tier-A with a
+// tier_promotion_log audit row; park marks resolved without modifying either
+// lesson. Behind OPENCLAW_ALLOW_SWARM_WRITE=1 (mirrors swarm_pin_lesson).
+server.tool(
+  "swarm_resolve_contradict",
+  "Resolve a §10.3 swarm contradict pair. Decision 'a' = keep lesson a, delete lesson b, promote a to Tier-A. 'b' = mirror. 'park' = mark resolved without modifying either lesson. Writes a tier_promotion_log audit row on a/b when a tier change occurs (reason starts with 'operator-resolved-contradict'). REQUIRES OPENCLAW_ALLOW_SWARM_WRITE=1 — refuses with structured error otherwise. Also writes a 'decisions'-category memory tagged 'swarm' on success (best-effort).",
+  swarmResolveContradictSchema.shape,
+  withErrorHandling((input) =>
+    swarmResolveContradictHandler(
+      swarmResolveContradictService,
+      memoryService,
+      swarmResolveContradictSchema.parse(input),
     ),
   ),
 );

--- a/mcp-server/src/services/swarm-resolve-contradict.ts
+++ b/mcp-server/src/services/swarm-resolve-contradict.ts
@@ -1,0 +1,232 @@
+/**
+ * Swarm resolve-contradict service — Phase 4 / issue #143 write-side slice.
+ *
+ * Thin wrapper around the `operator_resolve_contradict(p_pair_id UUID,
+ * p_decision TEXT) RETURNS JSONB` RPC shipped in migration 086. The
+ * heavy lifting — atomic UPDATE+DELETE+tier_promotion_log INSERT — lives
+ * in the SQL function so the substrate is identical regardless of whether
+ * the call comes from the dashboard's POST handler or this MCP tool.
+ *
+ * Three operator outcomes per SWARM_SPEC §10.3:
+ *
+ *   * 'a'    — keep lesson a, delete lesson b. The kept lesson is promoted
+ *              to Tier-A (B->A audit row in tier_promotion_log) when it
+ *              wasn't already there.
+ *   * 'b'    — mirror of 'a'.
+ *   * 'park' — mark the pair resolved with both lessons retained at their
+ *              current tier. No tier_promotion_log row (no tier change).
+ *
+ * Service-boundary contracts:
+ *
+ *   1. Decision validation happens BEFORE the RPC dispatch. The RPC
+ *      itself raises on unknown decisions, but a Postgres exception
+ *      surfaces less cleanly than an early structured throw — and we
+ *      can give the MCP caller a precise error message ("must be a/b/park")
+ *      rather than the postgrest-flavored RAISE EXCEPTION text.
+ *
+ *   2. Already-resolved pairs surface as an explicit error string, not a
+ *      generic RPC failure. The RPC's RAISE EXCEPTION carries the
+ *      timestamp; we forward it verbatim so the operator can see when
+ *      the pair was first resolved without an extra SELECT.
+ *
+ *   3. Outcome shape is normalized into `ResolveContradictOutcome` —
+ *      a discriminated union over the three decisions. The RPC returns
+ *      slightly different JSONB keys per branch (kept_id/dropped_id only
+ *      on a/b, no promotion flag on park); the discriminated union
+ *      makes the ts callers handle each branch explicitly rather than
+ *      dropping into `any`.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+export type ResolveContradictDecision = "a" | "b" | "park";
+
+export interface ResolveContradictBaseOutcome {
+  pair_id: string;
+  decision: ResolveContradictDecision;
+  resolved_at: string;
+}
+
+export interface ResolveContradictKeepOutcome
+  extends ResolveContradictBaseOutcome {
+  decision: "a" | "b";
+  kept_id: string;
+  dropped_id: string;
+  promoted_to_a: boolean;
+}
+
+export interface ResolveContradictParkOutcome
+  extends ResolveContradictBaseOutcome {
+  decision: "park";
+  a_id: string;
+  b_id: string;
+}
+
+export type ResolveContradictOutcome =
+  | ResolveContradictKeepOutcome
+  | ResolveContradictParkOutcome;
+
+/**
+ * Side-effect bag — every DB write goes through one of these so the
+ * orchestrator is testable without a live Supabase. Mirror of
+ * `SwarmPinDeps` from swarm-pin.ts.
+ */
+export interface SwarmResolveContradictDeps {
+  /**
+   * Invoke the migration-086 `operator_resolve_contradict(UUID, TEXT)`
+   * RPC and return the parsed JSONB body. Throws on RPC failure with
+   * the original postgrest message preserved so callers can distinguish
+   * "unknown pair" / "already resolved" / "decision rejected".
+   */
+  callOperatorResolveContradict(
+    pairId: string,
+    decision: ResolveContradictDecision,
+  ): Promise<unknown>;
+}
+
+const ALLOWED_DECISIONS: ReadonlySet<ResolveContradictDecision> = new Set([
+  "a",
+  "b",
+  "park",
+]);
+
+/**
+ * Validate that `decision` is one of the three §10.3 outcomes. Surfaced
+ * as an explicit guard so the MCP tool's structured-error response can
+ * say "decision must be a/b/park" rather than letting Postgres' RAISE
+ * EXCEPTION text leak through.
+ */
+export function isValidDecision(
+  decision: string,
+): decision is ResolveContradictDecision {
+  return ALLOWED_DECISIONS.has(decision as ResolveContradictDecision);
+}
+
+/**
+ * Map a JSONB row from `operator_resolve_contradict` into the typed
+ * outcome union. Postgres' jsonb_build_object preserves key names but
+ * not types — every value lands on `unknown` and we narrow here. Throws
+ * if the RPC returned a shape that doesn't match either branch (a bug
+ * in the migration would surface as a hard error rather than a silent
+ * mis-cast).
+ */
+export function parseResolveOutcome(raw: unknown): ResolveContradictOutcome {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(
+      `operator_resolve_contradict: expected JSONB object, got ${
+        Array.isArray(raw) ? "array" : typeof raw
+      }`,
+    );
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.ok !== true) {
+    throw new Error(
+      `operator_resolve_contradict: ok=false in response (raw=${JSON.stringify(
+        raw,
+      )})`,
+    );
+  }
+  const decision = r.decision;
+  if (decision !== "a" && decision !== "b" && decision !== "park") {
+    throw new Error(
+      `operator_resolve_contradict: decision must be a/b/park, got ${String(
+        decision,
+      )}`,
+    );
+  }
+  const pair_id = r.pair_id;
+  const resolved_at = r.resolved_at;
+  if (typeof pair_id !== "string" || typeof resolved_at !== "string") {
+    throw new Error(
+      `operator_resolve_contradict: missing pair_id or resolved_at (raw=${JSON.stringify(
+        raw,
+      )})`,
+    );
+  }
+  if (decision === "park") {
+    const a_id = r.a_id;
+    const b_id = r.b_id;
+    if (typeof a_id !== "string" || typeof b_id !== "string") {
+      throw new Error(
+        `operator_resolve_contradict park: missing a_id/b_id (raw=${JSON.stringify(
+          raw,
+        )})`,
+      );
+    }
+    return { pair_id, decision: "park", resolved_at, a_id, b_id };
+  }
+  const kept_id = r.kept_id;
+  const dropped_id = r.dropped_id;
+  if (typeof kept_id !== "string" || typeof dropped_id !== "string") {
+    throw new Error(
+      `operator_resolve_contradict ${decision}: missing kept_id/dropped_id (raw=${JSON.stringify(
+        raw,
+      )})`,
+    );
+  }
+  return {
+    pair_id,
+    decision,
+    resolved_at,
+    kept_id,
+    dropped_id,
+    promoted_to_a: r.promoted_to_a === true,
+  };
+}
+
+export class SwarmResolveContradictService {
+  private db: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.db = createClient(supabaseUrl, supabaseKey);
+  }
+
+  /**
+   * Resolve a contradict pair. Validates the decision before dispatch
+   * (so an MCP caller passing 'maybe' gets a clean structured error
+   * instead of a postgrest exception body). Throws on:
+   *   - decision not in {a, b, park}
+   *   - unknown pair_id
+   *   - pair already resolved (RPC raises with timestamp)
+   *   - RPC error (postgrest message preserved)
+   */
+  async resolveContradict(
+    pairId: string,
+    decision: ResolveContradictDecision,
+    deps: SwarmResolveContradictDeps,
+  ): Promise<ResolveContradictOutcome> {
+    if (!isValidDecision(decision)) {
+      throw new Error(
+        `swarm_resolve_contradict: decision must be a/b/park, got ${String(
+          decision,
+        )}`,
+      );
+    }
+    const raw = await deps.callOperatorResolveContradict(pairId, decision);
+    return parseResolveOutcome(raw);
+  }
+
+  /**
+   * Default deps wired against the service's own SupabaseClient. Same
+   * pattern as SwarmPinService.defaultDeps.
+   */
+  defaultDeps(): SwarmResolveContradictDeps {
+    const db = this.db;
+    return {
+      async callOperatorResolveContradict(pairId, decision) {
+        const { data, error } = await db.rpc(
+          "operator_resolve_contradict",
+          { p_pair_id: pairId, p_decision: decision },
+        );
+        if (error) {
+          throw new Error(
+            `operator_resolve_contradict RPC failed: ${
+              error.message ?? String(error)
+            }`,
+          );
+        }
+        return data;
+      },
+    };
+  }
+}

--- a/mcp-server/src/tools/swarm-resolve-contradict.ts
+++ b/mcp-server/src/tools/swarm-resolve-contradict.ts
@@ -1,0 +1,210 @@
+/**
+ * `swarm_resolve_contradict` MCP tool — second write-side slice of issue #143.
+ *
+ * Operator-side resolution of a §10.3 contradict pair via the
+ * migration-086 `operator_resolve_contradict(UUID, TEXT)` RPC. Three
+ * outcomes (a / b / park) — see SwarmResolveContradictService for the
+ * semantic contract.
+ *
+ * Behind `OPENCLAW_ALLOW_SWARM_WRITE=1` (mirrors `swarm_pin_lesson`):
+ * the tool deletes a swarm_lessons row on a/b decisions and writes a
+ * tier_promotion_log audit row, both of which are firebreak-protected
+ * substrate. No agent should mutate that without explicit operator opt-in.
+ *
+ * Memory-bus side-effect on success: a `decisions`-category memory tagged
+ * `swarm` so the agent's own resolve decisions become recallable. Best-
+ * effort — the RPC's audit trail in `tier_promotion_log` and the resolved_at
+ * stamp on `swarm_lesson_contradictions` are the durable record; the memory
+ * row is a recall convenience for the agent's own future introspection.
+ */
+
+import { z } from "zod";
+import { MemoryService } from "../services/supabase.js";
+import {
+  SwarmResolveContradictService,
+  type ResolveContradictDecision,
+  type ResolveContradictOutcome,
+} from "../services/swarm-resolve-contradict.js";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const swarmResolveContradictSchema = z.object({
+  pair_id: z
+    .string()
+    .regex(UUID_REGEX, "pair_id must be a UUID")
+    .describe(
+      "UUID of the swarm_lesson_contradictions row to resolve.",
+    ),
+  decision: z
+    .enum(["a", "b", "park"])
+    .describe(
+      "Resolution outcome. 'a' = keep lesson a, delete lesson b, promote a to Tier-A. " +
+        "'b' = mirror of a. 'park' = mark resolved without modifying either lesson.",
+    ),
+});
+
+export type SwarmResolveContradictInput = z.infer<
+  typeof swarmResolveContradictSchema
+>;
+
+export interface SwarmResolveContradictOutput {
+  ok: boolean;
+  outcome?: ResolveContradictOutcome;
+  memory_recorded?: boolean;
+  memory_error?: string;
+  error?: string;
+  fix_hint?: string;
+}
+
+export interface McpToolResult {
+  content: { type: "text"; text: string }[];
+}
+
+function asMcpResult(payload: SwarmResolveContradictOutput): McpToolResult {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+/**
+ * Ethics-gate check. Mirrors `swarm_pin_lesson` and the
+ * `OPENCLAW_ALLOW_BREEDING` pattern. A resolve-contradict on the a/b
+ * branch deletes a swarm_lessons row and bumps the kept lesson's tier —
+ * both writes need explicit operator consent.
+ */
+function isSwarmWriteAllowed(): boolean {
+  return process.env.OPENCLAW_ALLOW_SWARM_WRITE === "1";
+}
+
+/**
+ * Build the memory-bus content string for a successful resolve. Same
+ * shape as the swarm_pin_lesson decision memory so dashboard + recall
+ * tooling can filter on `category=decisions, tags includes swarm`.
+ */
+function describeOutcome(outcome: ResolveContradictOutcome): string {
+  if (outcome.decision === "park") {
+    return (
+      `Operator parked swarm contradiction ${outcome.pair_id}: ` +
+      `kept both lessons ${outcome.a_id} and ${outcome.b_id} at current tier.`
+    );
+  }
+  const promotion = outcome.promoted_to_a
+    ? "promoted kept lesson B → A"
+    : "kept lesson was already at A (no promotion)";
+  return (
+    `Operator resolved swarm contradiction ${outcome.pair_id} ` +
+    `(decision=${outcome.decision}): kept ${outcome.kept_id}, ` +
+    `dropped ${outcome.dropped_id}; ${promotion}.`
+  );
+}
+
+/**
+ * Map a service-layer error into the MCP `{ ok:false, error, fix_hint }`
+ * shape. The hint depends on the error keyword so an LLM caller learns
+ * what to try next without crashing the session.
+ */
+function toStructuredError(message: string): SwarmResolveContradictOutput {
+  let fix_hint: string;
+  if (/unknown pair_id/i.test(message)) {
+    fix_hint =
+      "Verify the pair_id exists in swarm_lesson_contradictions. " +
+      "Check spelling/case and that the pair has not already been deleted via CASCADE.";
+  } else if (/already resolved/i.test(message)) {
+    fix_hint =
+      "Pair has already been resolved (either by a prior operator decision or §10.5 REM-audit). " +
+      "Operator un-park is not exposed via MCP — touch swarm_lesson_contradictions directly if reopening is required.";
+  } else if (/decision must be a\/b\/park/i.test(message)) {
+    fix_hint =
+      "Pass decision as one of 'a', 'b', or 'park'. The MCP schema enforces this — " +
+      "this error indicates a malformed call or schema bypass.";
+  } else {
+    fix_hint =
+      "Inspect the swarm_lesson_contradictions / swarm_lessons / tier_promotion_log " +
+      "tables for the underlying DB error.";
+  }
+  return { ok: false, error: message, fix_hint };
+}
+
+/**
+ * Pure handler — exposed for unit tests so they don't have to unwrap the
+ * MCP `content` envelope. Same split as swarm-pin.ts.
+ */
+export async function swarmResolveContradict(
+  service: SwarmResolveContradictService,
+  memoryService: MemoryService,
+  input: SwarmResolveContradictInput,
+): Promise<SwarmResolveContradictOutput> {
+  if (!isSwarmWriteAllowed()) {
+    return {
+      ok: false,
+      error:
+        "swarm_resolve_contradict requires OPENCLAW_ALLOW_SWARM_WRITE=1",
+      fix_hint:
+        "Operator must opt in by setting OPENCLAW_ALLOW_SWARM_WRITE=1 in " +
+        "the MCP server environment. Without it, no MCP tool can write to " +
+        "the swarm trust substrate (§3.4 / §10.6 firebreak).",
+    };
+  }
+
+  let outcome: ResolveContradictOutcome;
+  try {
+    outcome = await service.resolveContradict(
+      input.pair_id,
+      input.decision as ResolveContradictDecision,
+      service.defaultDeps(),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return toStructuredError(message);
+  }
+
+  let memory_recorded = false;
+  let memory_error: string | undefined;
+  try {
+    await memoryService.create({
+      content: describeOutcome(outcome),
+      category: "decisions",
+      tags: ["swarm", "contradict-resolved", `decision-${outcome.decision}`],
+      metadata: {
+        pair_id: outcome.pair_id,
+        decision: outcome.decision,
+        ...(outcome.decision === "park"
+          ? { a_id: outcome.a_id, b_id: outcome.b_id }
+          : {
+              kept_id: outcome.kept_id,
+              dropped_id: outcome.dropped_id,
+              promoted_to_a: outcome.promoted_to_a,
+            }),
+        source: "swarm_resolve_contradict",
+      },
+      source: "swarm_resolve_contradict",
+    });
+    memory_recorded = true;
+  } catch (err) {
+    memory_error = err instanceof Error ? err.message : String(err);
+  }
+
+  return {
+    ok: true,
+    outcome,
+    memory_recorded,
+    ...(memory_error ? { memory_error } : {}),
+  };
+}
+
+/**
+ * MCP-facing adapter — wraps the pure handler's result in the
+ * `{ content: [{ type, text }] }` envelope that `withErrorHandling`
+ * expects. Same convention as swarmPinLessonHandler.
+ */
+export async function swarmResolveContradictHandler(
+  service: SwarmResolveContradictService,
+  memoryService: MemoryService,
+  input: SwarmResolveContradictInput,
+): Promise<McpToolResult> {
+  const output = await swarmResolveContradict(service, memoryService, input);
+  return asMcpResult(output);
+}


### PR DESCRIPTION
## Summary

Wraps migration-086's `operator_resolve_contradict(UUID, TEXT)` RPC as the **second write-side MCP tool** from issue #143 (after `swarm_pin_lesson` in #149's footprint and the existing `tools/swarm-pin.ts`). Three operator outcomes per SWARM_SPEC §10.3:

- **`'a'`** → keep lesson a, delete lesson b, promote a to Tier-A with a `tier_promotion_log` audit row (`reason='operator-resolved-contradict (kept-a, dropped peer …)'`).
- **`'b'`** → mirror.
- **`'park'`** → mark the pair resolved without modifying either lesson (no tier change → no audit row).

Behind `OPENCLAW_ALLOW_SWARM_WRITE=1` (mirrors `swarm_pin_lesson`): the a/b branch deletes a `swarm_lessons` row and bumps the kept lesson's tier — both writes need explicit operator consent.

## Why now

Migration 086 has been on `main` since `8950985`-era and ships the atomic SQL substrate (`operator_resolve_contradict` RPC + `swarm_lesson_contradictions_active` view + decision-paired CHECKs), but no caller is wired yet. Issue #142's frontend slice will hit the same RPC from the dashboard's POST handler; this PR exposes it through MCP so an LLM agent can also drive resolution without going through the dashboard. Both paths share the same SQL-side invariants — no application-trust drift between operator surfaces.

## Architecture

The substrate-layer correctness already lives in the SQL function (atomic UPDATE+DELETE+INSERT inside one stored procedure, idempotent error on already-resolved pairs, decision-paired CHECKs on `resolution_decision`). The TS service is a thin wrapper that adds three things on top:

1. **Pre-dispatch decision validation** — an MCP caller passing `'maybe'` gets a clean structured error (`decision must be a/b/park`) instead of a postgrest exception body. CRITICAL: the test asserts the RPC is NOT called when the decision is invalid — postgrest's `RAISE EXCEPTION` text would otherwise leak through.
2. **JSONB → TS shape narrowing** into a discriminated union over the three decisions. The two RPC branches return slightly different keys (`kept_id`/`dropped_id` only on a/b, no promotion flag on park); the union forces ts callers to handle each branch explicitly. `parseResolveOutcome` throws on shape drift so a future migration edit fails loud rather than silently feeding `undefined` into the memory-bus side-effect.
3. **Memory-bus side-effect** on success: a `decisions`-category memory tagged `swarm` so the agent's own resolve decisions become recallable. **Best-effort** — the durable record is the RPC's audit row in `tier_promotion_log` + the `resolved_at` stamp on `swarm_lesson_contradictions`; the memory row is a recall convenience for the agent's own future introspection (\"did I resolve any pairs in the last hour?\").

## Files

- **`mcp-server/src/services/swarm-resolve-contradict.ts`** (new, ~232 lines incl. doc) — `SwarmResolveContradictService.resolveContradict()` + the dep-injection bag (`callOperatorResolveContradict`) so tests don't need a live Supabase. Default deps wired against the service's own `SupabaseClient`. Mirror of `SwarmPinService` shape.
- **`mcp-server/src/tools/swarm-resolve-contradict.ts`** (new, ~210 lines incl. doc) — Zod schema (UUID + enum), ethics-gate (`OPENCLAW_ALLOW_SWARM_WRITE=1`), error-keyword → `fix_hint` mapping (unknown pair / already resolved / decision rejected), memory-bus side-effect, and the MCP-facing handler that wraps the pure result in the `{ content: [...] }` envelope.
- **`mcp-server/src/__tests__/swarm-resolve-contradict.test.ts`** (new, 18 tests) — four coverage layers matching `swarm-pin.test.ts`:
  - `isValidDecision` whitelist
  - `parseResolveOutcome` both branches + shape-drift loud failures + non-object input
  - service orchestration including the pre-dispatch invalid-decision rejection (asserts RPC is NOT called)
  - tool ethics-gate (unset env, non-`'1'` env values), best-effort memory contract (resolve still succeeds when memory write fails), error-keyword → `fix_hint` mapping, Zod schema malformed-input rejection
- **`mcp-server/src/index.ts`** — three small wiring blocks (import, service construction, `server.tool` registration) symmetric with `swarm_pin_lesson`.

## Acceptance criteria from #143 (this slice)

- [x] Tool registered in `mcp-server/src/index.ts` with proper schema
- [x] Write tool refuses without `OPENCLAW_ALLOW_SWARM_WRITE=1` and returns a structured `{ error, fix_hint }`
- [x] Unit + service-orchestration tests with injected deps (no live DB needed)
- [x] Tool description includes enough context for an LLM to use without further prompting
- [x] Memory-bus side-effect: each successful write also writes a memory entry with category `decisions` and tag `swarm`

## Out of scope

- The remaining #143 write tools — `swarm_publish_tier_a_lesson` (needs producer flow + v1.1 PoK fields), `swarm_admit_lesson` (needs default Supabase deps factory for `admitSwarmLesson`) — ship in follow-up PRs.
- Local-lesson pin (`lessons.tier='pinned'` override) is out of scope per migration 086's scope discipline (no append-only audit table on local `lessons`).
- Operator un-park: re-opening a parked pair is not exposed via MCP; Reed touches `swarm_lesson_contradictions` directly if needed.

## Test plan

- [x] `rm -rf dist && npm run build` clean (mcp-server)
- [x] `npm test` — **847 / 847 pass** on a clean dist
- [x] No new migration — 086 already on main; the decision-paired CHECKs and active-list view are SQL-level invariants this PR doesn't touch
- [ ] Reed merges; the remaining #143 write tools (`swarm_publish_tier_a_lesson`, `swarm_admit_lesson`) ship in follow-up PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)