### PR TITLE
ci: GitHub Actions workflow runs mcp-server tests on PRs

### DIFF
--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -23,7 +23,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 22 — `node --test` glob expansion ("**/*.test.js") is
+          # only supported on >=22 even though package.json engines is
+          # >=20. Bumping just CI here, not the engines field.
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: mcp-server/package-lock.json
 

--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -1,0 +1,37 @@
+name: mcp-server tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mcp-server/**'
+      - '.github/workflows/mcp-server-tests.yml'
+  pull_request:
+    paths:
+      - 'mcp-server/**'
+      - '.github/workflows/mcp-server-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/mcp-server-tests.yml`: checkout → Node 20 (npm cache) → `npm ci` → `npm run build` → `npm test`.
- Triggers on pushes to `main` and on PRs, scoped via `paths:` to `mcp-server/**` and the workflow file itself, so unrelated changes don't burn CI minutes.
- 10-minute job timeout (local run is ~6s / 828 tests, no external services required).

## Why

The 8 currently-open PRs all show empty `gh pr checks` output — there is no CI configured, so each merge requires manual local verification. That's been a recurring drag in the autonomous-tick loop and on Reed's manual merge workflow. This closes the gap with the smallest possible workflow file.

After this lands, future PRs will surface green/red status directly in the queue, which:
- Gives the manual merger immediate confidence signal.
- Lets the autonomous tick read `gh pr checks` to decide merge order without re-running tests.

## Test plan

- [ ] CI runs on this PR itself and goes green.
- [ ] After merge, the next PR touching `mcp-server/` triggers the workflow and reports a check status.
- [ ] A docs-only PR (no `mcp-server/**` change) does NOT trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)