### PR TITLE
feat(swarm): wire POST /swarm/lessons admission into dashboard-server (#138)

### DIFF
--- a/mcp-server/src/__tests__/dashboard-server-lesson-admission-wiring.test.ts
+++ b/mcp-server/src/__tests__/dashboard-server-lesson-admission-wiring.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Contract test for the wiring of POST /swarm/lessons into
+ * scripts/dashboard-server.mjs (Swarm sub-phase 4j, issue #138 follow-up).
+ *
+ * The handler module `swarm/endpoints/lesson-admission.ts` shipped in PR #154
+ * with 19 contract tests of its own. What `lesson-admission.test.ts` does NOT
+ * prove is that any HTTP host actually mounts the handler — and indeed for
+ * several days no host did. This file pins the wiring at the source-text
+ * level so a future refactor of dashboard-server.mjs cannot silently regress
+ * it without flipping a test red.
+ *
+ * Same shape-pin discipline as `dashboard-server-lesson-proof-wiring.test.ts`:
+ * scripts/dashboard-server.mjs is not part of the tsc test loop, so we read
+ * it as text and assert structural facts rather than booting it. Comments
+ * are stripped before keyword matches so an explanatory comment cannot
+ * satisfy a structural assertion.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Test runs from mcp-server/dist/__tests__/, repo root is three levels up.
+const DASHBOARD_PATH = resolve(
+  __dirname,
+  "../../..",
+  "scripts/dashboard-server.mjs",
+);
+const RAW = readFileSync(DASHBOARD_PATH, "utf8");
+const NO_COMMENTS = RAW.replace(/\/\/[^\n]*/g, "").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+
+// ---------------------------------------------------------------------------
+// (1) The handler module is imported.
+// ---------------------------------------------------------------------------
+
+test("dashboard-server imports admitSwarmLesson from the compiled handler", () => {
+  // Match the dynamic import — same pattern as buildLessonProofResponse.
+  const importRe =
+    /admitSwarmLesson[^}]*\}\s*=\s*await\s+import\([^)]*lesson-admission\.js[^)]*\)/;
+  assert.match(
+    NO_COMMENTS,
+    importRe,
+    "dashboard-server.mjs must import admitSwarmLesson from " +
+      "mcp-server/dist/swarm/endpoints/lesson-admission.js",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) The dispatcher routes POST /swarm/lessons (and only POST) to the
+// admission handler. GET /swarm/lessons is the outbound feed (#139) — the
+// method gate keeps the two endpoints from cross-routing.
+// ---------------------------------------------------------------------------
+
+test("dashboard-server routes POST /swarm/lessons to handleAdmitLesson", () => {
+  const compact = NO_COMMENTS.replace(/\s+/g, "");
+  assert.match(
+    compact,
+    /req\.method==="POST"&&req\.url==="\/swarm\/lessons"/,
+    "Dispatcher must guard the route on POST + exact /swarm/lessons match " +
+      "so GET /swarm/lessons (the #139 outbound feed) does not collide with " +
+      "the admission handler",
+  );
+  assert.match(
+    NO_COMMENTS,
+    /handleAdmitLesson\s*\(/,
+    "Dispatcher must call handleAdmitLesson when POST /swarm/lessons matches",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) The admission route registers BEFORE the static fall-through and
+// before the /api/ proxy prefix, otherwise a stray POST would be misrouted.
+// ---------------------------------------------------------------------------
+
+test("dashboard-server registers POST /swarm/lessons before /api/ proxy", () => {
+  const dispatcherStart = NO_COMMENTS.indexOf(
+    "http.createServer((req, res)",
+  );
+  assert.ok(dispatcherStart > 0, "createServer dispatcher must exist");
+  const admissionRouteIdx = NO_COMMENTS.indexOf(
+    "/swarm/lessons",
+    dispatcherStart,
+  );
+  const apiPrefixIdx = NO_COMMENTS.indexOf('"/api/"', dispatcherStart);
+  assert.ok(
+    admissionRouteIdx > 0 && apiPrefixIdx > 0 && admissionRouteIdx < apiPrefixIdx,
+    "Admission route registration must come before the /api/ proxy " +
+      "fall-through so a stray POST does not get rewritten as a PostgREST call",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (4) Adapter wires the §10.6 / §10.1 substrate paths. We pin the table /
+// RPC names so a future refactor cannot silently re-target them at the
+// wrong primitives — the admission contract leans on each one.
+// ---------------------------------------------------------------------------
+
+test("handleAdmitLesson loads pubkey + quarantine state from the nodes table", () => {
+  assert.match(
+    NO_COMMENTS,
+    /nodes\?select=pubkey_b64url/,
+    "getPubkeyForNode must SELECT nodes.pubkey_b64url so the wire-validator " +
+      "can verify Ed25519 signatures against the producer's published key",
+  );
+  assert.match(
+    NO_COMMENTS,
+    /nodes\?select=quarantined_until/,
+    "getQuarantinedUntil must SELECT nodes.quarantined_until — the §10.2 " +
+      "single-strike pre-check key",
+  );
+});
+
+test("handleAdmitLesson INSERTs into swarm_lessons with lesson_tier='B'", () => {
+  assert.match(
+    NO_COMMENTS,
+    /pgPostJson\(\s*"swarm_lessons"/,
+    "insertSwarmLesson must POST to swarm_lessons (admission persists at " +
+      "Tier-B per the §10.6 firebreak default)",
+  );
+  // The handler hard-pins lesson_tier to 'B'; the wiring forwards that
+  // verbatim. A future change to lesson_tier here would silently bypass
+  // the §10.6 broadcast firewall.
+  assert.match(
+    NO_COMMENTS,
+    /lesson_tier:\s*"B"/,
+    "INSERT body must pin lesson_tier='B' (firebreak default for any " +
+      "externally-admitted lesson per §10.6)",
+  );
+});
+
+test("recordTrustEdgeChange adapter calls record_trust_edge_change RPC", () => {
+  assert.match(
+    NO_COMMENTS,
+    /callRpc\(\s*"record_trust_edge_change"/,
+    "recordTrustEdgeChange must go through the migration-075 RPC so the " +
+      "trust_edge_log audit row is appended (§10.1)",
+  );
+});
+
+test("setQuarantine adapter PATCHes nodes.quarantined_until directly", () => {
+  // The single-strike window is one hour and quarantine_origin enforces
+  // p_days > 0; using PATCH is the only way to express the sub-day
+  // interval without a schema change. Mirror of the operator-restore PATCH
+  // path in #157.
+  const compact = NO_COMMENTS.replace(/\s+/g, "");
+  assert.match(
+    compact,
+    /pgPatchJson\(`nodes\?node_id=eq\./,
+    "setQuarantine must PATCH /nodes?node_id=eq.<id> so the §10.2 1-hour " +
+      "single-strike window is expressible (quarantine_origin RPC enforces " +
+      "p_days > 0 and can't represent sub-day windows)",
+  );
+  assert.ok(
+    !/quarantine_origin/.test(
+      NO_COMMENTS.slice(NO_COMMENTS.indexOf("setQuarantine")),
+    ) || NO_COMMENTS.indexOf("setQuarantine") < 0,
+    "setQuarantine adapter must NOT call the quarantine_origin RPC — " +
+      "p_days > 0 contract refuses sub-day windows",
+  );
+});

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -66,6 +66,13 @@ const { buildNodeAdvertisementResponse } = await import(
 const { buildLessonProofResponse } = await import(
   path.join(SWARM_ENDPOINTS_DIST, "lesson-proof.js")
 );
+// Swarm sub-phase 4j (issue #138): POST /swarm/lessons admission pipeline.
+// Mirrors the #128 → #152 substrate-then-wiring split — PR #154 shipped the
+// pure handler with 19 contract tests; this wiring mounts it on the HTTP
+// host so a peer can actually post a Lesson envelope.
+const { admitSwarmLesson } = await import(
+  path.join(SWARM_ENDPOINTS_DIST, "lesson-admission.js")
+);
 
 // --- load JWT_SECRET from docker/.env so we can mint a service_role JWT ---
 async function loadEnv() {
@@ -1834,6 +1841,183 @@ async function pgSelect(query) {
   return r.json();
 }
 
+// --- Swarm sub-phase 4j: POST /swarm/lessons -----------------------------
+// Receiver-side admission for incoming v1.1 Lesson envelopes (SWARM_SPEC §10.6
+// firebreak). The handler module `lesson-admission.ts` is pure — every side
+// effect (DB writes, signature lookups) goes through injected callbacks so
+// the contract tests can exercise every branch without HTTP / Postgres. This
+// adapter wires those callbacks against PostgREST + the existing swarm RPCs.
+//
+// Three deps are deliberately NOT supplied:
+//
+//   1. `getExpectedPrevLessonHash` — receiver-side rule-19 (broken
+//      commitment chain) requires per-origin chain tracking on the receiver
+//      side, which the substrate doesn't yet provide. swarm_lessons stores
+//      neither `prev_lesson_hash` nor `lesson_hash`; only the producer-side
+//      `lesson_chain` table (migration 074) carries those, and that table
+//      is keyed by self-published lessons. Wiring rule 19 here means a new
+//      `received_lesson_chain` table per-origin, which is its own follow-up.
+//
+//   2. `runContradictionGate` — the gate (migration 080 + PR #121) lives
+//      in the MCP server services tree, not in the dashboard host. Mounting
+//      it in this listener would cross the MCP/dashboard process boundary;
+//      §10.5 REM self-audit catches the same contradicts asynchronously, so
+//      the inline gate is a latency optimization, not a correctness one.
+//
+//   3. `setQuarantine` uses a direct PATCH on `nodes.quarantined_until`
+//      rather than the `quarantine_origin` RPC because the §10.2 single-
+//      strike interval is one hour and the RPC enforces `p_days > 0` (it
+//      can't represent sub-day windows without a schema change). Same
+//      pattern the operator-override restore path uses (#157 / lines 1731+).
+async function pgPostJson(path, body) {
+  const r = await fetch(new URL(`/${path}`, UPSTREAM), {
+    method: "POST",
+    headers: {
+      "Content-Type":  "application/json",
+      "Accept":        "application/json",
+      "Prefer":        "return=representation",
+      "Authorization": `Bearer ${SERVICE_JWT}`,
+      "apikey":        SERVICE_JWT,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) {
+    const text = await r.text().catch(() => "");
+    throw new Error(`postgrest POST /${path} failed: HTTP ${r.status} ${text}`);
+  }
+  return r.json();
+}
+
+async function pgPatchJson(path, body) {
+  const r = await fetch(new URL(`/${path}`, UPSTREAM), {
+    method: "PATCH",
+    headers: {
+      "Content-Type":  "application/json",
+      "Accept":        "application/json",
+      "Authorization": `Bearer ${SERVICE_JWT}`,
+      "apikey":        SERVICE_JWT,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) {
+    const text = await r.text().catch(() => "");
+    throw new Error(`postgrest PATCH /${path} failed: HTTP ${r.status} ${text}`);
+  }
+}
+
+function decodeB64Url(s) {
+  // Accept both URL-safe and standard base64; restore padding.
+  const std = String(s).replace(/-/g, "+").replace(/_/g, "/");
+  const pad = std.length % 4 === 0 ? std : std + "=".repeat(4 - (std.length % 4));
+  return new Uint8Array(Buffer.from(pad, "base64"));
+}
+
+async function handleAdmitLesson(req, res) {
+  if (req.method !== "POST") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "POST only" }));
+    return;
+  }
+  // Parse body upstream of admitSwarmLesson — the handler expects an
+  // already-parsed object so the HTTP host owns JSON.parse failures.
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  let body;
+  try {
+    body = raw.length === 0 ? null : JSON.parse(raw);
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(JSON.stringify({ error: "invalid JSON body" }));
+    return;
+  }
+
+  try {
+    const result = await admitSwarmLesson({
+      body,
+      ourSpecMajor: 1,
+      now: new Date(),
+      loadSelf: async () => {
+        const self = await nodeIdentityService.getSelf();
+        if (!self) return null;
+        return { node_id: self.node_id, pubkey_b64: self.pubkey_b64 };
+      },
+      getPubkeyForNode: async (nodeId) => {
+        const rows = await pgSelect(
+          `nodes?select=pubkey_b64url&node_id=eq.${encodeURIComponent(nodeId)}&limit=1`,
+        );
+        if (!Array.isArray(rows) || rows.length === 0) return null;
+        const b64 = rows[0]?.pubkey_b64url;
+        if (typeof b64 !== "string" || b64.length === 0) return null;
+        return decodeB64Url(b64);
+      },
+      getQuarantinedUntil: async (nodeId) => {
+        const rows = await pgSelect(
+          `nodes?select=quarantined_until&node_id=eq.${encodeURIComponent(nodeId)}&limit=1`,
+        );
+        if (!Array.isArray(rows) || rows.length === 0) return null;
+        return rows[0]?.quarantined_until ?? null;
+      },
+      insertSwarmLesson: async (lesson) => {
+        const inserted = await pgPostJson("swarm_lessons", {
+          id:                            lesson.id,
+          content:                       lesson.content,
+          embedding:                     lesson.embedding,
+          synthesized_from_cluster_size: lesson.synthesized_from_cluster_size,
+          origin_node_id:                lesson.origin_node_id,
+          signed_at:                     lesson.signed_at,
+          created_at:                    lesson.created_at,
+          signature:                     lesson.signature,
+          tags:                          lesson.tags ?? null,
+          spec_version:                  lesson.spec_version,
+          lesson_tier:                   "B",
+        });
+        const row = Array.isArray(inserted) ? inserted[0] : inserted;
+        return { lesson_id: row?.id ?? lesson.id };
+      },
+      setQuarantine: async (nodeId, untilMs, reason) => {
+        // Direct PATCH — the quarantine_origin RPC enforces p_days > 0,
+        // which can't represent the §10.2 1-hour single-strike window.
+        await pgPatchJson(
+          `nodes?node_id=eq.${encodeURIComponent(nodeId)}`,
+          {
+            quarantined_until: new Date(untilMs).toISOString(),
+            decay_reason:      reason,
+          },
+        );
+      },
+      recordTrustEdgeChange: async (nodeId, delta, reason) => {
+        // The handler hands us a delta (§10.1 +0.05 admitted); record_trust_edge_change
+        // sets an absolute new_weight. Read-modify-write so the audit row carries the
+        // before→after pair the §10.1 audit semantics expect.
+        const rows = await pgSelect(
+          `nodes?select=trust_weight&node_id=eq.${encodeURIComponent(nodeId)}&limit=1`,
+        );
+        const before = Array.isArray(rows) && rows.length > 0
+          ? Number(rows[0]?.trust_weight ?? 0.5)
+          : 0.5;
+        const next = Math.max(0, Math.min(1, before + delta));
+        await callRpc("record_trust_edge_change", {
+          p_node_id:    nodeId,
+          p_new_weight: next,
+          p_reason:     reason,
+        });
+      },
+      // Intentionally undefined — see header comment.
+      // getExpectedPrevLessonHash: undefined,
+      // runContradictionGate:      undefined,
+    });
+    res.writeHead(result.status, result.headers);
+    res.end(result.body);
+  } catch (e) {
+    res.writeHead(503, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(JSON.stringify({
+      error:  "lesson-admission handler failed",
+      detail: String(e?.message || e),
+    }));
+  }
+}
+
 async function handleLessonProof(_req, res, lessonId) {
   try {
     const result = await buildLessonProofResponse({
@@ -1894,6 +2078,9 @@ const server = http.createServer((req, res) => {
   if (req.url === "/swarm/contradict-resolve")  return handleSwarmContradictResolve(req, res);
   if (req.url === "/swarm/peer-trust-override") return handleSwarmPeerTrustOverride(req, res);
   if (req.url === "/swarm/lesson-pin")          return handleSwarmLessonPin(req, res);
+  // Swarm sub-phase 4j (issue #138): receiver-side admission. Distinct from
+  // the GET /swarm/lessons feed (PR #155 substrate) — methods route this.
+  if (req.method === "POST" && req.url === "/swarm/lessons") return handleAdmitLesson(req, res);
   // Swarm sub-phase 4e (issue #105): inclusion-proof endpoint.
   if (req.method === "GET" && req.url) {
     const proofMatch = req.url.match(PROOF_PATH_RE);


### PR DESCRIPTION
## Summary

PR #154 shipped the pure `lesson-admission.ts` handler with 19 contract tests but deferred HTTP wiring (mirror of the #128 → #152 substrate-then-wiring split). Until this lands, a peer posting a signed v1.1 envelope to `/swarm/lessons` hits the static fall-through and 404s — receiver pipeline conceptually closed, operationally unreachable.

This mounts `admitSwarmLesson` on `scripts/dashboard-server.mjs` so `curl -X POST /swarm/lessons -d <envelope>` returns the 201/4xx/503 mapping issue #138 specifies.

## Adapter wiring

| Dep | Path |
|---|---|
| `getPubkeyForNode` | `pgSelect nodes.pubkey_b64url`, b64url-decode → `Uint8Array` |
| `getQuarantinedUntil` | `pgSelect nodes.quarantined_until` |
| `insertSwarmLesson` | POST `/swarm_lessons`, `lesson_tier` hard-pinned `'B'` per §10.6 |
| `recordTrustEdgeChange` | `record_trust_edge_change` RPC (read-modify-write so the +0.05 delta becomes an absolute `new_weight` the audit row records) |
| `setQuarantine` | PATCH `/nodes?node_id=eq.X` (the `quarantine_origin` RPC enforces `p_days > 0` and can't express the §10.2 1-hour single-strike window) |

## Deliberately not wired

1. **`getExpectedPrevLessonHash`** — receiver-side rule 19 (broken commitment chain) needs a per-origin `received_lesson_chain` table. `lesson_chain` (mig 074) is producer-only; `swarm_lessons` stores neither `prev_lesson_hash` nor `lesson_hash`. Follow-up issue.
2. **`runContradictionGate`** — gate lives in the MCP server services tree, not in the dashboard host; §10.5 REM self-audit catches the same contradicts asynchronously, so the inline gate is a latency optimization, not a correctness one.

Both gaps are documented in the source comment above `handleAdmitLesson` so a future reader can see what's wired vs. deferred.

## Diff shape

```
mcp-server/src/__tests__/dashboard-server-lesson-admission-wiring.test.ts | 165 +++++++++++
scripts/dashboard-server.mjs                                              | 187 +++++++++++
2 files changed, 352 insertions(+)
```

No migration. No new MCP tool. No change to the existing `lesson-admission.ts` handler — the wiring is additive.

## Test plan

- [x] `cd mcp-server && rm -rf dist && npm run build` — clean
- [x] `npm test` — **835/835 pass** (828 prior + 7 wiring contract tests)
- [x] `node --check scripts/dashboard-server.mjs` — passes
- [x] Source-text contract test pins: import shape, POST+exact-URL guard (so GET `/swarm/lessons` from #155's outbound feed doesn't cross-route), registration before `/api/` proxy, `nodes.pubkey_b64url` / `nodes.quarantined_until` / `swarm_lessons` POST / `record_trust_edge_change` RPC / `nodes` PATCH targets all pinned
- [ ] Manual smoke after Reed merges + restarts the dashboard: `curl -X POST http://localhost:8787/swarm/lessons -H 'Content-Type: application/json' -d '<signed v1.1 envelope from a known peer>'` → 201 `{lesson_id, lesson_tier:'B', contradictions:0, origin_node_id}`

Refs #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)