### PR TITLE
feat(swarm): wire LessonContradictionRunner into digest step 3.55 (#137)

### DIFF
--- a/docs/SWARM_SPEC.md
+++ b/docs/SWARM_SPEC.md
@@ -628,6 +628,8 @@ swarm-labelled phase merges to `main`.
 | 4f — TrustEdge auto-tuning + quarantine (migration 075) | §10.1, §10.2 | [#107](https://github.com/Dewinator/mycelium/issues/107) | `25bf3a8` | ✅ on `main` |
 | 4f.1 — Trust-edge decay + quarantine release sweeps (migration 083) | §10.1, §10.2 | [#141](https://github.com/Dewinator/mycelium/issues/141) | — | 🟡 PR open (this branch) |
 | 4g — ConscienceAgent contradicts-trigger (migration 080) | §10.3 | [#108](https://github.com/Dewinator/mycelium/issues/108) | `6d59674` | ✅ on `main` |
+| 4g.2 — `LessonContradictionRunner` substrate (sweep + idempotent persist) | §10.3 | [#137](https://github.com/Dewinator/mycelium/issues/137) | `19a71d1` | ✅ on `main` |
+| 4g.2 follow-up — digest.ts step 3.55 wiring of §10.3 contradicts pass | §10.3 | [#137](https://github.com/Dewinator/mycelium/issues/137) | — | 🟡 PR open (this branch) |
 | 4h — REM self-audit pass (§10.5 falsification arrow) | §10.5 | [#109](https://github.com/Dewinator/mycelium/issues/109) | `8cad92f` | ✅ on `main` |
 | 4i.1 — Two-tier pinning + broadcast firewall (migration 078) | §10.4, §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | `db98ea0` | ✅ on `main` |
 | 4i.2 — REM promotion-audit Tier-B → Tier-A (migration 081, §10.6 promote arrow) | §10.6 | [#114](https://github.com/Dewinator/mycelium/issues/114) | `69dd87c` | ✅ on `main` |

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -28,6 +28,7 @@ import { ExperienceService } from "./services/experiences.js";
 import { RemAuditService } from "./services/rem-audit.js";
 import { RemPromotionService } from "./services/rem-promotion.js";
 import { RemDiversityService } from "./services/rem-diversity.js";
+import { LessonContradictionRunner } from "./services/lesson-contradiction-runner.js";
 import {
   recordExperienceSchema,
   recordExperience,
@@ -239,6 +240,7 @@ const swarmPeersService     = new SwarmPeersService(SUPABASE_URL, SUPABASE_KEY);
 const remAuditService       = new RemAuditService(SUPABASE_URL, SUPABASE_KEY);
 const remPromotionService   = new RemPromotionService(SUPABASE_URL, SUPABASE_KEY);
 const remDiversityService   = new RemDiversityService(SUPABASE_URL, SUPABASE_KEY);
+const lessonContradictionRunner = new LessonContradictionRunner(SUPABASE_URL, SUPABASE_KEY);
 // DEFERRED 2026-04-26 — federation service parked until federation phase.
 // const federationService = new FederationService(
 //   SUPABASE_URL,
@@ -651,6 +653,10 @@ server.tool(
     {
       service: remDiversityService,
       deps: remDiversityService.defaultDeps(),
+    },
+    {
+      service: lessonContradictionRunner,
+      deps: lessonContradictionRunner.defaultDeps(),
     }
   ))
 );

--- a/mcp-server/src/tools/digest.ts
+++ b/mcp-server/src/tools/digest.ts
@@ -13,6 +13,11 @@ import type {
   RemDiversityService,
   RemDiversityDeps,
 } from "../services/rem-diversity.js";
+import type {
+  LessonContradictionRunner,
+  RunOptions as LessonContradictionRunOptions,
+  RunDeps as LessonContradictionRunDeps,
+} from "../services/lesson-contradiction-runner.js";
 
 /**
  * `digest` — the end-of-conversation soul development pipeline.
@@ -85,7 +90,12 @@ export async function digest(
   input: z.infer<typeof digestSchema>,
   remAudit?: { service: RemAuditService; deps: RemAuditDeps },
   remPromotion?: { service: RemPromotionService; deps: RemPromotionDeps },
-  remDiversity?: { service: RemDiversityService; deps: RemDiversityDeps }
+  remDiversity?: { service: RemDiversityService; deps: RemDiversityDeps },
+  lessonContradictionRunner?: {
+    service: LessonContradictionRunner;
+    deps: LessonContradictionRunDeps;
+    opts?: LessonContradictionRunOptions;
+  }
 ) {
   const report: string[] = [];
   report.push("# Digest Report\n");
@@ -273,6 +283,44 @@ export async function digest(
       // Non-fatal — the audit pipeline must never poison the digest cycle.
       report.push(
         `**REM self-audit:** skipped — ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  // =========================================================================
+  // Step 3.55: §10.3 between-peer contradiction sweep (SWARM_SPEC §10.3)
+  //
+  // After self-audit (3.5, §10.5) clears local-vs-swarm falsifications, scan
+  // recently-arrived swarm_lessons against priors to surface peer-vs-peer
+  // contradictions. Each finding writes to swarm_lesson_contradictions and
+  // demotes both sides to Tier-B (the migration-080 RPC handles both atomically),
+  // so promotion (3.6) cannot fast-track a contested lesson in the same cycle.
+  //
+  // Spec sequence per issue #137 acceptance:
+  //   §10.5 (audit) → §10.3 (contradicts) → §10.6 (promote) → §10.4 (diversity)
+  // matches digest steps 3.5 → 3.55 → 3.6 → 3.7.
+  //
+  // Skipped silently when no runner deps are injected (tests / minimal client
+  // builds). Per-newcomer failures are caught inside the runner; this outer
+  // try/catch only fires on a load-side failure.
+  // =========================================================================
+  if (lessonContradictionRunner) {
+    try {
+      const summary = await lessonContradictionRunner.service.runContradictionPass(
+        lessonContradictionRunner.opts ?? {},
+        lessonContradictionRunner.deps,
+      );
+      if (summary.newcomers_scanned > 0) {
+        const failed = summary.outcomes.filter((o) => o.error).length;
+        const failedSummary = failed > 0 ? ` (${failed} failed)` : "";
+        report.push(
+          `**REM contradicts:** ${summary.total_findings} contradiction edge(s) across ${summary.newcomers_scanned} newcomer(s) vs ${summary.priors_loaded} prior(s)${failedSummary}`
+        );
+      }
+    } catch (err) {
+      // Non-fatal — the contradicts pipeline must never poison the digest cycle.
+      report.push(
+        `**REM contradicts:** skipped — ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }


### PR DESCRIPTION
## Summary

Closes the §10.3 between-peer contradicts hole that PR #148 (4g.2 substrate) and the `LessonContradictionRunner` header **explicitly left as a follow-up**:

> "Why a substrate-only PR (no digest wiring yet): […] We follow the same substrate-then-wiring split that PR #131 (substrate) → PR #132 (wiring) used for §10.4: ship the runner first, wire it in a small follow-up once #132 lands."

PR #132 is on `main` (commit `ba29e7c`). This is the wiring follow-up.

## Step order now matches issue #137 acceptance

| step | spec | name |
| --- | --- | --- |
| 3.5  | §10.5 | audit       (falsifies Tier-B vs local lived experience) |
| **3.55** | **§10.3** | **contradicts (sweeps recent peer admissions vs priors)  ← this PR** |
| 3.6  | §10.6 | promote     (Tier-B → Tier-A on corroborating clusters) |
| 3.7  | §10.4 | diversity   (multiplicative weight pull on cohort echoes) |

Matches the SWARM_SPEC sequence §10.5 → §10.3 → §10.6 → §10.4 verbatim.

## Files

- **`mcp-server/src/tools/digest.ts`** — new optional `lessonContradictionRunner?: { service; deps; opts? }` parameter (mirrors `remAudit` / `remPromotion` / `remDiversity` shape) and a step 3.55 block that calls `runContradictionPass`, prints `**REM contradicts:**` with finding/newcomer/prior counts, and never throws.
- **`mcp-server/src/index.ts`** — instantiates `LessonContradictionRunner` next to `RemDiversityService` and threads `defaultDeps()` into the digest tool registration.
- **`docs/SWARM_SPEC.md` §9** — adds two rows to the implementation status table:
  - `4g.2` substrate → `19a71d1` ✅ on `main`
  - `4g.2 follow-up` digest wiring → 🟡 PR open (this branch)

## Why no new digest test

Per the **PR #132 precedent** (sub-phase 4i.3 follow-up), `digest.ts` has no per-step unit tests today. The runner's own 12 tests in `lesson-contradiction-runner.test.ts` already cover the orchestration contract this wiring depends on (load → detect → record → demote, error isolation, no-op short-circuit). Adding a digest-level test for 3.55 alone would set a precedent that retroactively requires tests for 3.5 / 3.6 / 3.7 too — out of scope.

## Test plan

- [x] `cd mcp-server && rm -rf dist && npm run build` clean
- [x] `npm test` — **828 / 828 pass** on a clean dist
- [x] Existing `lesson-contradiction-runner.test.ts` (12 tests) untouched — the new dep bag is purely additive
- [ ] Reed merges; no migrations in this PR so no `bash scripts/migrate.sh` needed

Closes the wiring portion of #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)