### PR TITLE
feat(swarm): swarm_publish_tier_a_lesson MCP tool — issue #143 producer-side write slice

### DIFF
--- a/mcp-server/src/__tests__/swarm-publish.test.ts
+++ b/mcp-server/src/__tests__/swarm-publish.test.ts
@@ -1,0 +1,699 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SwarmPublishService,
+  assertLocalLessonPublishable,
+  assertChainTipBiconditional,
+  buildUnsignedSwarmLesson,
+  parsePublishOutcome,
+  isSequenceNumberRaceError,
+  DEFAULT_SPEC_VERSION,
+  MAX_SEQUENCE_RACE_RETRIES,
+  type LocalLessonRow,
+  type SwarmPublishDeps,
+  type PublishChainTip,
+} from "../services/swarm-publish.js";
+import {
+  swarmPublishTierAlesson,
+  swarmPublishTierAlessonSchema,
+} from "../tools/swarm-publish.js";
+import type { SignedRecord } from "../services/signature.js";
+
+// ---------------------------------------------------------------------------
+// swarm_publish_tier_a_lesson — issue #143 write-side slice
+//
+// What this exercises:
+//   1. assertLocalLessonPublishable — pre-sign validation traps every
+//      §3.1 / §5 / migration-071 invariant before a signing call wastes a
+//      clock tick or the orchestrator hits an opaque RPC raise.
+//   2. assertChainTipBiconditional — the publish path refuses to sign on
+//      a malformed chain tip (seq=0 iff prev=null), mirroring the
+//      lesson-chain.ts pin so a bad tip never produces signed bytes.
+//   3. buildUnsignedSwarmLesson — pure shape transformation, no clock,
+//      no randomness.
+//   4. parsePublishOutcome — the migration-087 RPC's JSONB body is
+//      strictly narrowed onto the discriminated union; shape drift fails
+//      loud rather than landing as `unknown` in the tool layer.
+//   5. SwarmPublishService.publishTierA — orchestrator behavior on the
+//      happy path, the already-published idempotency path, the
+//      sequence_number race retry loop (success on retry, exhaustion on
+//      persistent contention), and the validation/identity error paths.
+//   6. The MCP tool's ethics-gate refuses without
+//      OPENCLAW_ALLOW_SWARM_WRITE=1 (mirrors swarm_pin / swarm_resolve)
+//      and the Zod schema rejects malformed inputs.
+// ---------------------------------------------------------------------------
+
+const FAKE_LESSON_ID = "11111111-2222-3333-4444-555555555555";
+const FAKE_NODE_ID = "node-self-aaaa";
+
+function makeLocalRow(overrides: Partial<LocalLessonRow> = {}): LocalLessonRow {
+  return {
+    id: FAKE_LESSON_ID,
+    content: "When the chain tip races, retry with a fresh prev_hash.",
+    embedding: new Array(768).fill(0).map((_, i) => (i % 17) / 100),
+    evidence_count: 5,
+    created_at: "2026-05-01T12:00:00.000Z",
+    tags: ["swarm", "publish"],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (1) assertLocalLessonPublishable
+// ---------------------------------------------------------------------------
+
+test("assertLocalLessonPublishable accepts a well-formed row", () => {
+  assert.doesNotThrow(() => assertLocalLessonPublishable(makeLocalRow()));
+});
+
+test("assertLocalLessonPublishable rejects empty content (§5 rule 13 surface)", () => {
+  assert.throws(
+    () => assertLocalLessonPublishable(makeLocalRow({ content: "   " })),
+    /content is empty/i,
+  );
+});
+
+test("assertLocalLessonPublishable rejects evidence_count < 2 (§3.1 cluster floor)", () => {
+  assert.throws(
+    () => assertLocalLessonPublishable(makeLocalRow({ evidence_count: 1 })),
+    /evidence_count must be >= 2/,
+  );
+});
+
+test("assertLocalLessonPublishable rejects content exceeding 8192 octets (§5 rule 12)", () => {
+  // 9000 ASCII chars = 9000 octets, comfortably over the 8192 cap.
+  const huge = "x".repeat(9000);
+  assert.throws(
+    () => assertLocalLessonPublishable(makeLocalRow({ content: huge })),
+    /exceeds 8192 octets/,
+  );
+});
+
+test("assertLocalLessonPublishable enforces 8192 octets in OCTETS not characters", () => {
+  // 4-byte emoji * 2049 = 8196 octets > 8192. Char count is 2049 — well
+  // under any naive char limit. The validator MUST measure octets.
+  const emoji = "🌱"; // 4 bytes UTF-8
+  const content = emoji.repeat(2049);
+  assert.throws(
+    () => assertLocalLessonPublishable(makeLocalRow({ content })),
+    /exceeds 8192 octets/,
+  );
+});
+
+test("assertLocalLessonPublishable rejects wrong embedding dimension (pgvector(768))", () => {
+  assert.throws(
+    () => assertLocalLessonPublishable(makeLocalRow({ embedding: [0.1, 0.2] })),
+    /768-dim/,
+  );
+});
+
+test("assertLocalLessonPublishable rejects missing id", () => {
+  assert.throws(
+    () => assertLocalLessonPublishable(makeLocalRow({ id: "" })),
+    /missing id/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) assertChainTipBiconditional
+// ---------------------------------------------------------------------------
+
+test("assertChainTipBiconditional accepts the genesis case (seq=0, prev=null)", () => {
+  assert.doesNotThrow(() =>
+    assertChainTipBiconditional({ sequence_number: 0, prev_lesson_hash: null }),
+  );
+});
+
+test("assertChainTipBiconditional accepts the steady-state case (seq>0, prev=hash)", () => {
+  assert.doesNotThrow(() =>
+    assertChainTipBiconditional({
+      sequence_number: 7,
+      prev_lesson_hash: "z-prev-hash",
+    }),
+  );
+});
+
+test("assertChainTipBiconditional rejects (seq=0, prev=hash)", () => {
+  assert.throws(
+    () =>
+      assertChainTipBiconditional({
+        sequence_number: 0,
+        prev_lesson_hash: "z-stray",
+      }),
+    /biconditional violated/,
+  );
+});
+
+test("assertChainTipBiconditional rejects (seq>0, prev=null)", () => {
+  assert.throws(
+    () =>
+      assertChainTipBiconditional({
+        sequence_number: 1,
+        prev_lesson_hash: null,
+      }),
+    /biconditional violated/,
+  );
+});
+
+test("assertChainTipBiconditional rejects negative sequence_number (post-biconditional)", () => {
+  // Use prev_hash != null so the biconditional passes (seq=0 iff prev=null)
+  // and we reach the negative-sequence check.
+  assert.throws(
+    () =>
+      assertChainTipBiconditional({
+        sequence_number: -1,
+        prev_lesson_hash: "z-some-hash",
+      }),
+    /negative sequence_number/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) buildUnsignedSwarmLesson
+// ---------------------------------------------------------------------------
+
+test("buildUnsignedSwarmLesson maps row → UnsignedLesson with self origin", () => {
+  const out = buildUnsignedSwarmLesson(makeLocalRow(), FAKE_NODE_ID, "1.1");
+  assert.equal(out.id, FAKE_LESSON_ID);
+  assert.equal(out.origin_node_id, FAKE_NODE_ID);
+  assert.equal(out.synthesized_from_cluster_size, 5);
+  assert.equal(out.spec_version, "1.1");
+  assert.equal(out.created_at, "2026-05-01T12:00:00.000Z");
+  assert.deepEqual(out.tags, ["swarm", "publish"]);
+});
+
+test("buildUnsignedSwarmLesson defaults missing tags to []", () => {
+  const out = buildUnsignedSwarmLesson(
+    makeLocalRow({ tags: null }),
+    FAKE_NODE_ID,
+    "1.1",
+  );
+  assert.deepEqual(out.tags, []);
+});
+
+test("buildUnsignedSwarmLesson rejects empty selfNodeId — would produce an unsignable origin", () => {
+  assert.throws(
+    () => buildUnsignedSwarmLesson(makeLocalRow(), "", "1.1"),
+    /selfNodeId is required/,
+  );
+});
+
+test("buildUnsignedSwarmLesson is a pure transform (no clock, no randomness)", () => {
+  const a = buildUnsignedSwarmLesson(makeLocalRow(), FAKE_NODE_ID, "1.1");
+  const b = buildUnsignedSwarmLesson(makeLocalRow(), FAKE_NODE_ID, "1.1");
+  assert.deepEqual(a, b);
+});
+
+// ---------------------------------------------------------------------------
+// (4) parsePublishOutcome
+// ---------------------------------------------------------------------------
+
+test("parsePublishOutcome narrows the published JSONB body", () => {
+  const raw = {
+    ok: true,
+    status: "published",
+    lesson_id: FAKE_LESSON_ID,
+    origin_node_id: FAKE_NODE_ID,
+    lesson_tier: "A",
+    sequence_number: 3,
+    lesson_hash: "z-hash",
+    audit_reason: "tool-publish: smoke test",
+    signed_at: "2026-05-01T12:34:56.000Z",
+    received_at: "2026-05-01T12:34:56.123Z",
+  };
+  const out = parsePublishOutcome(raw);
+  assert.equal(out.status, "published");
+  if (out.status === "published") {
+    assert.equal(out.sequence_number, 3);
+    assert.equal(out.lesson_hash, "z-hash");
+    assert.equal(out.audit_reason, "tool-publish: smoke test");
+  }
+});
+
+test("parsePublishOutcome narrows the already_published JSONB body", () => {
+  const out = parsePublishOutcome({
+    ok: true,
+    status: "already_published",
+    lesson_id: FAKE_LESSON_ID,
+    lesson_tier: "A",
+    chain_present: true,
+  });
+  assert.equal(out.status, "already_published");
+  if (out.status === "already_published") {
+    assert.equal(out.chain_present, true);
+  }
+});
+
+test("parsePublishOutcome rejects ok=false bodies", () => {
+  assert.throws(
+    () => parsePublishOutcome({ ok: false, status: "published" }),
+    /ok flag missing or not true/,
+  );
+});
+
+test("parsePublishOutcome rejects unknown status (catches future RPC drift)", () => {
+  assert.throws(
+    () =>
+      parsePublishOutcome({
+        ok: true,
+        status: "promoted",
+        lesson_id: FAKE_LESSON_ID,
+      }),
+    /unexpected status/,
+  );
+});
+
+test("parsePublishOutcome rejects non-object input", () => {
+  assert.throws(() => parsePublishOutcome(null), /expected JSONB object/);
+  assert.throws(() => parsePublishOutcome([]), /expected JSONB object/);
+  assert.throws(() => parsePublishOutcome("string"), /expected JSONB object/);
+});
+
+test("parsePublishOutcome rejects missing fields on the published arm", () => {
+  assert.throws(
+    () =>
+      parsePublishOutcome({
+        ok: true,
+        status: "published",
+        lesson_id: FAKE_LESSON_ID,
+        // missing origin_node_id, sequence_number, etc.
+      }),
+    /missing or not a string/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (5) isSequenceNumberRaceError
+// ---------------------------------------------------------------------------
+
+test("isSequenceNumberRaceError matches the migration-087 raise prefix", () => {
+  const err = new Error(
+    "operator_publish_tier_a_lesson: lesson_chain_sequence_number_race (UNIQUE violation)",
+  );
+  assert.equal(isSequenceNumberRaceError(err), true);
+});
+
+test("isSequenceNumberRaceError ignores unrelated errors", () => {
+  assert.equal(
+    isSequenceNumberRaceError(new Error("RPC timeout")),
+    false,
+  );
+  assert.equal(
+    isSequenceNumberRaceError(
+      new Error("operator_publish_tier_a_lesson: swarm_lessons_id_race"),
+    ),
+    false,
+  );
+});
+
+test("isSequenceNumberRaceError handles non-Error throws", () => {
+  assert.equal(isSequenceNumberRaceError("lesson_chain_sequence_number_race"), true);
+  assert.equal(isSequenceNumberRaceError(42), false);
+});
+
+// ---------------------------------------------------------------------------
+// (6) SwarmPublishService.publishTierA — orchestrator
+// ---------------------------------------------------------------------------
+
+interface RecordedCalls {
+  loaded:    string[];
+  selfReads: number;
+  tipReads:  number;
+  rpcCalls:  Array<{ sequence: number; prev_hash: string | null; lesson_hash: string }>;
+  signs:     number;
+}
+
+interface MakeDepsOpts {
+  row?: LocalLessonRow | null;
+  self?: string | null;
+  tips?: PublishChainTip[];
+  rpcOutcomes?: Array<unknown | Error>;
+}
+
+function makeDeps(
+  opts: MakeDepsOpts = {},
+): { deps: SwarmPublishDeps; calls: RecordedCalls } {
+  const calls: RecordedCalls = {
+    loaded:    [],
+    selfReads: 0,
+    tipReads:  0,
+    rpcCalls:  [],
+    signs:     0,
+  };
+  const tips = opts.tips ?? [
+    { sequence_number: 0, prev_lesson_hash: null },
+  ];
+  const rpcOutcomes = opts.rpcOutcomes ?? [];
+  let tipIdx = 0;
+  let rpcIdx = 0;
+
+  const deps: SwarmPublishDeps = {
+    async loadLocalLesson(id) {
+      calls.loaded.push(id);
+      return opts.row === undefined ? makeLocalRow() : opts.row;
+    },
+    async loadSelfNodeId() {
+      calls.selfReads++;
+      return opts.self === undefined ? FAKE_NODE_ID : opts.self;
+    },
+    async readChainTip() {
+      calls.tipReads++;
+      const tip = tips[Math.min(tipIdx, tips.length - 1)];
+      tipIdx++;
+      return tip;
+    },
+    async callOperatorPublishTierA(args) {
+      calls.rpcCalls.push({
+        sequence:    args.sequence,
+        prev_hash:   args.prev_hash,
+        lesson_hash: args.lesson_hash,
+      });
+      const outcome = rpcOutcomes[Math.min(rpcIdx, rpcOutcomes.length - 1)];
+      rpcIdx++;
+      if (outcome instanceof Error) throw outcome;
+      return outcome;
+    },
+    signRecord: <T extends object>(record: T): SignedRecord<T> => {
+      calls.signs++;
+      const signed_at = "2026-05-01T12:34:56.000Z";
+      const payload = { ...record, signed_at } as T & { signed_at: string };
+      return {
+        record:    payload,
+        signature: `sig-${calls.signs}`,
+        signed_at,
+      };
+    },
+  };
+  return { deps, calls };
+}
+
+test("publishTierA — happy path: validates, signs once, calls RPC once, returns published", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const { deps, calls } = makeDeps({
+    rpcOutcomes: [
+      {
+        ok: true,
+        status: "published",
+        lesson_id: FAKE_LESSON_ID,
+        origin_node_id: FAKE_NODE_ID,
+        lesson_tier: "A",
+        sequence_number: 0,
+        lesson_hash: "z-fresh",
+        audit_reason: "tool-publish",
+        signed_at: "2026-05-01T12:34:56.000Z",
+        received_at: "2026-05-01T12:34:56.100Z",
+      },
+    ],
+  });
+  const out = await svc.publishTierA(FAKE_LESSON_ID, {}, deps);
+  assert.equal(out.status, "published");
+  assert.equal(calls.signs, 1, "should sign exactly once on a clean publish");
+  assert.equal(calls.rpcCalls.length, 1);
+  assert.equal(calls.rpcCalls[0].sequence, 0);
+  assert.equal(calls.rpcCalls[0].prev_hash, null);
+});
+
+test("publishTierA — already_published RPC body is propagated as the typed outcome", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const { deps, calls } = makeDeps({
+    rpcOutcomes: [
+      {
+        ok: true,
+        status: "already_published",
+        lesson_id: FAKE_LESSON_ID,
+        lesson_tier: "A",
+        chain_present: true,
+      },
+    ],
+  });
+  const out = await svc.publishTierA(FAKE_LESSON_ID, {}, deps);
+  assert.equal(out.status, "already_published");
+  if (out.status === "already_published") {
+    assert.equal(out.chain_present, true);
+  }
+  // Even on the no-op path the orchestrator MUST do a sign — the RPC
+  // contract requires the signature payload regardless. The DB short-
+  // circuits inside the txn; the TS layer can't tell ahead of time.
+  assert.equal(calls.signs, 1);
+});
+
+test("publishTierA — sequence_number race: retries with a fresh tip and succeeds", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const { deps, calls } = makeDeps({
+    tips: [
+      { sequence_number: 5, prev_lesson_hash: "z-old" },
+      { sequence_number: 6, prev_lesson_hash: "z-new" },
+    ],
+    rpcOutcomes: [
+      new Error(
+        "operator_publish_tier_a_lesson: lesson_chain_sequence_number_race (...)",
+      ),
+      {
+        ok: true,
+        status: "published",
+        lesson_id: FAKE_LESSON_ID,
+        origin_node_id: FAKE_NODE_ID,
+        lesson_tier: "A",
+        sequence_number: 6,
+        lesson_hash: "z-second",
+        audit_reason: "tool-publish",
+        signed_at: "2026-05-01T12:34:56.000Z",
+        received_at: "2026-05-01T12:34:57.000Z",
+      },
+    ],
+  });
+  const out = await svc.publishTierA(FAKE_LESSON_ID, {}, deps);
+  assert.equal(out.status, "published");
+  assert.equal(calls.tipReads, 2, "must re-read tip on race");
+  assert.equal(calls.signs, 2, "must re-sign on race because prev_hash changed");
+  assert.equal(calls.rpcCalls.length, 2);
+  assert.equal(calls.rpcCalls[0].sequence, 5);
+  assert.equal(calls.rpcCalls[1].sequence, 6);
+  assert.equal(calls.rpcCalls[1].prev_hash, "z-new");
+});
+
+test("publishTierA — exhausts the retry budget on persistent contention", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const raceErr = new Error(
+    "operator_publish_tier_a_lesson: lesson_chain_sequence_number_race",
+  );
+  const { deps, calls } = makeDeps({
+    tips: [{ sequence_number: 1, prev_lesson_hash: "z-prev" }],
+    rpcOutcomes: [raceErr, raceErr, raceErr, raceErr],
+  });
+  await assert.rejects(
+    svc.publishTierA(FAKE_LESSON_ID, {}, deps),
+    /exceeded \d+ sequence_number race retries/,
+  );
+  assert.equal(calls.rpcCalls.length, MAX_SEQUENCE_RACE_RETRIES);
+});
+
+test("publishTierA — non-race RPC errors propagate without retry", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const { deps, calls } = makeDeps({
+    rpcOutcomes: [
+      new Error(
+        "operator_publish_tier_a_lesson: origin foo does not match local self bar",
+      ),
+    ],
+  });
+  await assert.rejects(
+    svc.publishTierA(FAKE_LESSON_ID, {}, deps),
+    /does not match local self/,
+  );
+  assert.equal(calls.rpcCalls.length, 1);
+});
+
+test("publishTierA — rejects when local lesson row does not exist", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const { deps, calls } = makeDeps({ row: null });
+  await assert.rejects(
+    svc.publishTierA(FAKE_LESSON_ID, {}, deps),
+    /not found/,
+  );
+  assert.equal(calls.signs, 0);
+  assert.equal(calls.rpcCalls.length, 0);
+});
+
+test("publishTierA — rejects when node identity is not bootstrapped", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  const { deps, calls } = makeDeps({ self: null });
+  await assert.rejects(
+    svc.publishTierA(FAKE_LESSON_ID, {}, deps),
+    /not bootstrapped/,
+  );
+  assert.equal(calls.signs, 0);
+  assert.equal(calls.rpcCalls.length, 0);
+});
+
+test("publishTierA — applies caller's spec_version override", async () => {
+  // The override flows into the unsigned envelope — receivers see "2.0".
+  // We can't peek the envelope directly, but the RPC call captures the
+  // signature input chain. Instead pin via a deps-side spy that records
+  // the spec_version. Easiest: assert default vs override behavior by
+  // inspecting the RPC args via a custom dep.
+  const svc = new SwarmPublishService("http://stub", "stub");
+  let captured = "";
+  const baseDeps = makeDeps({
+    rpcOutcomes: [
+      {
+        ok: true,
+        status: "published",
+        lesson_id: FAKE_LESSON_ID,
+        origin_node_id: FAKE_NODE_ID,
+        lesson_tier: "A",
+        sequence_number: 0,
+        lesson_hash: "z",
+        audit_reason: "tool-publish",
+        signed_at: "2026-05-01T12:34:56.000Z",
+        received_at: "2026-05-01T12:34:56.000Z",
+      },
+    ],
+  }).deps;
+  const deps: SwarmPublishDeps = {
+    ...baseDeps,
+    async callOperatorPublishTierA(args) {
+      captured = args.spec_version;
+      return baseDeps.callOperatorPublishTierA(args);
+    },
+  };
+  await svc.publishTierA(FAKE_LESSON_ID, { spec_version: "9.9" }, deps);
+  assert.equal(captured, "9.9");
+});
+
+test("publishTierA — defaults spec_version to DEFAULT_SPEC_VERSION when caller omits", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  let captured = "";
+  const baseDeps = makeDeps({
+    rpcOutcomes: [
+      {
+        ok: true,
+        status: "published",
+        lesson_id: FAKE_LESSON_ID,
+        origin_node_id: FAKE_NODE_ID,
+        lesson_tier: "A",
+        sequence_number: 0,
+        lesson_hash: "z",
+        audit_reason: "tool-publish",
+        signed_at: "2026-05-01T12:34:56.000Z",
+        received_at: "2026-05-01T12:34:56.000Z",
+      },
+    ],
+  }).deps;
+  const deps: SwarmPublishDeps = {
+    ...baseDeps,
+    async callOperatorPublishTierA(args) {
+      captured = args.spec_version;
+      return baseDeps.callOperatorPublishTierA(args);
+    },
+  };
+  await svc.publishTierA(FAKE_LESSON_ID, {}, deps);
+  assert.equal(captured, DEFAULT_SPEC_VERSION);
+});
+
+test("publishTierA — threads caller note into RPC audit_note arg", async () => {
+  const svc = new SwarmPublishService("http://stub", "stub");
+  let capturedNote: string | null = "<unset>";
+  const baseDeps = makeDeps({
+    rpcOutcomes: [
+      {
+        ok: true,
+        status: "published",
+        lesson_id: FAKE_LESSON_ID,
+        origin_node_id: FAKE_NODE_ID,
+        lesson_tier: "A",
+        sequence_number: 0,
+        lesson_hash: "z",
+        audit_reason: "tool-publish: matched against local logbook",
+        signed_at: "2026-05-01T12:34:56.000Z",
+        received_at: "2026-05-01T12:34:56.000Z",
+      },
+    ],
+  }).deps;
+  const deps: SwarmPublishDeps = {
+    ...baseDeps,
+    async callOperatorPublishTierA(args) {
+      capturedNote = args.audit_note;
+      return baseDeps.callOperatorPublishTierA(args);
+    },
+  };
+  await svc.publishTierA(
+    FAKE_LESSON_ID,
+    { note: "matched against local logbook" },
+    deps,
+  );
+  assert.equal(capturedNote, "matched against local logbook");
+});
+
+// ---------------------------------------------------------------------------
+// (7) MCP tool: ethics-gate + Zod schema
+// ---------------------------------------------------------------------------
+
+test("swarmPublishTierAlesson refuses when OPENCLAW_ALLOW_SWARM_WRITE is unset", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  try {
+    const stubPub = {} as unknown as SwarmPublishService;
+    const stubMem = {} as unknown as Parameters<
+      typeof swarmPublishTierAlesson
+    >[1];
+    const out = await swarmPublishTierAlesson(stubPub, stubMem, {
+      lesson_id: FAKE_LESSON_ID,
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+    assert.ok(out.fix_hint, "structured error must carry a fix_hint");
+  } finally {
+    if (original !== undefined)
+      process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmPublishTierAlesson refuses with non-'1' env values (only '1' opens the gate)", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "true"; // truthy but not '1'
+  try {
+    const stubPub = {} as unknown as SwarmPublishService;
+    const stubMem = {} as unknown as Parameters<
+      typeof swarmPublishTierAlesson
+    >[1];
+    const out = await swarmPublishTierAlesson(stubPub, stubMem, {
+      lesson_id: FAKE_LESSON_ID,
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+  } finally {
+    if (original === undefined)
+      delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmPublishTierAlessonSchema rejects malformed UUIDs", () => {
+  const bad = swarmPublishTierAlessonSchema.safeParse({
+    lesson_id: "not-a-uuid",
+  });
+  assert.equal(bad.success, false);
+
+  const ok = swarmPublishTierAlessonSchema.safeParse({
+    lesson_id: FAKE_LESSON_ID,
+  });
+  assert.equal(ok.success, true);
+});
+
+test("swarmPublishTierAlessonSchema accepts optional spec_version + note within bounds", () => {
+  const ok = swarmPublishTierAlessonSchema.safeParse({
+    lesson_id: FAKE_LESSON_ID,
+    spec_version: "1.1",
+    note: "smoke test",
+  });
+  assert.equal(ok.success, true);
+});
+
+test("swarmPublishTierAlessonSchema rejects oversize note (>480 chars)", () => {
+  const bad = swarmPublishTierAlessonSchema.safeParse({
+    lesson_id: FAKE_LESSON_ID,
+    note: "x".repeat(500),
+  });
+  assert.equal(bad.success, false);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -170,6 +170,10 @@ import { SwarmAdmitService } from "./services/swarm-admit.js";
 import {
   swarmAdmitLessonSchema, swarmAdmitLessonHandler,
 } from "./tools/swarm-admit.js";
+import { SwarmPublishService } from "./services/swarm-publish.js";
+import {
+  swarmPublishTierAlessonSchema, swarmPublishTierAlessonHandler,
+} from "./tools/swarm-publish.js";
 import {
   getSelfModelSchema, getSelfModel,
   updateSelfModelSchema, updateSelfModel,
@@ -242,6 +246,7 @@ const nodeIdentityService   = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY
 const swarmPinService       = new SwarmPinService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPeersService     = new SwarmPeersService(SUPABASE_URL, SUPABASE_KEY);
 const swarmAdmitService     = new SwarmAdmitService(SUPABASE_URL, SUPABASE_KEY);
+const swarmPublishService   = new SwarmPublishService(SUPABASE_URL, SUPABASE_KEY);
 const remAuditService       = new RemAuditService(SUPABASE_URL, SUPABASE_KEY);
 const remPromotionService   = new RemPromotionService(SUPABASE_URL, SUPABASE_KEY);
 const remDiversityService   = new RemDiversityService(SUPABASE_URL, SUPABASE_KEY);
@@ -931,6 +936,28 @@ server.tool(
   swarmAdmitLessonSchema.shape,
   withErrorHandling((input) =>
     swarmAdmitLessonHandler(swarmAdmitService, memoryService, swarmAdmitLessonSchema.parse(input)),
+  ),
+);
+
+// --- swarm phase 4 write-side: publish a local lesson at Tier-A (issue #143)
+// Producer-side counterpart to swarm_pin_lesson — instead of overriding an
+// already-stored row's tier, this tool takes a LOCAL `lessons` row, signs it
+// with the node's self-key (Ed25519, key file outside the DB per pillar 1),
+// computes the §3.7.2 chain hash, appends a `lesson_chain` entry, inserts
+// into `swarm_lessons`, and audits the B→A promotion in
+// `tier_promotion_log` — all in one atomic txn (migration 087). Behind the
+// OPENCLAW_ALLOW_SWARM_WRITE=1 ethics-gate (publishing onto the wire is the
+// most consequential surface in this tool family).
+server.tool(
+  "swarm_publish_tier_a_lesson",
+  "Force a local lesson onto the swarm at Tier-A (broadcast-eligible). Signs the lesson with the node's self-key, appends a lesson_chain entry, inserts into swarm_lessons, and audits the B→A promotion atomically (one txn). Idempotent against already-published lessons. REQUIRES OPENCLAW_ALLOW_SWARM_WRITE=1 — refuses with a structured error otherwise. Also writes a 'decisions'-category memory tagged 'swarm' on success (best-effort).",
+  swarmPublishTierAlessonSchema.shape,
+  withErrorHandling((input) =>
+    swarmPublishTierAlessonHandler(
+      swarmPublishService,
+      memoryService,
+      swarmPublishTierAlessonSchema.parse(input),
+    ),
   ),
 );
 

--- a/mcp-server/src/services/swarm-publish.ts
+++ b/mcp-server/src/services/swarm-publish.ts
@@ -1,0 +1,603 @@
+/**
+ * Swarm publish-tier-A service — Phase 4 / issue #143 write-side slice.
+ *
+ * Forces a locally-generated lesson into the broadcast-eligible Tier-A
+ * state: signs it with the node's self-key, computes the §3.7.2 chain
+ * hash, and dispatches to the migration-087 RPC
+ * `operator_publish_tier_a_lesson(...)` for the atomic lesson_chain +
+ * swarm_lessons + tier_promotion_log + UPDATE-to-A apply.
+ *
+ * Why the TS layer has to participate at all (vs a pure SQL RPC):
+ *
+ *   - The Ed25519 private key MUST stay in the chmod-0600 file outside the
+ *     database (Verfassung pillar 1: sovereignty). Postgres has no way to
+ *     read it. So signing happens in TS via signWithSelfKey, and the
+ *     resulting signature + signed_at + lesson_hash are passed into the
+ *     RPC for atomic apply.
+ *
+ *   - The chain hash (lesson_hash) commits to the full signed bytes
+ *     including the signature itself (SWARM_SPEC §3.7.2). It can only be
+ *     computed AFTER signing, so the TS layer owns this hash too.
+ *
+ *   - The chain tip read (`compute_next_prev_lesson_hash` +
+ *     `compute_next_sequence_number`) happens in TS so it can be folded
+ *     into the same retry loop as the signing — a sequence_number race
+ *     forces a re-sign because the new tip has a different prev_hash.
+ *
+ * Concurrency contract — sequence_number race:
+ *
+ *   Two parallel publishers can read the same chain tip and race to
+ *   insert the same sequence_number. Migration 074's UNIQUE constraint
+ *   catches the loser; the migration-087 RPC re-raises as
+ *   `lesson_chain_sequence_number_race`. We retry the WHOLE pipeline
+ *   (re-read tip, re-build, re-sign, re-call RPC) up to
+ *   MAX_SEQUENCE_RACE_RETRIES times. Same retry budget as
+ *   signLessonAndAppendToChain — three is generous; a third concurrent
+ *   publisher on a single mycelium indicates misconfiguration.
+ *
+ * Idempotency contract:
+ *
+ *   - Already-Tier-A swarm_lessons row → RPC returns
+ *     status='already_published'; the service returns the same.
+ *   - Already-Tier-B swarm_lessons row for this id → RPC raises (a
+ *     self-published lesson at B with this RPC's contract is an
+ *     inconsistent state). Service surfaces as a hard error with a
+ *     fix_hint pointing the operator at swarm_pin_lesson.
+ *
+ * Spec invariants enforced before signing (so a bad caller gets a clean
+ * error rather than an opaque RPC raise):
+ *
+ *   - synth_size >= 2 (§3.1 / migration 071 column CHECK)
+ *   - content octet-length <= 8192 (§5 rule 12 / migration 071 CHECK)
+ *   - embedding length 768 (NodeJS doesn't enforce vector dimension; the
+ *     RPC's pgvector cast would fail late, so we cut it short here)
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  computeLessonHash,
+  type UnsignedLesson,
+  type SignedLesson,
+} from "./lesson-chain.js";
+import {
+  signWithSelfKey,
+  type SignedRecord,
+} from "./signature.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * The local lesson row this service publishes. A subset of the columns on
+ * `lessons` (migration 015) — only the fields the swarm Lesson envelope
+ * needs. The service loader produces this; tests construct it directly.
+ */
+export interface LocalLessonRow {
+  id: string;
+  content: string;
+  embedding: number[];
+  evidence_count: number;
+  created_at: string;
+  tags?: string[] | null;
+}
+
+/**
+ * The chain tip read from `compute_next_prev_lesson_hash` +
+ * `compute_next_sequence_number` (migration 074). Same shape as
+ * `ChainTip` in lesson-chain.ts; duplicated here so the publish service's
+ * dep bag stays self-contained without re-exporting an internal.
+ */
+export interface PublishChainTip {
+  prev_lesson_hash: string | null;
+  sequence_number: number;
+}
+
+/**
+ * Discriminated outcome returned to the MCP tool layer. The two arms map
+ * one-to-one onto the migration-087 RPC's `status` field so the tool can
+ * branch on `outcome.status` without re-parsing.
+ */
+export type PublishTierAOutcome =
+  | {
+      status: "published";
+      lesson_id: string;
+      origin_node_id: string;
+      lesson_tier: "A";
+      sequence_number: number;
+      lesson_hash: string;
+      audit_reason: string;
+      signed_at: string;
+      received_at: string;
+    }
+  | {
+      status: "already_published";
+      lesson_id: string;
+      lesson_tier: "A";
+      chain_present: boolean;
+    };
+
+/** Per-call options. `note` is appended to the audit reason. */
+export interface PublishTierAOptions {
+  /** Spec version stamped on the wire. Defaults to "1.1". */
+  spec_version?: string;
+  /** Human-readable note, appended to `tool-publish:` in tier_promotion_log. */
+  note?: string;
+}
+
+/**
+ * Side-effect bag — every DB write goes through one of these so the
+ * orchestrator is testable without a live Supabase. Mirror of
+ * `LessonChainDeps` from lesson-chain.ts.
+ */
+export interface SwarmPublishDeps {
+  /**
+   * Load the local lesson row for `lessonId`. Returns null when the row
+   * does not exist (caller maps to a "lesson not found" error). The
+   * service does NOT touch any other column from `lessons` — keep the
+   * shape narrow so a future column rename is a one-line change here.
+   */
+  loadLocalLesson(lessonId: string): Promise<LocalLessonRow | null>;
+  /**
+   * Resolve `node_id` from `nodes WHERE is_self = TRUE`. Returns null
+   * when the node identity has not been bootstrapped (no `is_self` row).
+   * The migration-085 trigger would also raise on this case; checking
+   * up front gives a cleaner error.
+   */
+  loadSelfNodeId(): Promise<string | null>;
+  /**
+   * Read the chain tip — `compute_next_prev_lesson_hash` +
+   * `compute_next_sequence_number` (migration 074). The service refuses
+   * to sign if the biconditional `seq=0 iff prev=null` is violated.
+   */
+  readChainTip(): Promise<PublishChainTip>;
+  /**
+   * Invoke the migration-087 `operator_publish_tier_a_lesson(...)` RPC
+   * and return the parsed JSONB body. Throws on RPC failure with the
+   * original postgrest message preserved so the orchestrator can
+   * pattern-match for the `lesson_chain_sequence_number_race` retry case.
+   */
+  callOperatorPublishTierA(args: {
+    lesson_id: string;
+    content: string;
+    embedding: number[];
+    synth_size: number;
+    origin: string;
+    signed_at: string;
+    created_at: string;
+    signature: string;
+    tags: string[];
+    spec_version: string;
+    lesson_hash: string;
+    prev_hash: string | null;
+    sequence: number;
+    audit_note: string | null;
+  }): Promise<unknown>;
+  /**
+   * Sign a record with the node's persistent self-key. Defaults to
+   * `signWithSelfKey` (reads `MYCELIUM_NODE_KEY` or
+   * `~/.mycelium/node.key`). Tests inject a deterministic signer.
+   */
+  signRecord?: <T extends object>(record: T) => SignedRecord<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported so the unit tests can pin them independently.
+// ---------------------------------------------------------------------------
+
+/**
+ * Default spec version stamped on the wire when the caller does not
+ * specify. v1.1 is the current Proof-of-Knowledge spec; v1.0 callers
+ * still deserialize correctly per §6.1 minor-bump compat. Bumped here
+ * (vs 1.0) because the producer pipeline emits the v1.1 evidence_*
+ * fields as soon as they are populated; lessons published via this tool
+ * may not have them but the spec_version itself is forward-compatible.
+ */
+export const DEFAULT_SPEC_VERSION = "1.1";
+
+/** Bounded retry budget on a parallel `sequence_number` race. */
+export const MAX_SEQUENCE_RACE_RETRIES = 3;
+
+/**
+ * Validate a local lesson row against the wire-spec invariants this
+ * service is responsible for catching pre-sign. Throws with a precise
+ * error message — the MCP tool wraps the message into a structured
+ * `{error, fix_hint}` payload.
+ *
+ * - synth_size >= 2 — §3.1 / migration 071 column CHECK
+ * - content octet length <= 8192 — §5 rule 12 / migration 071 CHECK
+ * - embedding length === 768 — pgvector(768) (migration 002 et al.)
+ * - content non-empty — defensive: an empty lesson would pass octet
+ *   bounds but is meaningless on the wire and §5 rule 13 (content non-
+ *   empty) would reject it on the receiver side.
+ */
+export function assertLocalLessonPublishable(row: LocalLessonRow): void {
+  if (!row.id || typeof row.id !== "string") {
+    throw new Error("publish: local lesson row missing id");
+  }
+  if (typeof row.content !== "string" || row.content.trim().length === 0) {
+    throw new Error("publish: local lesson content is empty");
+  }
+  // Buffer.byteLength gives the UTF-8 octet length — same metric the
+  // migration-071 CHECK uses (octet_length(content)).
+  const octets = Buffer.byteLength(row.content, "utf8");
+  if (octets > 8192) {
+    throw new Error(
+      `publish: local lesson content exceeds 8192 octets (got ${octets})`,
+    );
+  }
+  if (typeof row.evidence_count !== "number" || row.evidence_count < 2) {
+    throw new Error(
+      `publish: local lesson evidence_count must be >= 2 (got ${row.evidence_count}). The §3.1 cluster floor refuses single-experience lessons on the wire.`,
+    );
+  }
+  if (!Array.isArray(row.embedding) || row.embedding.length !== 768) {
+    throw new Error(
+      `publish: local lesson embedding must be a 768-dim vector (got ${
+        Array.isArray(row.embedding) ? `length ${row.embedding.length}` : typeof row.embedding
+      })`,
+    );
+  }
+}
+
+/**
+ * Build the `UnsignedLesson` payload for the producer signing step from a
+ * loaded local lesson row + the resolved self node_id. Pure — no
+ * randomness, no clock reads. The tip's `prev_lesson_hash` is attached
+ * later by `signLessonAndAppendToChain` (or, in this service, by the
+ * orchestrator just before calling the signer); the unsigned payload
+ * here intentionally omits it for the same reason
+ * `signLessonAndAppendToChain` does (the chain hook owns prev_hash).
+ *
+ * The `created_at` field on the wire MUST be the local lesson's
+ * created_at — receivers reason about freshness via (now - created_at)
+ * and rebroadcasting a stale lesson with a fresh created_at would let
+ * a node's audit-window count a re-publish as a fresh observation.
+ */
+export function buildUnsignedSwarmLesson(
+  row: LocalLessonRow,
+  selfNodeId: string,
+  spec_version: string,
+): UnsignedLesson {
+  if (!selfNodeId) {
+    throw new Error("publish: selfNodeId is required");
+  }
+  const tags = Array.isArray(row.tags) ? [...row.tags] : [];
+  return {
+    id: row.id,
+    content: row.content,
+    embedding: row.embedding,
+    synthesized_from_cluster_size: row.evidence_count,
+    origin_node_id: selfNodeId,
+    created_at: row.created_at,
+    spec_version,
+    tags,
+  };
+}
+
+/**
+ * Validate the chain tip's first-lesson biconditional (seq=0 iff
+ * prev=null) — same pin as `assertChainTipBiconditional` in
+ * lesson-chain.ts. Duplicated here on purpose so the publish path raises
+ * BEFORE signing (the signature commits to prev_hash; a lying tip would
+ * waste a sign call).
+ */
+export function assertChainTipBiconditional(tip: PublishChainTip): void {
+  const isFirst = tip.sequence_number === 0;
+  const hasNullPrev = tip.prev_lesson_hash === null;
+  if (isFirst !== hasNullPrev) {
+    throw new Error(
+      `publish: chain tip biconditional violated (seq=${tip.sequence_number}, prev_hash=${
+        tip.prev_lesson_hash === null ? "null" : "present"
+      }) — must be seq=0 iff prev=null`,
+    );
+  }
+  if (tip.sequence_number < 0) {
+    throw new Error(
+      `publish: chain tip returned negative sequence_number (${tip.sequence_number})`,
+    );
+  }
+}
+
+/**
+ * Map the JSONB body of `operator_publish_tier_a_lesson` onto the typed
+ * `PublishTierAOutcome` union. Postgres' jsonb_build_object preserves
+ * key names but not types — every value lands on `unknown` and we narrow
+ * here. Throws on shape drift so a future migration edit fails loud
+ * (same discipline as `parseResolveOutcome` in
+ * swarm-resolve-contradict.ts).
+ */
+export function parsePublishOutcome(raw: unknown): PublishTierAOutcome {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(
+      `operator_publish_tier_a_lesson: expected JSONB object, got ${
+        Array.isArray(raw) ? "array" : typeof raw
+      }`,
+    );
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.ok !== true) {
+    throw new Error(
+      `operator_publish_tier_a_lesson: ok flag missing or not true: ${JSON.stringify(r)}`,
+    );
+  }
+  const status = r.status;
+  if (status === "already_published") {
+    return {
+      status: "already_published",
+      lesson_id: requireString(r, "lesson_id"),
+      lesson_tier: "A",
+      chain_present: Boolean(r.chain_present),
+    };
+  }
+  if (status === "published") {
+    return {
+      status: "published",
+      lesson_id:       requireString(r, "lesson_id"),
+      origin_node_id:  requireString(r, "origin_node_id"),
+      lesson_tier:     "A",
+      sequence_number: requireNumber(r, "sequence_number"),
+      lesson_hash:     requireString(r, "lesson_hash"),
+      audit_reason:    requireString(r, "audit_reason"),
+      signed_at:       requireString(r, "signed_at"),
+      received_at:     requireString(r, "received_at"),
+    };
+  }
+  throw new Error(
+    `operator_publish_tier_a_lesson: unexpected status ${JSON.stringify(status)}`,
+  );
+}
+
+function requireString(r: Record<string, unknown>, key: string): string {
+  const v = r[key];
+  if (typeof v !== "string") {
+    throw new Error(
+      `operator_publish_tier_a_lesson: ${key} missing or not a string`,
+    );
+  }
+  return v;
+}
+
+function requireNumber(r: Record<string, unknown>, key: string): number {
+  const v = r[key];
+  if (typeof v !== "number" || !Number.isFinite(v)) {
+    throw new Error(
+      `operator_publish_tier_a_lesson: ${key} missing or not a finite number`,
+    );
+  }
+  return v;
+}
+
+/**
+ * Detect the migration-087 sequence_number race signal so the
+ * orchestrator can retry. The RPC re-raises with a stable diagnostic
+ * prefix; we match on substring for resilience to minor wording
+ * changes (and to the fact that postgrest may wrap or truncate the
+ * message text on its way through the client).
+ */
+export function isSequenceNumberRaceError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("lesson_chain_sequence_number_race");
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export class SwarmPublishService {
+  private db: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.db = createClient(supabaseUrl, supabaseKey);
+  }
+
+  /**
+   * Publish a local lesson at Tier-A. Returns the parsed outcome union;
+   * throws on:
+   *   - lesson not found
+   *   - validation failure (synth_size, content size, embedding shape)
+   *   - node identity not bootstrapped
+   *   - chain tip biconditional violation
+   *   - RPC error (preserved verbatim for the tool layer's fix_hint mapping)
+   *   - exceeded MAX_SEQUENCE_RACE_RETRIES on a parallel publisher race
+   */
+  async publishTierA(
+    lessonId: string,
+    options: PublishTierAOptions,
+    deps: SwarmPublishDeps,
+  ): Promise<PublishTierAOutcome> {
+    const local = await deps.loadLocalLesson(lessonId);
+    if (local === null) {
+      throw new Error(`publish: local lesson ${lessonId} not found`);
+    }
+    assertLocalLessonPublishable(local);
+
+    const self = await deps.loadSelfNodeId();
+    if (!self) {
+      throw new Error(
+        "publish: node identity not bootstrapped — run scripts/init-node-identity.mjs first",
+      );
+    }
+
+    const spec_version = options.spec_version ?? DEFAULT_SPEC_VERSION;
+    const auditNote = options.note ?? null;
+    const signer = deps.signRecord ?? signWithSelfKey;
+
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < MAX_SEQUENCE_RACE_RETRIES; attempt++) {
+      const tip = await deps.readChainTip();
+      assertChainTipBiconditional(tip);
+
+      const unsigned = buildUnsignedSwarmLesson(local, self, spec_version);
+      const withPrev = {
+        ...unsigned,
+        prev_lesson_hash: tip.prev_lesson_hash,
+      };
+      const signed = signer(withPrev);
+      const fullySigned = {
+        ...signed.record,
+        signature: signed.signature,
+      } as SignedLesson;
+      const lesson_hash = computeLessonHash(fullySigned);
+
+      try {
+        const raw = await deps.callOperatorPublishTierA({
+          lesson_id:    local.id,
+          content:      local.content,
+          embedding:    local.embedding,
+          synth_size:   local.evidence_count,
+          origin:       self,
+          signed_at:    signed.signed_at,
+          created_at:   local.created_at,
+          signature:    signed.signature,
+          tags:         unsigned.tags ?? [],
+          spec_version,
+          lesson_hash,
+          prev_hash:    tip.prev_lesson_hash,
+          sequence:     tip.sequence_number,
+          audit_note:   auditNote,
+        });
+        return parsePublishOutcome(raw);
+      } catch (err) {
+        if (isSequenceNumberRaceError(err)) {
+          lastErr = err;
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw new Error(
+      `publish: exceeded ${MAX_SEQUENCE_RACE_RETRIES} sequence_number race retries; last error: ${
+        lastErr instanceof Error ? lastErr.message : String(lastErr)
+      }`,
+    );
+  }
+
+  /**
+   * Default deps wired against the service's own SupabaseClient. The MCP
+   * tool uses this when running in-process; tests inject mocks.
+   */
+  defaultDeps(): SwarmPublishDeps {
+    const db = this.db;
+    return {
+      async loadLocalLesson(lessonId) {
+        const { data, error } = await db
+          .from("lessons")
+          .select("id, lesson, embedding, evidence_count, created_at")
+          .eq("id", lessonId)
+          .maybeSingle();
+        if (error) {
+          throw new Error(
+            `publish loadLocalLesson failed: ${error.message ?? String(error)}`,
+          );
+        }
+        if (!data) return null;
+        const row = data as {
+          id: string;
+          lesson: string;
+          embedding: number[] | string | null;
+          evidence_count: number;
+          created_at: string;
+        };
+        // pgvector returns the embedding as a pg-formatted string ('[…]')
+        // by default. Parse it so the orchestrator sees a number[].
+        let embedding: number[];
+        if (Array.isArray(row.embedding)) {
+          embedding = row.embedding;
+        } else if (typeof row.embedding === "string") {
+          embedding = parseVectorString(row.embedding);
+        } else {
+          throw new Error(
+            `publish loadLocalLesson: lesson ${lessonId} has no embedding`,
+          );
+        }
+        return {
+          id:             row.id,
+          content:        row.lesson,
+          embedding,
+          evidence_count: row.evidence_count,
+          created_at:     row.created_at,
+        };
+      },
+      async loadSelfNodeId() {
+        const { data, error } = await db
+          .from("nodes")
+          .select("node_id")
+          .eq("is_self", true)
+          .maybeSingle();
+        if (error) {
+          throw new Error(
+            `publish loadSelfNodeId failed: ${error.message ?? String(error)}`,
+          );
+        }
+        if (!data) return null;
+        return (data as { node_id: string }).node_id;
+      },
+      async readChainTip() {
+        const [{ data: prev, error: prevErr }, { data: seq, error: seqErr }] =
+          await Promise.all([
+            db.rpc("compute_next_prev_lesson_hash"),
+            db.rpc("compute_next_sequence_number"),
+          ]);
+        if (prevErr) {
+          throw new Error(
+            `publish compute_next_prev_lesson_hash failed: ${prevErr.message}`,
+          );
+        }
+        if (seqErr) {
+          throw new Error(
+            `publish compute_next_sequence_number failed: ${seqErr.message}`,
+          );
+        }
+        return {
+          prev_lesson_hash: (prev as string | null) ?? null,
+          sequence_number:  typeof seq === "number" ? seq : Number(seq ?? 0),
+        };
+      },
+      async callOperatorPublishTierA(args) {
+        const { data, error } = await db.rpc("operator_publish_tier_a_lesson", {
+          p_lesson_id:    args.lesson_id,
+          p_content:      args.content,
+          p_embedding:    args.embedding,
+          p_synth_size:   args.synth_size,
+          p_origin:       args.origin,
+          p_signed_at:    args.signed_at,
+          p_created_at:   args.created_at,
+          p_signature:    args.signature,
+          p_tags:         args.tags,
+          p_spec_version: args.spec_version,
+          p_lesson_hash:  args.lesson_hash,
+          p_prev_hash:    args.prev_hash,
+          p_sequence:     args.sequence,
+          p_audit_note:   args.audit_note,
+        });
+        if (error) {
+          throw new Error(error.message ?? String(error));
+        }
+        return data;
+      },
+    };
+  }
+}
+
+/**
+ * Parse a pgvector string (`"[1, 2, 3]"`) into a number[]. Defensive
+ * against trailing whitespace and the rare `null` embedding (rejected
+ * by the loader before reaching here).
+ */
+function parseVectorString(s: string): number[] {
+  const trimmed = s.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
+    throw new Error(`publish: malformed vector string: ${trimmed.slice(0, 32)}…`);
+  }
+  const inner = trimmed.slice(1, -1).trim();
+  if (inner.length === 0) return [];
+  return inner.split(",").map((part) => {
+    const n = Number(part.trim());
+    if (!Number.isFinite(n)) {
+      throw new Error(`publish: malformed vector entry: ${part}`);
+    }
+    return n;
+  });
+}

--- a/mcp-server/src/tools/swarm-publish.ts
+++ b/mcp-server/src/tools/swarm-publish.ts
@@ -1,0 +1,253 @@
+/**
+ * `swarm_publish_tier_a_lesson` MCP tool — issue #143 write-side slice.
+ *
+ * Forces a locally-generated lesson into the broadcast-eligible Tier-A
+ * state by signing it with the node's self-key, computing the §3.7.2
+ * chain hash, and dispatching to the migration-087 RPC for the atomic
+ * apply (lesson_chain INSERT + swarm_lessons INSERT + tier_promotion_log
+ * audit row + UPDATE-to-A in one txn).
+ *
+ * Behind `OPENCLAW_ALLOW_SWARM_WRITE=1` (mirrors `swarm_pin_lesson` and
+ * `swarm_resolve_contradict`): the tool writes to the §10.6 trust
+ * substrate AND emits a signed envelope onto the wire — both are
+ * surfaces that need explicit operator opt-in (Verfassung pillar 6:
+ * cyber security; pillar 1: sovereignty).
+ *
+ * Memory-bus side-effect on success: the agent writes a
+ * `decisions`-category memory tagged `swarm` so its own publish actions
+ * become recallable. Best-effort — the durable record is the
+ * tier_promotion_log row plus the lesson_chain entry.
+ */
+
+import { z } from "zod";
+import { MemoryService } from "../services/supabase.js";
+import {
+  SwarmPublishService,
+  type PublishTierAOutcome,
+} from "../services/swarm-publish.js";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const swarmPublishTierAlessonSchema = z.object({
+  lesson_id: z
+    .string()
+    .regex(UUID_REGEX, "lesson_id must be a UUID")
+    .describe("UUID of the LOCAL `lessons` row to publish."),
+  spec_version: z
+    .string()
+    .max(16)
+    .optional()
+    .describe(
+      "Optional spec version stamped on the wire. Defaults to '1.1' (the current Proof-of-Knowledge envelope).",
+    ),
+  note: z
+    .string()
+    .max(480)
+    .optional()
+    .describe(
+      "Optional human-readable note appended to the audit reason after the 'tool-publish:' prefix. Capped at 480 chars to fit the migration-078 reason CHECK (octet_length <= 512).",
+    ),
+});
+
+export type SwarmPublishTierAlessonInput = z.infer<
+  typeof swarmPublishTierAlessonSchema
+>;
+
+export interface SwarmPublishTierAlessonOutput {
+  ok: boolean;
+  status?: PublishTierAOutcome["status"];
+  lesson_id?: string;
+  origin_node_id?: string;
+  lesson_tier?: "A";
+  sequence_number?: number;
+  lesson_hash?: string;
+  audit_reason?: string;
+  signed_at?: string;
+  received_at?: string;
+  chain_present?: boolean;
+  memory_recorded?: boolean;
+  memory_error?: string;
+  error?: string;
+  fix_hint?: string;
+}
+
+export interface McpToolResult {
+  content: { type: "text"; text: string }[];
+}
+
+function asMcpResult(payload: SwarmPublishTierAlessonOutput): McpToolResult {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+/**
+ * Ethics-gate check. Mirrors the `OPENCLAW_ALLOW_BREEDING` /
+ * `OPENCLAW_ALLOW_SWARM_WRITE` pattern. Publishing onto the swarm IS
+ * the most consequential surface this tool family exposes (the lesson
+ * leaves the local node for any peer that polls /swarm/lessons), so a
+ * conservative explicit-opt-in default is the right policy.
+ */
+function isSwarmWriteAllowed(): boolean {
+  return process.env.OPENCLAW_ALLOW_SWARM_WRITE === "1";
+}
+
+/**
+ * Map an RPC / service error message onto a hint the operator can act
+ * on. The keyword set covers the named raise prefixes from migration
+ * 087 plus the validation messages from `assertLocalLessonPublishable`.
+ */
+function fixHintFromError(message: string): string {
+  if (message.includes("local lesson") && message.includes("not found")) {
+    return "Verify the lesson_id exists in the local `lessons` table. The publish tool takes a LOCAL lesson id, not a swarm_lessons id.";
+  }
+  if (message.includes("evidence_count must be >= 2")) {
+    return "The §3.1 cluster floor refuses single-experience lessons on the wire. Wait until the lesson accumulates more evidence (or merge it via dedup_lessons).";
+  }
+  if (message.includes("content exceeds")) {
+    return "Trim the local lesson content (octet_length <= 8192). The §5 rule 12 cap is firm.";
+  }
+  if (message.includes("embedding must be a 768-dim")) {
+    return "The local lesson has no embedding or the embedding is the wrong dimension. Re-embed the lesson via the embedding pipeline first.";
+  }
+  if (message.includes("identity not bootstrapped") || message.includes("no is_self row")) {
+    return "Run `node scripts/init-node-identity.mjs` to generate the keypair and insert the self row in `nodes` before publishing.";
+  }
+  if (message.includes("origin") && message.includes("does not match local self")) {
+    return "Internal mismatch: the service derived a self_node_id that the database trigger rejected. Inspect `nodes WHERE is_self=true` for stale rows.";
+  }
+  if (message.includes("already exists at tier B")) {
+    return "A non-self swarm_lessons row already occupies this id. Inspect with `swarm_list_peers` and either resolve via `swarm_resolve_contradict` or pin manually with `swarm_pin_lesson`.";
+  }
+  if (message.includes("sequence_number race")) {
+    return "Concurrent publishers exhausted the retry budget. Retry the tool — the chain tip will have advanced.";
+  }
+  if (message.includes("biconditional violated")) {
+    return "Chain tip read returned an inconsistent state (sequence vs prev_hash). Inspect `lesson_chain` for corruption — this should not happen under normal operation.";
+  }
+  if (message.includes("no embedding")) {
+    return "The local lesson row is missing an embedding. Re-embed via the embedding pipeline first.";
+  }
+  return "Inspect server logs for the underlying error and the migration-087 / 078 / 074 contracts before retrying.";
+}
+
+/**
+ * Pure handler — returns the structured output. Exposed for unit tests
+ * so they don't have to unwrap the MCP `content` envelope. The
+ * MCP-facing adapter wraps this in the `{ content: [...] }` shape that
+ * `withErrorHandling` expects.
+ */
+export async function swarmPublishTierAlesson(
+  publishService: SwarmPublishService,
+  memoryService: MemoryService,
+  input: SwarmPublishTierAlessonInput,
+): Promise<SwarmPublishTierAlessonOutput> {
+  if (!isSwarmWriteAllowed()) {
+    return {
+      ok: false,
+      error: "swarm_publish_tier_a_lesson requires OPENCLAW_ALLOW_SWARM_WRITE=1",
+      fix_hint:
+        "Operator must opt in by setting OPENCLAW_ALLOW_SWARM_WRITE=1 in " +
+        "the MCP server environment. Without it, no MCP tool can write to " +
+        "the swarm trust substrate (§3.4 / §10.6 firebreak) or publish " +
+        "lessons onto the wire.",
+    };
+  }
+
+  let outcome: PublishTierAOutcome;
+  try {
+    outcome = await publishService.publishTierA(
+      input.lesson_id,
+      { spec_version: input.spec_version, note: input.note },
+      publishService.defaultDeps(),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok:    false,
+      error: message,
+      fix_hint: fixHintFromError(message),
+    };
+  }
+
+  // Memory-bus side-effect — best-effort. The audit row in
+  // tier_promotion_log + the lesson_chain entry are the durable record;
+  // this memory row is a recall convenience for the agent's own future
+  // introspection ("did I publish anything in the last hour?").
+  let memory_recorded = false;
+  let memory_error: string | undefined;
+  try {
+    const noun =
+      outcome.status === "published"
+        ? `Published swarm_lesson ${outcome.lesson_id} at Tier-A (seq ${outcome.sequence_number}, hash ${outcome.lesson_hash}). ${outcome.audit_reason}`
+        : `Re-publish no-op: lesson ${outcome.lesson_id} already at Tier-A (chain_present=${outcome.chain_present}).`;
+    await memoryService.create({
+      content:  noun,
+      category: "decisions",
+      tags:     ["swarm", "publish", "tier-a"],
+      metadata: {
+        lesson_id: outcome.lesson_id,
+        status:    outcome.status,
+        source:    "swarm_publish_tier_a_lesson",
+        ...(outcome.status === "published"
+          ? {
+              sequence_number: outcome.sequence_number,
+              lesson_hash:     outcome.lesson_hash,
+            }
+          : {}),
+      },
+      source: "swarm_publish_tier_a_lesson",
+    });
+    memory_recorded = true;
+  } catch (err) {
+    memory_error = err instanceof Error ? err.message : String(err);
+  }
+
+  if (outcome.status === "published") {
+    return {
+      ok:              true,
+      status:          "published",
+      lesson_id:       outcome.lesson_id,
+      origin_node_id:  outcome.origin_node_id,
+      lesson_tier:     "A",
+      sequence_number: outcome.sequence_number,
+      lesson_hash:     outcome.lesson_hash,
+      audit_reason:    outcome.audit_reason,
+      signed_at:       outcome.signed_at,
+      received_at:     outcome.received_at,
+      memory_recorded,
+      ...(memory_error ? { memory_error } : {}),
+    };
+  }
+  return {
+    ok:            true,
+    status:        "already_published",
+    lesson_id:     outcome.lesson_id,
+    lesson_tier:   "A",
+    chain_present: outcome.chain_present,
+    memory_recorded,
+    ...(memory_error ? { memory_error } : {}),
+  };
+}
+
+/**
+ * MCP-facing adapter — wraps the pure handler's result in the
+ * `{ content: [{ type, text }] }` envelope that `withErrorHandling`
+ * expects. Returning structured JSON-as-text matches the convention used
+ * by recall.ts and the rest of the tool surface.
+ */
+export async function swarmPublishTierAlessonHandler(
+  publishService: SwarmPublishService,
+  memoryService: MemoryService,
+  input: SwarmPublishTierAlessonInput,
+): Promise<McpToolResult> {
+  const output = await swarmPublishTierAlesson(
+    publishService,
+    memoryService,
+    input,
+  );
+  return asMcpResult(output);
+}

--- a/supabase/migrations/087_swarm_publish_tier_a.sql
+++ b/supabase/migrations/087_swarm_publish_tier_a.sql
@@ -1,0 +1,226 @@
+-- 087_swarm_publish_tier_a.sql — Swarm Phase 4, issue #143 (write-side slice)
+--
+-- Atomic backend RPC for the `swarm_publish_tier_a_lesson` MCP tool.
+-- Forces a locally-generated lesson into the broadcast-eligible Tier-A
+-- state in a single transaction:
+--
+--   1. Append a row to `lesson_chain` (commits the §3.7.2 chain).
+--   2. Insert a row into `swarm_lessons` (default tier 'B' from migration 078
+--      DEFAULT — the firebreak holds inside this txn for a single statement).
+--   3. Append a `tier_promotion_log` row (B → A, reason starts with
+--      'tool-publish'). The (from_tier <> to_tier) CHECK is satisfied
+--      because we transition B → A within the same txn.
+--   4. Update `swarm_lessons.lesson_tier` to 'A'.
+--
+-- All four writes share one transaction. On any failure mid-flight the
+-- entire publish rolls back — no orphan chain row, no half-promoted swarm
+-- row, no dangling audit row. This is the atomicity the resolve-contradict
+-- RPC (migration 086) provides for §10.3 resolutions, applied to §10.6
+-- producer-side publication.
+--
+-- Why a dedicated RPC rather than the producer pipeline used by /swarm/lessons
+-- inbound admission (PR #154):
+--   - inbound admission writes Tier-B; here we MUST land at Tier-A with an
+--     audit row. Re-using the inbound path would not exercise the audit.
+--   - The producer-side lesson_chain hook (PR #146) signs + chains a lesson
+--     in the local lessons workflow but never touches swarm_lessons. This
+--     RPC bridges that gap for the operator-tool surface.
+--   - The signing step still happens in TS (the privkey stays in the chmod
+--     0600 file outside the database — pillar 1 sovereignty). The TS layer
+--     reads the chain tip, signs, computes the lesson_hash, and passes the
+--     full payload to this RPC for the atomic apply.
+--
+-- Concurrency contract — sequence_number race:
+--   Two concurrent publishers can read the same chain tip and race to insert
+--   the same sequence_number. Migration 074's UNIQUE(sequence_number) catches
+--   the loser. We re-raise as a typed error (`sequence_number_race`) so the
+--   TS service knows to re-read the tip, re-sign, and retry. Three retries
+--   is the budget — a third concurrent publisher on a single mycelium
+--   indicates misconfiguration. Same retry policy as
+--   signLessonAndAppendToChain (lesson-chain.ts).
+--
+-- Idempotency contract:
+--   If a swarm_lessons row already exists for `p_lesson_id` AND its tier is
+--   'A', the RPC returns ok=true / status='already_published' without
+--   touching anything. Re-running the tool against an already-published
+--   lesson is therefore a safe no-op. A swarm_lessons row at 'B' for a
+--   self-published lesson is an inconsistent state (a self-row with chain
+--   entry must always be A under this RPC's contract); the RPC raises so
+--   the operator can investigate rather than silently re-promote.
+--
+-- Self-broadcast safety integration:
+--   The lesson_chain INSERT triggers `lesson_chain_assert_self_origin`
+--   (migration 085), which requires `nodes WHERE is_self = TRUE`. The
+--   swarm_lessons INSERT triggers `swarm_lessons_assert_self_origin`,
+--   which (since the chain row was just inserted in the same txn) checks
+--   that `p_origin = self_node_id`. This RPC verifies self-identity before
+--   any insert and rejects with a clean error if `p_origin` doesn't match
+--   — the trigger remains the SQL-layer firewall but the RPC gives a
+--   readable error before the trigger fires.
+--
+-- Scope discipline:
+--   * One new RPC + GRANT. No DROP, no DELETE on existing tables, no
+--     schema changes. Reed runs the migration manually after merge —
+--     the autonomy loop is forbidden from executing it (075-086 discipline).
+--   * The MCP tool surface (swarm_publish_tier_a_lesson) lands in the
+--     same PR; the dashboard frontend for "operator publish" is not in
+--     scope for #143 (separate from #142's contradict/quarantine UI).
+
+-- ---------------------------------------------------------------------------
+-- (1) operator_publish_tier_a_lesson — atomic publish + chain + audit
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION operator_publish_tier_a_lesson(
+  p_lesson_id     UUID,
+  p_content       TEXT,
+  p_embedding     VECTOR(768),
+  p_synth_size    INT,
+  p_origin        TEXT,
+  p_signed_at     TIMESTAMPTZ,
+  p_created_at    TIMESTAMPTZ,
+  p_signature     TEXT,
+  p_tags          TEXT[],
+  p_spec_version  TEXT,
+  p_lesson_hash   TEXT,
+  p_prev_hash     TEXT,
+  p_sequence      INT,
+  p_audit_note    TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_self          TEXT;
+  v_existing_tier TEXT;
+  v_existing_chain BOOLEAN;
+  v_now           TIMESTAMPTZ := NOW();
+  v_audit_reason  TEXT;
+BEGIN
+  -- (a) Self-identity check (defense in depth — the trigger from migration
+  --     085 also asserts this, but a clean error here beats a trigger raise).
+  SELECT node_id INTO v_self FROM nodes WHERE is_self = TRUE LIMIT 1;
+  IF v_self IS NULL THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: no is_self row in nodes — bootstrap node identity first';
+  END IF;
+  IF p_origin IS DISTINCT FROM v_self THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: origin % does not match local self %', p_origin, v_self;
+  END IF;
+
+  -- (b) Spec invariants the migration-071 column CHECKs would also catch,
+  --     but raising here gives the caller a meaningful error rather than
+  --     a generic constraint violation.
+  IF p_synth_size < 2 THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: synthesized_from_cluster_size must be >= 2 (got %)', p_synth_size;
+  END IF;
+  IF octet_length(p_content) > 8192 THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: content exceeds 8192 octets (% octets)', octet_length(p_content);
+  END IF;
+  IF p_signed_at < p_created_at THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: signed_at (%) must be >= created_at (%)', p_signed_at, p_created_at;
+  END IF;
+
+  -- (c) Chain tip biconditional (migration 074 CHECK) — re-asserted here
+  --     so a malformed caller gets a clean error pre-INSERT.
+  IF (p_sequence = 0) <> (p_prev_hash IS NULL) THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: chain tip biconditional violated (sequence=%, prev_hash=%)',
+      p_sequence, COALESCE(p_prev_hash, 'NULL');
+  END IF;
+  IF p_sequence < 0 THEN
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: sequence must be non-negative (got %)', p_sequence;
+  END IF;
+
+  -- (d) Idempotency — already published?
+  SELECT lesson_tier INTO v_existing_tier FROM swarm_lessons WHERE id = p_lesson_id;
+  IF v_existing_tier = 'A' THEN
+    -- Already at A. Whether or not a chain row exists, the broadcast
+    -- contract is satisfied; treat as no-op.
+    SELECT EXISTS(SELECT 1 FROM lesson_chain WHERE lesson_id = p_lesson_id)
+      INTO v_existing_chain;
+    RETURN jsonb_build_object(
+      'ok',          true,
+      'status',      'already_published',
+      'lesson_id',   p_lesson_id,
+      'lesson_tier', 'A',
+      'chain_present', v_existing_chain
+    );
+  ELSIF v_existing_tier = 'B' THEN
+    -- A self-published lesson at tier B with this RPC's contract is an
+    -- inconsistent state (either a previous publish was interrupted between
+    -- the swarm_lessons INSERT and the tier UPDATE — the txn boundary should
+    -- have prevented that — or the row was admitted as foreign and the chain
+    -- insert below would re-attribute it). Either way: refuse rather than
+    -- silently re-promote a non-self row.
+    RAISE EXCEPTION 'operator_publish_tier_a_lesson: lesson % already exists at tier B — operator must inspect before re-publish', p_lesson_id;
+  END IF;
+
+  -- (e) Build the audit reason. 512 octet CHECK on tier_promotion_log.reason
+  --     leaves us ~480 octets for the operator note after the prefix.
+  v_audit_reason := 'tool-publish';
+  IF p_audit_note IS NOT NULL AND length(trim(p_audit_note)) > 0 THEN
+    v_audit_reason := v_audit_reason || ': ' || left(trim(p_audit_note), 480);
+  END IF;
+
+  -- (f) The four writes — all in this txn. Chain first so the
+  --     swarm_lessons trigger (migration 085) sees the chain row exists
+  --     and enforces origin=self via the cross-row check.
+  INSERT INTO lesson_chain (lesson_id, signed_at, lesson_hash, prev_lesson_hash, sequence_number)
+  VALUES (p_lesson_id, p_signed_at, p_lesson_hash, p_prev_hash, p_sequence);
+
+  INSERT INTO swarm_lessons (
+    id, content, embedding, synthesized_from_cluster_size, origin_node_id,
+    signed_at, created_at, signature, tags, spec_version
+  ) VALUES (
+    p_lesson_id, p_content, p_embedding, p_synth_size, p_origin,
+    p_signed_at, p_created_at, p_signature, p_tags, p_spec_version
+  );
+  -- lesson_tier defaults to 'B' (migration 078 firebreak); promote next.
+
+  INSERT INTO tier_promotion_log (lesson_id, from_tier, to_tier, reason, evidence_ids)
+  VALUES (p_lesson_id, 'B', 'A', v_audit_reason, ARRAY[]::UUID[]);
+
+  UPDATE swarm_lessons SET lesson_tier = 'A' WHERE id = p_lesson_id;
+
+  RETURN jsonb_build_object(
+    'ok',             true,
+    'status',         'published',
+    'lesson_id',      p_lesson_id,
+    'origin_node_id', p_origin,
+    'lesson_tier',    'A',
+    'sequence_number', p_sequence,
+    'lesson_hash',    p_lesson_hash,
+    'audit_reason',   v_audit_reason,
+    'signed_at',      p_signed_at,
+    'received_at',    v_now
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    -- Re-raise UNIQUE conflicts with stable diagnostic prefixes the TS
+    -- service can pattern-match on. The lesson_chain conflicts are the
+    -- two retry-or-idempotency cases; the swarm_lessons one is a hard
+    -- error (the idempotency check above should have caught the
+    -- already-exists case — reaching here means a race in the tiny
+    -- window between SELECT and INSERT).
+    IF SQLERRM LIKE '%lesson_chain_pkey%' OR SQLERRM LIKE '%lesson_chain%lesson_id%' THEN
+      RAISE EXCEPTION 'operator_publish_tier_a_lesson: lesson_chain_lesson_id_race (%)', SQLERRM;
+    ELSIF SQLERRM LIKE '%lesson_chain_sequence_number%' OR SQLERRM LIKE '%sequence_number%' THEN
+      RAISE EXCEPTION 'operator_publish_tier_a_lesson: lesson_chain_sequence_number_race (%)', SQLERRM;
+    ELSIF SQLERRM LIKE '%swarm_lessons_pkey%' OR SQLERRM LIKE '%swarm_lessons%id%' THEN
+      RAISE EXCEPTION 'operator_publish_tier_a_lesson: swarm_lessons_id_race (%)', SQLERRM;
+    ELSE
+      RAISE;
+    END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION operator_publish_tier_a_lesson(
+  UUID, TEXT, VECTOR(768), INT, TEXT,
+  TIMESTAMPTZ, TIMESTAMPTZ, TEXT, TEXT[], TEXT,
+  TEXT, TEXT, INT, TEXT
+) TO anon, service_role;
+
+COMMENT ON FUNCTION operator_publish_tier_a_lesson(
+  UUID, TEXT, VECTOR(768), INT, TEXT,
+  TIMESTAMPTZ, TIMESTAMPTZ, TEXT, TEXT[], TEXT,
+  TEXT, TEXT, INT, TEXT
+) IS
+  'docs/SWARM_SPEC.md §10.6 producer-side publish path. Atomically signs (caller-supplied), chains, inserts into swarm_lessons at tier B (firebreak default) and promotes to tier A with a tier_promotion_log audit row (reason starts with ''tool-publish''). Backend for the swarm_publish_tier_a_lesson MCP tool (issue #143 write-side slice). Idempotent against already-published lessons; raises lesson_chain_sequence_number_race for concurrent-publisher retries.';


### PR DESCRIPTION
## Summary

Producer-side counterpart to `swarm_pin_lesson` (PR #150). Adds the
`swarm_publish_tier_a_lesson` MCP tool from issue #143 (4th of 5
sub-tools — `swarm_admit_lesson` remains).

Instead of overriding an already-stored row's tier, this tool takes a
LOCAL `lessons` row, signs it with the node's self-key, and atomically:

1. Appends a `lesson_chain` entry (§3.7.2 chain hash).
2. Inserts into `swarm_lessons` (firebreak default tier B).
3. Audits the B→A promotion in `tier_promotion_log` (reason `tool-publish`).
4. Updates `swarm_lessons.lesson_tier` to A.

All four writes share one txn — on any failure mid-flight the entire
publish rolls back.

## Why a dedicated RPC vs the inbound admission path

- Inbound admission (PR #154) writes Tier-B; here we MUST land at
  Tier-A with an audit row. Re-using the inbound path would not
  exercise the audit.
- The producer-side `lesson_chain` hook (PR #146) signs + chains a
  lesson in the local lessons workflow but never touches `swarm_lessons`.
  This RPC bridges that gap for the operator-tool surface.
- The signing step still happens in TS (privkey stays in the chmod
  0600 file outside the database — pillar 1 sovereignty). The TS
  layer reads the chain tip, signs, computes the lesson_hash, and
  passes the full payload to this RPC for the atomic apply.

## Files

- `supabase/migrations/087_swarm_publish_tier_a.sql` — `operator_publish_tier_a_lesson(...)` plpgsql RPC. Self-identity defense in depth, spec invariant pre-checks, chain tip biconditional, idempotent already-published path, stable raise prefixes the TS layer pattern-matches for the `lesson_chain_sequence_number_race` retry case.
- `mcp-server/src/services/swarm-publish.ts` — orchestrator. Pre-sign validation, chain tip read, sign with self-key, RPC dispatch, bounded retry loop on `sequence_number` race (3 attempts, mirrors `signLessonAndAppendToChain`).
- `mcp-server/src/tools/swarm-publish.ts` — MCP-facing adapter. Behind `OPENCLAW_ALLOW_SWARM_WRITE=1` (mirrors `swarm_pin_lesson` and `swarm_resolve_contradict`). Maps RPC raise prefixes onto operator-actionable `fix_hint`s. Best-effort memory-bus side-effect (`decisions`/`swarm` tag).
- `mcp-server/src/__tests__/swarm-publish.test.ts` — 40 unit tests.
- `mcp-server/src/index.ts` — tool registration.

## Test plan

- [x] `npm test` in mcp-server → 868 tests pass (40 new + 828 existing, no regressions).
- [x] `tsc --noEmit` clean.
- [x] Migration 087 number is unclaimed (no other open PR touches `supabase/migrations/`).
- [ ] Reed runs migration 087 manually after merge (autonomy loop is forbidden from executing it — 075-086 discipline).
- [ ] Live smoke test against a local Supabase: publish a lesson with `evidence_count >= 2`, observe the `tier_promotion_log` audit row with `reason = 'tool-publish'` and the `swarm_lessons.lesson_tier = 'A'` row.

## Out of scope

- `swarm_admit_lesson` (5th sub-tool of issue #143) — separate follow-up PR.
- Dashboard "operator publish" UI — issue #143 explicitly out-of-scopes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)