### PR TITLE
feat(swarm): swarm_admit_lesson MCP tool — issue #143 receiver-side test slice

### DIFF
--- a/mcp-server/src/__tests__/swarm-admit.test.ts
+++ b/mcp-server/src/__tests__/swarm-admit.test.ts
@@ -1,0 +1,605 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+
+import {
+  SwarmAdmitService,
+  parseAdmitResponse,
+  type SwarmAdmitDeps,
+  type SwarmAdmitOutcome,
+} from "../services/swarm-admit.js";
+import {
+  swarmAdmitLesson,
+  swarmAdmitLessonSchema,
+} from "../tools/swarm-admit.js";
+import { sign } from "../services/signature.js";
+import { computeNodeId } from "../services/node-identity.js";
+import { WIRE_SPEC_VERSION } from "../services/wire-types.js";
+import type { HttpResponseShape } from "../swarm/endpoints/lesson-admission.js";
+
+// ---------------------------------------------------------------------------
+// swarm_admit_lesson — fifth and final write-side slice of issue #143
+//
+// Three contracts:
+//   1. parseAdmitResponse maps the handler's HttpResponseShape into the
+//      typed SwarmAdmitOutcome union. Throws on shape drift (missing
+//      lesson_id on 201, non-JSON body) so a future handler edit fails
+//      loud rather than silently mis-shaping the MCP output.
+//   2. SwarmAdmitService.admit threads the deps bag into admitSwarmLesson
+//      and returns a typed outcome — exercising the happy path and the
+//      five rejection branches end-to-end against the same in-memory
+//      harness lesson-admission.test.ts uses.
+//   3. swarmAdmitLesson tool refuses without OPENCLAW_ALLOW_SWARM_WRITE=1,
+//      writes a memory-bus row only on a 201, and surfaces operator-
+//      actionable fix_hints on every non-201 decision.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// (1) parseAdmitResponse — pure mapper
+// ---------------------------------------------------------------------------
+
+function jsonRes(status: number, body: unknown): HttpResponseShape {
+  return {
+    status,
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify(body),
+  };
+}
+
+test("parseAdmitResponse maps a 201 into the admitted outcome", () => {
+  const out = parseAdmitResponse(
+    jsonRes(201, {
+      lesson_id: "11111111-2222-4333-8444-555555555555",
+      lesson_tier: "B",
+      contradictions: 0,
+      origin_node_id: "QmFakePeerId",
+    }),
+  );
+  assert.equal(out.decision, "admitted");
+  if (out.decision !== "admitted") return;
+  assert.equal(out.lesson_id, "11111111-2222-4333-8444-555555555555");
+  assert.equal(out.lesson_tier, "B");
+  assert.deepEqual(out.contradicts_with, []);
+  assert.equal(out.trust_delta, 0.05);
+  assert.equal(out.origin_node_id, "QmFakePeerId");
+  assert.equal(out.http_status, 201);
+});
+
+test("parseAdmitResponse throws on a 201 with missing lesson_id (shape drift loud)", () => {
+  assert.throws(
+    () => parseAdmitResponse(jsonRes(201, { lesson_tier: "B" })),
+    /201 body missing/i,
+  );
+});
+
+test("parseAdmitResponse throws on non-JSON body (shape drift loud)", () => {
+  assert.throws(
+    () =>
+      parseAdmitResponse({
+        status: 500,
+        headers: {},
+        body: "<html>upstream down</html>",
+      }),
+    /non-JSON body/i,
+  );
+});
+
+test("parseAdmitResponse maps a 403 onto decision='quarantined'", () => {
+  const out = parseAdmitResponse(
+    jsonRes(403, {
+      error: "origin is currently quarantined",
+      origin_node_id: "QmPeer",
+      quarantined_until: "2026-05-02T13:00:00.000Z",
+    }),
+  );
+  assert.equal(out.decision, "quarantined");
+  assert.equal(out.http_status, 403);
+  assert.equal((out as { origin_node_id?: string }).origin_node_id, "QmPeer");
+  assert.equal((out as { quarantined?: boolean }).quarantined, false); // pre-check, not a fresh quarantine
+});
+
+test("parseAdmitResponse maps a 401 unknown-peer onto decision='unknown_peer'", () => {
+  const out = parseAdmitResponse(
+    jsonRes(401, {
+      error: "unknown peer; pubkey not held for origin_node_id",
+      origin_node_id: "QmStranger",
+    }),
+  );
+  assert.equal(out.decision, "unknown_peer");
+});
+
+test("parseAdmitResponse maps a 400 self-loop onto decision='self_loop'", () => {
+  const out = parseAdmitResponse(
+    jsonRes(400, {
+      error: "admission of self-published lesson refused (use producer path)",
+      origin_node_id: "QmSelf",
+    }),
+  );
+  assert.equal(out.decision, "self_loop");
+});
+
+test("parseAdmitResponse maps a 401+rule5 onto decision='rejected' with quarantined=true", () => {
+  const out = parseAdmitResponse(
+    jsonRes(401, {
+      error: "wire validation rejected record",
+      rule: 5,
+      reason: "ed25519 verify returned false",
+      origin_node_id: "QmSpoof",
+      quarantined: true,
+    }),
+  );
+  assert.equal(out.decision, "rejected");
+  assert.equal((out as { rule?: number }).rule, 5);
+  assert.equal((out as { quarantined?: boolean }).quarantined, true);
+});
+
+test("parseAdmitResponse maps a 503 onto decision='internal_error'", () => {
+  const out = parseAdmitResponse(
+    jsonRes(503, {
+      error: "insertSwarmLesson failed",
+      detail: "ECONNREFUSED 127.0.0.1:5432",
+    }),
+  );
+  assert.equal(out.decision, "internal_error");
+  assert.equal((out as { detail?: string }).detail, "ECONNREFUSED 127.0.0.1:5432");
+});
+
+// ---------------------------------------------------------------------------
+// (2) SwarmAdmitService.admit — orchestration end-to-end with a real signer
+// ---------------------------------------------------------------------------
+
+interface Identity {
+  pem: string;
+  pubkeyRaw: Uint8Array;
+  pubkeyB64: string;
+  nodeId: string;
+}
+
+function freshIdentity(): Identity {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ type: "spki", format: "der" });
+  const pubkeyRaw = new Uint8Array(spki.subarray(spki.length - 32));
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  return {
+    pem,
+    pubkeyRaw,
+    pubkeyB64: Buffer.from(pubkeyRaw).toString("base64"),
+    nodeId: computeNodeId(Buffer.from(pubkeyRaw)),
+  };
+}
+
+function full768(seed = 0): number[] {
+  const out = new Array<number>(768);
+  for (let i = 0; i < 768; i++) out[i] = (seed + i) / 1000;
+  return out;
+}
+
+function buildValidEnvelope(
+  producer: Identity,
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  const unsigned = {
+    id: "11111111-2222-4333-8444-555555555555",
+    content: "Receivers must firebreak admitted lessons at Tier-B by default.",
+    embedding: full768(),
+    synthesized_from_cluster_size: 4,
+    origin_node_id: producer.nodeId,
+    signed_at: "2026-04-28T11:00:00.000Z",
+    created_at: "2026-04-27T10:00:00.000Z",
+    tags: ["test", "swarm"],
+    spec_version: WIRE_SPEC_VERSION,
+    evidence_root: "1220" + "ab".repeat(32),
+    evidence_count: 4,
+    prev_lesson_hash: null,
+    maturity_age_days: 1,
+    useful_count: 0,
+    ...overrides,
+  };
+  return { ...unsigned, signature: sign(unsigned, producer.pem) };
+}
+
+interface DepsHarness {
+  deps: SwarmAdmitDeps;
+  inserted: Array<{ id: string; lesson_tier: string }>;
+  trust: Array<{ node_id: string; delta: number; reason: string }>;
+  quarantines: Array<{ node_id: string; until_ms: number; reason: string }>;
+}
+
+function buildHarness(opts: {
+  self: Identity;
+  knownPeers?: Map<string, Identity>;
+  quarantinedUntil?: Map<string, string>;
+  failInsert?: boolean;
+  failTrust?: boolean;
+  loadSelfThrows?: boolean;
+}): DepsHarness {
+  const inserted: DepsHarness["inserted"] = [];
+  const trust: DepsHarness["trust"] = [];
+  const quarantines: DepsHarness["quarantines"] = [];
+  return {
+    inserted,
+    trust,
+    quarantines,
+    deps: {
+      loadSelf: async () => {
+        if (opts.loadSelfThrows) throw new Error("loadSelf boom");
+        return { node_id: opts.self.nodeId, pubkey_b64: opts.self.pubkeyB64 };
+      },
+      getPubkeyForNode: async (nodeId) => {
+        const peer = opts.knownPeers?.get(nodeId);
+        return peer ? peer.pubkeyRaw : null;
+      },
+      getQuarantinedUntil: async (nodeId) =>
+        opts.quarantinedUntil?.get(nodeId) ?? null,
+      insertSwarmLesson: async (row) => {
+        if (opts.failInsert) throw new Error("insert boom");
+        inserted.push({ id: row.id, lesson_tier: row.lesson_tier });
+        return { lesson_id: row.id };
+      },
+      setQuarantine: async (node_id, until_ms, reason) => {
+        quarantines.push({ node_id, until_ms, reason });
+      },
+      recordTrustEdgeChange: async (node_id, delta, reason) => {
+        if (opts.failTrust) throw new Error("trust boom");
+        trust.push({ node_id, delta, reason });
+      },
+    },
+  };
+}
+
+const FIXED_NOW = new Date("2026-04-28T12:00:00.000Z");
+
+test("admit returns 'admitted' on a valid v1.1 envelope and pins lesson_tier='B'", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const h = buildHarness({
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+  const envelope = buildValidEnvelope(peer);
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+
+  assert.equal(out.decision, "admitted");
+  if (out.decision !== "admitted") return;
+  assert.equal(out.lesson_tier, "B");
+  assert.equal(out.trust_delta, 0.05);
+  assert.equal(out.origin_node_id, peer.nodeId);
+  // §10.6 firebreak: every admitted row lands at B.
+  assert.equal(h.inserted[0].lesson_tier, "B");
+  assert.equal(h.trust[0].delta, 0.05);
+  assert.equal(h.trust[0].reason, "admitted");
+});
+
+test("admit returns 'self_loop' when the envelope claims this node as origin", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const envelope = buildValidEnvelope(self);
+  const h = buildHarness({ self });
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+  assert.equal(out.decision, "self_loop");
+  assert.equal(h.inserted.length, 0, "self-loop must not persist");
+});
+
+test("admit returns 'unknown_peer' when the producer's pubkey is not held", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const h = buildHarness({ self, knownPeers: new Map() });
+  const envelope = buildValidEnvelope(peer);
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+  assert.equal(out.decision, "unknown_peer");
+  // No edge to quarantine — §10.2 single-strike only fires for known peers.
+  assert.equal(h.quarantines.length, 0);
+});
+
+test("admit returns 'quarantined' on a peer with a future quarantined_until", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const futureIso = new Date(FIXED_NOW.getTime() + 30 * 60 * 1000).toISOString();
+  const h = buildHarness({
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    quarantinedUntil: new Map([[peer.nodeId, futureIso]]),
+  });
+  const envelope = buildValidEnvelope(peer);
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+  assert.equal(out.decision, "quarantined");
+  // Pre-check is decision-only — never re-quarantines.
+  assert.equal(h.quarantines.length, 0);
+  assert.equal(h.inserted.length, 0);
+});
+
+test("admit returns 'rejected' with rule=5 + quarantined=true on bad signature", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const envelope = buildValidEnvelope(peer);
+  // Tamper the signature so rule 5 fails.
+  envelope.signature = "BADBASE64=";
+  const h = buildHarness({
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+  });
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+  assert.equal(out.decision, "rejected");
+  assert.equal((out as { rule?: number }).rule, 5);
+  assert.equal((out as { quarantined?: boolean }).quarantined, true);
+  // §10.2 single-strike: handler called setQuarantine.
+  assert.equal(h.quarantines.length, 1);
+  assert.equal(h.quarantines[0].reason, "wire-rule-5");
+});
+
+test("admit returns 'internal_error' when insertSwarmLesson throws", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const h = buildHarness({
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    failInsert: true,
+  });
+  const envelope = buildValidEnvelope(peer);
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+  assert.equal(out.decision, "internal_error");
+});
+
+test("admit still returns 'admitted' when the trust-edge bump throws (best-effort)", async () => {
+  const svc = new SwarmAdmitService("http://stub", "stub");
+  const self = freshIdentity();
+  const peer = freshIdentity();
+  const h = buildHarness({
+    self,
+    knownPeers: new Map([[peer.nodeId, peer]]),
+    failTrust: true,
+  });
+  const envelope = buildValidEnvelope(peer);
+
+  const out = await svc.admit(envelope, h.deps, { now: FIXED_NOW });
+  // Lesson is durable; trust failure degrades reputation accuracy, not correctness.
+  assert.equal(out.decision, "admitted");
+  assert.equal(h.inserted.length, 1);
+  assert.equal(h.trust.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// (3) MCP tool: ethics-gate, fix_hints, memory side-effect
+// ---------------------------------------------------------------------------
+
+const FAKE_ENVELOPE = { id: "irrelevant — gate refuses before validation" };
+
+test("swarmAdmitLesson refuses when OPENCLAW_ALLOW_SWARM_WRITE is unset", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  try {
+    const stubSvc = {} as unknown as SwarmAdmitService;
+    const stubMem = {} as unknown as Parameters<typeof swarmAdmitLesson>[1];
+    const out = await swarmAdmitLesson(stubSvc, stubMem, { envelope: FAKE_ENVELOPE });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+    assert.ok(out.fix_hint);
+  } finally {
+    if (original !== undefined) process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmAdmitLesson refuses with non-'1' env values (only '1' opens the gate)", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "true";
+  try {
+    const stubSvc = {} as unknown as SwarmAdmitService;
+    const stubMem = {} as unknown as Parameters<typeof swarmAdmitLesson>[1];
+    const out = await swarmAdmitLesson(stubSvc, stubMem, { envelope: FAKE_ENVELOPE });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /OPENCLAW_ALLOW_SWARM_WRITE/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmAdmitLessonSchema accepts an object envelope and rejects non-objects", () => {
+  const ok = swarmAdmitLessonSchema.safeParse({ envelope: { id: "x" } });
+  assert.equal(ok.success, true);
+  // Non-object envelope is rejected by Zod.
+  const bad1 = swarmAdmitLessonSchema.safeParse({ envelope: "not-an-object" });
+  assert.equal(bad1.success, false);
+  const bad2 = swarmAdmitLessonSchema.safeParse({ envelope: 42 });
+  assert.equal(bad2.success, false);
+});
+
+// Tool happy-path + memory side-effect — uses a fake service that returns a
+// canned outcome so we can pin the memory metadata shape without spinning
+// up Supabase.
+test("swarmAdmitLesson writes a decisions/swarm memory on a 201 admit", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    const fakeSvc = {
+      defaultDeps: () => ({}) as SwarmAdmitDeps,
+      admit: async () =>
+        ({
+          decision: "admitted",
+          lesson_id: "11111111-2222-4333-8444-555555555555",
+          lesson_tier: "B",
+          contradicts_with: [],
+          trust_delta: 0.05,
+          origin_node_id: "QmPeerXYZ",
+          http_status: 201,
+        }) as SwarmAdmitOutcome,
+    } as unknown as SwarmAdmitService;
+    const created: Array<Record<string, unknown>> = [];
+    const fakeMem = {
+      create: async (row: Record<string, unknown>) => {
+        created.push(row);
+      },
+    } as unknown as Parameters<typeof swarmAdmitLesson>[1];
+
+    const out = await swarmAdmitLesson(fakeSvc, fakeMem, {
+      envelope: FAKE_ENVELOPE,
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.decision, "admitted");
+    assert.equal(out.lesson_id, "11111111-2222-4333-8444-555555555555");
+    assert.equal(out.memory_recorded, true);
+    assert.equal(created.length, 1);
+    assert.equal(created[0].category, "decisions");
+    assert.deepEqual(
+      (created[0].tags as string[]).slice(0, 2),
+      ["swarm", "lesson-admitted"],
+    );
+    const meta = created[0].metadata as Record<string, unknown>;
+    assert.equal(meta.lesson_id, "11111111-2222-4333-8444-555555555555");
+    assert.equal(meta.origin_node_id, "QmPeerXYZ");
+    assert.equal(meta.source, "swarm_admit_lesson");
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmAdmitLesson reports memory failure as memory_error but still ok=true", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    const fakeSvc = {
+      defaultDeps: () => ({}) as SwarmAdmitDeps,
+      admit: async () =>
+        ({
+          decision: "admitted",
+          lesson_id: "11111111-2222-4333-8444-555555555555",
+          lesson_tier: "B",
+          contradicts_with: [],
+          trust_delta: 0.05,
+          origin_node_id: "QmPeerXYZ",
+          http_status: 201,
+        }) as SwarmAdmitOutcome,
+    } as unknown as SwarmAdmitService;
+    const fakeMem = {
+      create: async () => {
+        throw new Error("ollama down");
+      },
+    } as unknown as Parameters<typeof swarmAdmitLesson>[1];
+
+    const out = await swarmAdmitLesson(fakeSvc, fakeMem, {
+      envelope: FAKE_ENVELOPE,
+    });
+    // Lesson admission is durable; the memory row is convenience.
+    assert.equal(out.ok, true);
+    assert.equal(out.memory_recorded, false);
+    assert.match(out.memory_error ?? "", /ollama down/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmAdmitLesson surfaces a fix_hint specific to each non-201 decision", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    const cases: Array<{ outcome: SwarmAdmitOutcome; hintMatch: RegExp }> = [
+      {
+        outcome: {
+          decision: "self_loop",
+          http_status: 400,
+          quarantined: false,
+          error: "self-published",
+        },
+        hintMatch: /producer path/i,
+      },
+      {
+        outcome: {
+          decision: "unknown_peer",
+          http_status: 401,
+          quarantined: false,
+          error: "unknown peer",
+        },
+        hintMatch: /pubkey_b64url/i,
+      },
+      {
+        outcome: {
+          decision: "quarantined",
+          http_status: 403,
+          quarantined: false,
+          error: "origin is currently quarantined",
+        },
+        hintMatch: /quarantine window/i,
+      },
+      {
+        outcome: {
+          decision: "rejected",
+          http_status: 401,
+          rule: 5,
+          quarantined: true,
+          error: "wire validation rejected record",
+        },
+        hintMatch: /single-strike/i,
+      },
+      {
+        outcome: {
+          decision: "internal_error",
+          http_status: 503,
+          quarantined: false,
+          error: "insertSwarmLesson failed",
+        },
+        hintMatch: /dashboard logs/i,
+      },
+    ];
+
+    for (const c of cases) {
+      const fakeSvc = {
+        defaultDeps: () => ({}) as SwarmAdmitDeps,
+        admit: async () => c.outcome,
+      } as unknown as SwarmAdmitService;
+      const fakeMem = {
+        create: async () => {
+          throw new Error("memory shouldn't be touched on non-201");
+        },
+      } as unknown as Parameters<typeof swarmAdmitLesson>[1];
+      const out = await swarmAdmitLesson(fakeSvc, fakeMem, {
+        envelope: FAKE_ENVELOPE,
+      });
+      assert.equal(out.ok, false);
+      assert.equal(out.decision, c.outcome.decision);
+      assert.match(out.fix_hint ?? "", c.hintMatch);
+    }
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});
+
+test("swarmAdmitLesson translates a service-layer throw into ok=false + fix_hint", async () => {
+  const original = process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+  process.env.OPENCLAW_ALLOW_SWARM_WRITE = "1";
+  try {
+    const fakeSvc = {
+      defaultDeps: () => {
+        throw new Error("supabase unreachable");
+      },
+      admit: async () => {
+        throw new Error("never reached");
+      },
+    } as unknown as SwarmAdmitService;
+    const fakeMem = {
+      create: async () => {},
+    } as unknown as Parameters<typeof swarmAdmitLesson>[1];
+    const out = await swarmAdmitLesson(fakeSvc, fakeMem, {
+      envelope: FAKE_ENVELOPE,
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error ?? "", /supabase unreachable/);
+    assert.match(out.fix_hint ?? "", /init-node-identity/);
+  } finally {
+    if (original === undefined) delete process.env.OPENCLAW_ALLOW_SWARM_WRITE;
+    else process.env.OPENCLAW_ALLOW_SWARM_WRITE = original;
+  }
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -165,6 +165,10 @@ import { SwarmPeersService } from "./services/swarm-peers.js";
 import {
   swarmListPeersSchema, swarmListPeers,
 } from "./tools/swarm-peers.js";
+import { SwarmAdmitService } from "./services/swarm-admit.js";
+import {
+  swarmAdmitLessonSchema, swarmAdmitLessonHandler,
+} from "./tools/swarm-admit.js";
 import {
   getSelfModelSchema, getSelfModel,
   updateSelfModelSchema, updateSelfModel,
@@ -236,6 +240,7 @@ const relationsService      = new RelationsService(SUPABASE_URL, SUPABASE_KEY);
 const nodeIdentityService   = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPinService       = new SwarmPinService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPeersService     = new SwarmPeersService(SUPABASE_URL, SUPABASE_KEY);
+const swarmAdmitService     = new SwarmAdmitService(SUPABASE_URL, SUPABASE_KEY);
 const remAuditService       = new RemAuditService(SUPABASE_URL, SUPABASE_KEY);
 const remPromotionService   = new RemPromotionService(SUPABASE_URL, SUPABASE_KEY);
 const remDiversityService   = new RemDiversityService(SUPABASE_URL, SUPABASE_KEY);
@@ -902,6 +907,25 @@ server.tool(
   "List swarm peers known to this node with their §10 trust state: trust_weight, quarantine flag, last_seen_at, last decay reason, latest trust_edge_log delta, and 24h admission count. Pass includeSelf=true to also return the self row. Read-only.",
   swarmListPeersSchema.shape,
   withErrorHandling((input) => swarmListPeers(swarmPeersService, swarmListPeersSchema.parse(input)))
+);
+
+// --- swarm phase 4 write-side: receiver-side admission (issue #143, last) ---
+// Fifth and final write-side slice of issue #143's MCP-tool surface. Runs a
+// v1.1 Lesson envelope through the same admission pipeline the
+// `POST /swarm/lessons` HTTP endpoint uses (PR #154 substrate, PR #163
+// wiring) — useful for local single-node integration testing without
+// spinning up a second peer. §10.6 firebreak: every admitted row lands at
+// lesson_tier='B' regardless of how it arrived; promotion to A is the
+// exclusive job of RemPromotionService (corroboration) or swarm_pin_lesson
+// (operator override). Behind OPENCLAW_ALLOW_SWARM_WRITE=1 (mirrors
+// swarm_pin_lesson and swarm_resolve_contradict).
+server.tool(
+  "swarm_admit_lesson",
+  "Receiver-side test entrypoint: take a v1.1 Lesson envelope (object) and run the same admission pipeline `POST /swarm/lessons` uses. Returns {ok, decision, lesson_id?, lesson_tier='B', contradicts_with?, trust_delta?, origin_node_id?, rule?, quarantined?, fix_hint?}. §10.6 firebreak: admitted rows always land at Tier-B. REQUIRES OPENCLAW_ALLOW_SWARM_WRITE=1 — refuses with a structured error otherwise. Also writes a 'decisions'-category memory tagged 'swarm' on a 201 (best-effort).",
+  swarmAdmitLessonSchema.shape,
+  withErrorHandling((input) =>
+    swarmAdmitLessonHandler(swarmAdmitService, memoryService, swarmAdmitLessonSchema.parse(input)),
+  ),
 );
 
 /* DEFERRED 2026-04-26 — pairing (tinder) + federation-PKI + federation Phase 2.

--- a/mcp-server/src/services/swarm-admit.ts
+++ b/mcp-server/src/services/swarm-admit.ts
@@ -1,0 +1,352 @@
+/**
+ * Swarm admit-lesson service — Phase 4 / issue #143 receiver-side test slice.
+ *
+ * Wraps the pure `admitSwarmLesson` HTTP-shaped handler from
+ * `swarm/endpoints/lesson-admission.ts` with a TS-friendly orchestrator that
+ * builds the side-effect bag against Supabase + `NodeIdentityService`. Two
+ * surfaces share the same handler and therefore the same admission
+ * semantics:
+ *
+ *   - HTTP host (PR #163): peer posts a v1.1 envelope to `POST /swarm/lessons`.
+ *   - This MCP tool: an LLM agent or local test driver passes the envelope
+ *     in-process. Useful for single-node integration testing without
+ *     spinning up a second peer (#143 explicitly motivates this).
+ *
+ * Both wirings respect the §10.6 firebreak: every admitted row lands at
+ * `lesson_tier='B'` regardless of how it arrived; promotion to A is the
+ * exclusive job of `RemPromotionService` (corroboration) or
+ * `swarm_pin_lesson` (operator override).
+ *
+ * Design boundaries — same calls the dashboard wiring (#163) deliberately
+ * leaves un-wired:
+ *
+ *   1. `getExpectedPrevLessonHash` — receiver-side rule-19 needs a
+ *      per-origin `received_lesson_chain` table that does not yet exist
+ *      in the substrate. Producer-side `lesson_chain` (mig 074) does NOT
+ *      cover this. Follow-up issue.
+ *   2. `runContradictionGate` — the §10.3 gate runs out-of-band via
+ *      `LessonContradictionRunner` (PR #148 substrate, PR #164 wiring) on
+ *      the digest cycle. Wiring it inline here would require loading +
+ *      iterating priors per call; the asynchronous REM self-audit (§10.5)
+ *      plus the digest-side runner already cover the same ground. The
+ *      `contradicts_with` field in the tool output therefore reports the
+ *      empty array on success — callers learn about contradictions via
+ *      the digest's experience log, not the admit response.
+ *
+ * Both deferrals keep this slice tight (mirror of the dashboard wiring's
+ * shape) and reviewable on its own — adding the gate or rule 19 doubles
+ * the surface and would block on a substrate change anyway.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import {
+  admitSwarmLesson,
+  type HttpResponseShape,
+  type LessonAdmissionDeps,
+} from "../swarm/endpoints/lesson-admission.js";
+import { NodeIdentityService } from "./node-identity.js";
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+export type SwarmAdmitDecision =
+  | "admitted"
+  | "rejected"
+  | "quarantined"
+  | "self_loop"
+  | "unknown_peer"
+  | "internal_error";
+
+/**
+ * Typed projection of the handler's HttpResponseShape into the surface
+ * issue #143 specifies. The handler returns either a 201 with a small
+ * JSON envelope or a 4xx/503 with `{ error, ... }` — we collapse those
+ * into one `SwarmAdmitOutcome` discriminated union the MCP layer can
+ * pattern-match on without re-parsing the response body.
+ */
+export interface SwarmAdmitSuccess {
+  decision: "admitted";
+  lesson_id: string;
+  lesson_tier: "B";
+  /** UUIDs of priors flagged by the §10.3 gate. Always empty in this
+   *  slice — the gate is wired by `LessonContradictionRunner` on the
+   *  digest cycle, not inline at admission time. See module header. */
+  contradicts_with: string[];
+  /** §10.1 +0.05 "admitted" trust bump applied to `origin_node_id`. */
+  trust_delta: number;
+  origin_node_id: string;
+  http_status: 201;
+}
+
+export interface SwarmAdmitFailure {
+  decision: Exclude<SwarmAdmitDecision, "admitted">;
+  http_status: number;
+  /** §5 wire rule the validator rejected on, when the failure came from
+   *  validation. Absent for pre-validation guards (self-loop, unknown
+   *  peer, quarantine pre-check, body shape). */
+  rule?: number;
+  /** True when the rejection pulled the producer into the §10.2
+   *  single-strike 1-hour quarantine (rules 5 / 16 / 19 / 20). */
+  quarantined: boolean;
+  error: string;
+  origin_node_id?: string;
+  detail?: string;
+}
+
+export type SwarmAdmitOutcome = SwarmAdmitSuccess | SwarmAdmitFailure;
+
+/**
+ * Parse the handler's HttpResponseShape into a typed outcome. Throws on
+ * shape drift (missing `lesson_id` on 201, non-JSON body) so a future
+ * handler edit fails loud rather than silently feeding `undefined` into
+ * the memory-bus side-effect.
+ */
+export function parseAdmitResponse(res: HttpResponseShape): SwarmAdmitOutcome {
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(res.body) as Record<string, unknown>;
+  } catch (e) {
+    throw new Error(
+      `swarm_admit_lesson: handler returned non-JSON body (status=${res.status}, body=${res.body.slice(0, 200)})`,
+    );
+  }
+
+  if (res.status === 201) {
+    const lesson_id = body.lesson_id;
+    const lesson_tier = body.lesson_tier;
+    const origin_node_id = body.origin_node_id;
+    if (typeof lesson_id !== "string" || lesson_tier !== "B" || typeof origin_node_id !== "string") {
+      throw new Error(
+        `swarm_admit_lesson: 201 body missing lesson_id / lesson_tier='B' / origin_node_id (raw=${JSON.stringify(body)})`,
+      );
+    }
+    return {
+      decision: "admitted",
+      lesson_id,
+      lesson_tier: "B",
+      // Gate is deferred (see header). The digest-cycle runner discovers
+      // contradicts asynchronously and writes to swarm_lesson_contradictions.
+      contradicts_with: [],
+      trust_delta: 0.05,
+      origin_node_id,
+      http_status: 201,
+    };
+  }
+
+  // Failure path. Map status + body shape onto the discriminated decision.
+  const error = typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
+  const origin_node_id = typeof body.origin_node_id === "string" ? body.origin_node_id : undefined;
+  const rule = typeof body.rule === "number" ? body.rule : undefined;
+  const quarantined = body.quarantined === true;
+
+  let decision: Exclude<SwarmAdmitDecision, "admitted">;
+  if (res.status === 403) {
+    decision = "quarantined";
+  } else if (res.status === 401 && /unknown peer/i.test(error)) {
+    decision = "unknown_peer";
+  } else if (res.status === 400 && /self-published/i.test(error)) {
+    decision = "self_loop";
+  } else if (res.status >= 500) {
+    decision = "internal_error";
+  } else {
+    decision = "rejected";
+  }
+
+  return {
+    decision,
+    http_status: res.status,
+    rule,
+    quarantined,
+    error,
+    origin_node_id,
+    detail: typeof body.detail === "string" ? body.detail : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Side-effect dep bag — shape mirrors LessonAdmissionDeps but we own the
+// `body` and `now` fields ourselves and let callers inject only the IO.
+// ---------------------------------------------------------------------------
+
+export interface SwarmAdmitDeps {
+  /** Self-row from `nodes.is_self=true`. Same shape `loadSelf` expects. */
+  loadSelf: LessonAdmissionDeps["loadSelf"];
+  /** Raw 32-byte Ed25519 pubkey for `node_id`, or null when unknown. */
+  getPubkeyForNode: LessonAdmissionDeps["getPubkeyForNode"];
+  /** Current `quarantined_until` ISO-8601, or null when not quarantined. */
+  getQuarantinedUntil: LessonAdmissionDeps["getQuarantinedUntil"];
+  /** Persist the validated lesson to `swarm_lessons` at lesson_tier='B'. */
+  insertSwarmLesson: LessonAdmissionDeps["insertSwarmLesson"];
+  /** Set `nodes.quarantined_until` (single-strike per §5/§10.2). */
+  setQuarantine: LessonAdmissionDeps["setQuarantine"];
+  /** Append `(node_id, delta, reason)` to the trust log (§10.1). */
+  recordTrustEdgeChange: LessonAdmissionDeps["recordTrustEdgeChange"];
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class SwarmAdmitService {
+  private db: SupabaseClient;
+  private nodeIdentity: NodeIdentityService;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.db = createClient(supabaseUrl, supabaseKey);
+    this.nodeIdentity = new NodeIdentityService(supabaseUrl, supabaseKey);
+  }
+
+  /**
+   * Run the admission pipeline on a single envelope and return a typed
+   * outcome. `now` defaults to wall-clock; tests inject a fixed Date so
+   * quarantine windows are deterministic.
+   */
+  async admit(
+    envelope: unknown,
+    deps: SwarmAdmitDeps,
+    opts: { now?: Date; ourSpecMajor?: number } = {},
+  ): Promise<SwarmAdmitOutcome> {
+    const res = await admitSwarmLesson({
+      body: envelope,
+      ourSpecMajor: opts.ourSpecMajor ?? 1,
+      now: opts.now ?? new Date(),
+      loadSelf: deps.loadSelf,
+      getPubkeyForNode: deps.getPubkeyForNode,
+      getQuarantinedUntil: deps.getQuarantinedUntil,
+      insertSwarmLesson: deps.insertSwarmLesson,
+      setQuarantine: deps.setQuarantine,
+      recordTrustEdgeChange: deps.recordTrustEdgeChange,
+      // Deferred — see module header. Both rule-19 chain tracking and the
+      // §10.3 gate land in follow-up slices.
+      // getExpectedPrevLessonHash: undefined,
+      // runContradictionGate:      undefined,
+    });
+    return parseAdmitResponse(res);
+  }
+
+  /**
+   * Default deps wired against this service's own SupabaseClient and
+   * NodeIdentityService. Mirror of `SwarmPinService.defaultDeps`. Same
+   * five callbacks the dashboard wiring (#163) constructs by hand.
+   */
+  defaultDeps(): SwarmAdmitDeps {
+    const db = this.db;
+    const nodeIdentity = this.nodeIdentity;
+    return {
+      loadSelf: async () => {
+        const self = await nodeIdentity.getSelf();
+        if (!self) return null;
+        return { node_id: self.node_id, pubkey_b64: self.pubkey_b64 };
+      },
+      getPubkeyForNode: async (nodeId) => {
+        const { data, error } = await db
+          .from("nodes")
+          .select("pubkey_b64url")
+          .eq("node_id", nodeId)
+          .maybeSingle();
+        if (error) {
+          throw new Error(`nodes.pubkey_b64url fetch failed: ${error.message ?? String(error)}`);
+        }
+        if (!data) return null;
+        const b64 = (data as { pubkey_b64url: string | null }).pubkey_b64url;
+        if (typeof b64 !== "string" || b64.length === 0) return null;
+        return decodeB64Url(b64);
+      },
+      getQuarantinedUntil: async (nodeId) => {
+        const { data, error } = await db
+          .from("nodes")
+          .select("quarantined_until")
+          .eq("node_id", nodeId)
+          .maybeSingle();
+        if (error) {
+          throw new Error(`nodes.quarantined_until fetch failed: ${error.message ?? String(error)}`);
+        }
+        if (!data) return null;
+        return (data as { quarantined_until: string | null }).quarantined_until ?? null;
+      },
+      insertSwarmLesson: async (lesson) => {
+        const { data, error } = await db
+          .from("swarm_lessons")
+          .insert({
+            id:                            lesson.id,
+            content:                       lesson.content,
+            embedding:                     lesson.embedding,
+            synthesized_from_cluster_size: lesson.synthesized_from_cluster_size,
+            origin_node_id:                lesson.origin_node_id,
+            signed_at:                     lesson.signed_at,
+            created_at:                    lesson.created_at,
+            signature:                     lesson.signature,
+            tags:                          lesson.tags ?? null,
+            spec_version:                  lesson.spec_version,
+            // §10.6 firebreak — admitted rows land at B regardless of
+            // what the producer claimed. Promotion is the exclusive job
+            // of RemPromotionService / swarm_pin_lesson.
+            lesson_tier:                   "B",
+          })
+          .select("id")
+          .single();
+        if (error) {
+          throw new Error(`swarm_lessons insert failed: ${error.message ?? String(error)}`);
+        }
+        const row = data as { id: string } | null;
+        return { lesson_id: row?.id ?? lesson.id };
+      },
+      setQuarantine: async (nodeId, untilMs, reason) => {
+        // Direct UPDATE — the quarantine_origin RPC enforces p_days > 0
+        // which can't represent the §10.2 1-hour single-strike window.
+        // Same trade-off the dashboard wiring (#163) takes.
+        const { error } = await db
+          .from("nodes")
+          .update({
+            quarantined_until: new Date(untilMs).toISOString(),
+            decay_reason:      reason,
+          })
+          .eq("node_id", nodeId);
+        if (error) {
+          throw new Error(`nodes setQuarantine failed: ${error.message ?? String(error)}`);
+        }
+      },
+      recordTrustEdgeChange: async (nodeId, delta, reason) => {
+        // The §10.1 contract is delta-based ("+0.05 admitted"); the RPC
+        // sets an absolute new_weight. Read-modify-write so the audit
+        // row carries the before→after pair the §10.1 semantics expect.
+        // Same shape the dashboard wiring (#163) uses.
+        const { data: nodeRow, error: nodeErr } = await db
+          .from("nodes")
+          .select("trust_weight")
+          .eq("node_id", nodeId)
+          .maybeSingle();
+        if (nodeErr) {
+          throw new Error(`nodes.trust_weight fetch failed: ${nodeErr.message ?? String(nodeErr)}`);
+        }
+        const before = nodeRow ? Number((nodeRow as { trust_weight: number }).trust_weight ?? 0.5) : 0.5;
+        const next = Math.max(0, Math.min(1, before + delta));
+        const { error: rpcErr } = await db.rpc("record_trust_edge_change", {
+          p_node_id:    nodeId,
+          p_new_weight: next,
+          p_reason:     reason,
+        });
+        if (rpcErr) {
+          throw new Error(`record_trust_edge_change RPC failed: ${rpcErr.message ?? String(rpcErr)}`);
+        }
+      },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode a URL-safe or standard base64 string (with or without padding)
+ * into a raw byte array. Mirrors the dashboard wiring's helper so the
+ * MCP path and the HTTP path agree on what counts as a valid pubkey
+ * encoding.
+ */
+function decodeB64Url(s: string): Uint8Array {
+  const std = s.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = std.length % 4 === 0 ? std : std + "=".repeat(4 - (std.length % 4));
+  return new Uint8Array(Buffer.from(pad, "base64"));
+}

--- a/mcp-server/src/tools/swarm-admit.ts
+++ b/mcp-server/src/tools/swarm-admit.ts
@@ -1,0 +1,238 @@
+/**
+ * `swarm_admit_lesson` MCP tool — fifth and final write-side slice of
+ * issue #143.
+ *
+ * Receiver-side test entrypoint: takes a v1.1 Lesson envelope (full body,
+ * not just the id) and runs it through the same admission pipeline the
+ * `POST /swarm/lessons` HTTP endpoint uses (PR #154 substrate, PR #163
+ * wiring). Useful for local single-node integration testing without
+ * spinning up a second peer — the intent #143 explicitly calls out.
+ *
+ * Behind `OPENCLAW_ALLOW_SWARM_WRITE=1` (mirrors `swarm_pin_lesson` and
+ * `swarm_resolve_contradict`): admission INSERTs a `swarm_lessons` row
+ * and bumps trust + (potentially) quarantines a peer. None of those
+ * writes should happen without explicit operator opt-in.
+ *
+ * Memory-bus side-effect on a successful 201: a `decisions`-category
+ * memory tagged `swarm` so the agent's own admit decisions become
+ * recallable. Best-effort — the durable record is the swarm_lessons row
+ * + the trust_edge_log audit; the memory row is a recall convenience for
+ * the agent's own future introspection ("did I admit anything from peer
+ * X in the last hour?").
+ */
+
+import { z } from "zod";
+import { MemoryService } from "../services/supabase.js";
+import {
+  SwarmAdmitService,
+  type SwarmAdmitOutcome,
+  type SwarmAdmitSuccess,
+} from "../services/swarm-admit.js";
+
+export const swarmAdmitLessonSchema = z.object({
+  envelope: z
+    .record(z.unknown())
+    .describe(
+      "Full v1.1 Lesson envelope as a JSON object — id, content, embedding, " +
+        "synthesized_from_cluster_size, origin_node_id, signed_at, created_at, " +
+        "signature, spec_version, evidence_root, evidence_count, " +
+        "prev_lesson_hash, maturity_age_days, useful_count, optional tags. " +
+        "The wire-validator (§5 rules 1-13/16/19/20) re-checks every field; " +
+        "no client-side trust is granted to the shape.",
+    ),
+});
+
+export type SwarmAdmitLessonInput = z.infer<typeof swarmAdmitLessonSchema>;
+
+export interface SwarmAdmitLessonOutput {
+  ok: boolean;
+  /** Stable machine-readable decision tag, present on every response. */
+  decision?: SwarmAdmitOutcome["decision"];
+  http_status?: number;
+  /** Populated on `decision='admitted'`. */
+  lesson_id?: string;
+  lesson_tier?: "B";
+  contradicts_with?: string[];
+  trust_delta?: number;
+  origin_node_id?: string;
+  /** §5 wire rule the validator rejected on, when applicable. */
+  rule?: number;
+  /** True when the rejection pulled the producer into quarantine. */
+  quarantined?: boolean;
+  memory_recorded?: boolean;
+  memory_error?: string;
+  error?: string;
+  fix_hint?: string;
+  detail?: string;
+}
+
+export interface McpToolResult {
+  content: { type: "text"; text: string }[];
+}
+
+function asMcpResult(payload: SwarmAdmitLessonOutput): McpToolResult {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+/**
+ * Ethics-gate check. Mirrors `swarm_pin_lesson` and
+ * `swarm_resolve_contradict`. Admission INSERTs a swarm_lessons row,
+ * bumps trust on the origin, and may quarantine a peer for an hour —
+ * all writes the §3.4 / §10.6 firebreak requires explicit operator
+ * consent for.
+ */
+function isSwarmWriteAllowed(): boolean {
+  return process.env.OPENCLAW_ALLOW_SWARM_WRITE === "1";
+}
+
+/**
+ * Map a non-201 outcome's decision tag onto an operator-actionable hint.
+ * The §5 rule numbers in the body let an LLM caller correlate with
+ * `docs/SWARM_SPEC.md` if it has the spec in context.
+ */
+function fixHintFor(out: Exclude<SwarmAdmitOutcome, SwarmAdmitSuccess>): string {
+  switch (out.decision) {
+    case "self_loop":
+      return "The envelope's origin_node_id matches this node's own node_id. " +
+        "Self-published lessons go through the producer path (swarm_publish_tier_a_lesson), " +
+        "never the admission endpoint.";
+    case "unknown_peer":
+      return "No pubkey is held for the envelope's origin_node_id. " +
+        "Register the peer first (insert into nodes with pubkey_b64url) before admission.";
+    case "quarantined":
+      return "The origin is currently quarantined — admission will resume after the " +
+        "quarantine window expires. Quarantine state is per-peer in nodes.quarantined_until.";
+    case "internal_error":
+      return "A dependency (DB, signature lookup) threw. Inspect the dashboard logs " +
+        "or the response detail field for the underlying cause.";
+    case "rejected":
+      if (out.rule === 5 || out.rule === 19) {
+        return `Wire rule ${out.rule} failed — signature or chain mismatch. ` +
+          "The producer has been quarantined for one hour (§10.2 single-strike). " +
+          "Re-sign the envelope with the matching key, or wait for quarantine to lift.";
+      }
+      if (out.rule === 16 || out.rule === 20) {
+        return `Wire rule ${out.rule} failed — proof-of-knowledge shape rejected. ` +
+          "Quarantined for one hour (§10.2 single-strike). Verify evidence_root and " +
+          "evidence_count against the producer's lesson_evidence_origin table.";
+      }
+      if (typeof out.rule === "number") {
+        return `Wire rule ${out.rule} failed — see docs/SWARM_SPEC.md §5 for the rule body. ` +
+          "No quarantine for non-single-strike rules; fix the envelope and retry.";
+      }
+      return "Pre-validation guard rejected the envelope. Inspect the error string for " +
+        "the specific cause (body shape, missing origin_node_id, malformed UUID).";
+  }
+}
+
+function describeAdmitOutcome(out: SwarmAdmitSuccess): string {
+  return (
+    `Admitted swarm lesson ${out.lesson_id} from peer ${out.origin_node_id} at tier B ` +
+    `(§10.6 firebreak). Trust +${out.trust_delta.toFixed(2)} applied via §10.1.`
+  );
+}
+
+/**
+ * Pure handler — exposed for unit tests so they don't have to unwrap the
+ * MCP `content` envelope. Same split as `swarm_pin_lesson` and
+ * `swarm_resolve_contradict`.
+ */
+export async function swarmAdmitLesson(
+  service: SwarmAdmitService,
+  memoryService: MemoryService,
+  input: SwarmAdmitLessonInput,
+): Promise<SwarmAdmitLessonOutput> {
+  if (!isSwarmWriteAllowed()) {
+    return {
+      ok: false,
+      error: "swarm_admit_lesson requires OPENCLAW_ALLOW_SWARM_WRITE=1",
+      fix_hint:
+        "Operator must opt in by setting OPENCLAW_ALLOW_SWARM_WRITE=1 in " +
+        "the MCP server environment. Without it, no MCP tool can write to " +
+        "the swarm trust substrate (§3.4 / §10.6 firebreak).",
+    };
+  }
+
+  let outcome: SwarmAdmitOutcome;
+  try {
+    outcome = await service.admit(input.envelope, service.defaultDeps());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: message,
+      fix_hint:
+        "Service-layer throw before the handler returned. " +
+        "Likely a Supabase outage or a self-row that hasn't been bootstrapped — " +
+        "run scripts/init-node-identity.mjs and check docker compose status.",
+    };
+  }
+
+  if (outcome.decision !== "admitted") {
+    return {
+      ok: false,
+      decision: outcome.decision,
+      http_status: outcome.http_status,
+      rule: outcome.rule,
+      quarantined: outcome.quarantined,
+      origin_node_id: outcome.origin_node_id,
+      error: outcome.error,
+      detail: outcome.detail,
+      fix_hint: fixHintFor(outcome),
+    };
+  }
+
+  // Best-effort memory side-effect — see module header.
+  let memory_recorded = false;
+  let memory_error: string | undefined;
+  try {
+    await memoryService.create({
+      content: describeAdmitOutcome(outcome),
+      category: "decisions",
+      tags: ["swarm", "lesson-admitted", `origin-${outcome.origin_node_id.slice(0, 12)}`],
+      metadata: {
+        lesson_id:      outcome.lesson_id,
+        origin_node_id: outcome.origin_node_id,
+        lesson_tier:    outcome.lesson_tier,
+        trust_delta:    outcome.trust_delta,
+        source:         "swarm_admit_lesson",
+      },
+      source: "swarm_admit_lesson",
+    });
+    memory_recorded = true;
+  } catch (err) {
+    memory_error = err instanceof Error ? err.message : String(err);
+  }
+
+  return {
+    ok: true,
+    decision: "admitted",
+    http_status: 201,
+    lesson_id: outcome.lesson_id,
+    lesson_tier: outcome.lesson_tier,
+    contradicts_with: outcome.contradicts_with,
+    trust_delta: outcome.trust_delta,
+    origin_node_id: outcome.origin_node_id,
+    memory_recorded,
+    ...(memory_error ? { memory_error } : {}),
+  };
+}
+
+/**
+ * MCP-facing adapter — wraps the pure handler's result in the
+ * `{ content: [{ type, text }] }` envelope that `withErrorHandling`
+ * expects. Same convention as `swarmPinLessonHandler` and
+ * `swarmResolveContradictHandler`.
+ */
+export async function swarmAdmitLessonHandler(
+  service: SwarmAdmitService,
+  memoryService: MemoryService,
+  input: SwarmAdmitLessonInput,
+): Promise<McpToolResult> {
+  const output = await swarmAdmitLesson(service, memoryService, input);
+  return asMcpResult(output);
+}


### PR DESCRIPTION
## Summary

Fifth and final write-side slice of issue #143's MCP-tool surface (after `swarm_pin_lesson` #150, `swarm_list_peers` #149, `swarm_resolve_contradict` PR #161, `swarm_publish_tier_a_lesson` PR #162).

Wraps the pure `admitSwarmLesson` handler from PR #154 with a TS-friendly orchestrator that builds the side-effect bag against Supabase + `NodeIdentityService` — the same five callbacks the dashboard wiring (PR #163) constructs by hand. Both surfaces share the same handler and therefore the same admission semantics:

| Surface | Caller | Wiring |
|---|---|---|
| HTTP (`POST /swarm/lessons`) | Peer node over the wire | PR #163 (open) |
| MCP (`swarm_admit_lesson`) | Local LLM agent / test driver | This PR |

§10.6 firebreak: every admitted row lands at `lesson_tier='B'` regardless of how it arrived. Promotion to A is the exclusive job of `RemPromotionService` (corroboration) or `swarm_pin_lesson` (operator override).

## Why a dedicated MCP entrypoint

Issue #143 explicitly calls out this surface: *"useful for local single-node integration testing without needing a second node"*. The HTTP path requires a second peer to even exercise; the MCP path lets a local test driver feed envelopes directly.

The MCP version is also the cheapest way for an LLM agent to drive an admission decision when the dashboard isn't running (e.g. headless CI or post-incident replay).

## Behind the OPENCLAW_ALLOW_SWARM_WRITE=1 ethics gate

Mirrors `swarm_pin_lesson` (#150) and `swarm_resolve_contradict` (#161). Admission INSERTs a `swarm_lessons` row, bumps trust on the origin (§10.1 +0.05 admitted), and may quarantine a peer for one hour (§10.2 single-strike on rules 5/16/19/20). All three are firebreak-protected substrate writes — no agent should mutate that without explicit operator opt-in.

## Two callbacks deliberately deferred

Mirror of the dashboard wiring's stance:

1. **`getExpectedPrevLessonHash`** — receiver-side rule 19 (broken commitment chain) needs a per-origin `received_lesson_chain` table the substrate doesn't yet provide. Producer-side `lesson_chain` (mig 074) does NOT cover this. Follow-up issue.
2. **`runContradictionGate`** — the §10.3 gate runs out-of-band via `LessonContradictionRunner` (PR #148 substrate, PR #164 wiring) on the digest cycle. Wiring it inline here would require loading + iterating priors per call; the asynchronous REM self-audit (§10.5) plus the digest-side runner already cover the same ground. The `contradicts_with` field in the tool output reports the empty array on success — callers learn about contradictions via the digest's experience log, not the admit response.

Both deferrals keep this slice tight and reviewable on its own — adding either doubles the surface and would block on a substrate change anyway. Documented in the source comments above `SwarmAdmitService` and `index.ts`.

## Output shape (per issue #143)

```jsonc
// Success
{
  "ok": true,
  "decision": "admitted",
  "http_status": 201,
  "lesson_id": "11111111-2222-4333-8444-555555555555",
  "lesson_tier": "B",
  "contradicts_with": [],     // empty until the gate is wired
  "trust_delta": 0.05,
  "origin_node_id": "QmPeer…",
  "memory_recorded": true
}

// Failure (e.g. rule-5 bad signature)
{
  "ok": false,
  "decision": "rejected",
  "http_status": 401,
  "rule": 5,
  "quarantined": true,
  "error": "wire validation rejected record",
  "fix_hint": "Wire rule 5 failed — signature or chain mismatch. The producer has been quarantined for one hour (§10.2 single-strike). Re-sign the envelope with the matching key, or wait for quarantine to lift."
}
```

The `decision` tag is a stable machine-readable enum: `admitted`, `rejected`, `quarantined`, `self_loop`, `unknown_peer`, `internal_error`. Each non-`admitted` decision gets an operator-actionable `fix_hint`.

## Files

- **`mcp-server/src/services/swarm-admit.ts`** (~270 lines incl. doc) — `SwarmAdmitService.admit()` + `parseAdmitResponse` mapper (HttpResponseShape → discriminated `SwarmAdmitOutcome`). Throws on shape drift (missing `lesson_id` on 201, non-JSON body) so a future handler edit fails loud rather than silently mis-shaping the MCP output. `defaultDeps()` wires the five callbacks against `SupabaseClient` + `NodeIdentityService`. Mirror of `SwarmPinService.defaultDeps`.
- **`mcp-server/src/tools/swarm-admit.ts`** (~210 lines incl. doc) — Zod schema (`envelope: z.record(z.unknown())`), ethics gate (`OPENCLAW_ALLOW_SWARM_WRITE=1`), per-decision `fix_hint` mapper, best-effort memory-bus side-effect (`decisions`/`swarm` tag).
- **`mcp-server/src/__tests__/swarm-admit.test.ts`** (22 tests) — three coverage layers matching `swarm-resolve-contradict.test.ts`:
  - `parseAdmitResponse` mapping: 8 cases incl. shape-drift loud failures
  - `SwarmAdmitService.admit` end-to-end with a real Ed25519 signer (via `freshIdentity` + `sign`): 6 branches (admitted, self_loop, unknown_peer, quarantined, rejected +rule5+quarantine, internal_error, best-effort trust failure still admits)
  - Tool ethics gate (unset env, non-`'1'` env values), Zod schema (object accepted, non-object rejected), best-effort memory contract (admit still succeeds when memory write fails), `fix_hint` per decision (5 decisions), service-throw translation
- **`mcp-server/src/index.ts`** — 7 lines wiring (import, service construction, `server.tool` registration), symmetric with `swarm_pin_lesson`.

## Acceptance criteria from #143 (this slice)

- [x] Tool registered in `mcp-server/src/index.ts` with proper schema
- [x] Write tool refuses without `OPENCLAW_ALLOW_SWARM_WRITE=1` and returns a structured `{ error, fix_hint }`
- [x] Unit + service-orchestration tests with injected deps (no live DB needed, no second peer needed)
- [x] Tool description includes enough context for an LLM to use without further prompting
- [x] Memory-bus side-effect: each successful admit also writes a memory entry with category `decisions` and tag `swarm`

## Test plan

- [x] `cd mcp-server && rm -rf dist && npm run build` — clean
- [x] `npm test` — **850/850 pass** (22 new + 828 prior, no regressions)
- [x] No migration — handler substrate (PR #154) and trust columns (mig 071, 075) are already on main
- [ ] Reed merges; with this slice issue #143's MCP-tool surface is complete and the issue can close

## Out of scope

- Dashboard wiring of `POST /swarm/lessons` — PR #163 (separate, open).
- §10.3 contradiction gate inline at admit time — follow-up; the digest-cycle runner (PR #148 substrate, PR #164 wiring) covers the same ground asynchronously.
- Receiver-side rule 19 chain tracking — needs a `received_lesson_chain` substrate table; follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)