### PR TITLE
feat(dashboard): operator peer-trust override buttons — issue #142 second frontend slice

### DIFF
--- a/dashboard/i18n/de.json
+++ b/dashboard/i18n/de.json
@@ -96,6 +96,12 @@
   "card.swarm.trustlog.sub": "jede positive oder negative änderung am peer-vertrauen mit grund. quelle für audit.",
   "card.swarm.diversity": "REM diversitäts-audit",
   "card.swarm.diversity.sub": "der nächtliche REM-zyklus prüft, ob lessons aus zu wenigen quellen stammen oder einander zu ähnlich sind, und drückt das gewicht runter — die anti-echo-chamber-mechanik aus §10.4.",
+  "swarm.peer.action_col": "aktion",
+  "swarm.peer.distrust": "vertrauen aufheben",
+  "swarm.peer.restore": "vertrauen wiederherstellen",
+  "swarm.peer.distrust.confirm": "vertrauen zu diesem peer auf 0 setzen und 30 tage in quarantäne schicken? eingehende lessons werden bis dahin abgewiesen.",
+  "swarm.peer.restore.confirm": "vertrauen zu diesem peer auf den default 0.5 zurücksetzen und quarantäne aufheben?",
+  "swarm.peer.error": "operator-aktion fehlgeschlagen: {detail}",
   "intro.emergence": "<b>Emergenz</b> sind Momente, in denen der Agent etwas tut, das nicht direkt aus seiner Programmierung folgt — er widerspricht seinen eigenen Grundsätzen, lehnt eine Aufgabe begründet ab, formuliert ein neues Ziel, drückt unaufgefordert Unsicherheit aus, bildet eine stabile Meinung über jemanden. Solche Momente werden erfasst, damit du sie sehen und einordnen kannst.<span class=\"sub\">Sechs Indikatoren werden erkannt — vier automatisch aus den Daten, zwei aus den Tagesereignissen des Agenten.</span>",
   "intro.neurochemistry": "Drei chemische Signale steuern den inneren Zustand des Agenten — analog zur menschlichen Neurochemie. <b>Dopamin</b> misst, wie gut Vorhersagen passen (Lernfortschritt). <b>Serotonin</b> bestimmt Geduld und Planungsweite. <b>Noradrenalin</b> regelt Wachheit und Fokus.<span class=\"sub\">Die vier klassischen Affekt-Werte (Neugier, Zufriedenheit, Selbstvertrauen, Frustration) werden aus diesen drei Signalen abgeleitet.</span>",
 

--- a/dashboard/i18n/en.json
+++ b/dashboard/i18n/en.json
@@ -96,6 +96,12 @@
   "card.swarm.trustlog.sub": "every positive or negative change to peer trust with reason. audit trail.",
   "card.swarm.diversity": "REM diversity audit",
   "card.swarm.diversity.sub": "the nightly REM cycle checks whether lessons come from too few sources or are too similar, and dampens their weight — the anti-echo-chamber mechanic from §10.4.",
+  "swarm.peer.action_col": "action",
+  "swarm.peer.distrust": "revoke trust",
+  "swarm.peer.restore": "restore trust",
+  "swarm.peer.distrust.confirm": "set trust for this peer to 0 and quarantine for 30 days? inbound lessons will be rejected until then.",
+  "swarm.peer.restore.confirm": "reset trust for this peer to the default 0.5 and clear quarantine?",
+  "swarm.peer.error": "operator action failed: {detail}",
   "intro.emergence": "<b>Emergence</b> moments are when the agent does something that doesn't follow directly from its programming — contradicting its own principles, refusing a task with reasoning, formulating a new goal, expressing unprompted uncertainty, forming a stable opinion of someone. These moments are recorded so you can see and weigh them.<span class=\"sub\">Six indicators are detected — four automatically from data, two from the agent's daily events.</span>",
   "intro.neurochemistry": "Three chemical signals steer the agent's inner state — analogous to human neurochemistry. <b>Dopamine</b> measures how well predictions match (learning progress). <b>Serotonin</b> sets patience and planning horizon. <b>Noradrenaline</b> regulates arousal and focus.<span class=\"sub\">The four classic affect values (curiosity, satisfaction, confidence, frustration) are derived from these three signals.</span>",
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1123,6 +1123,27 @@
     background: color-mix(in srgb, var(--text-faint) 60%, transparent);
   }
 
+  /* Operator actions on the peer-trust table — small button row in the      */
+  /* last column. Mirrors .contradicts-actions discipline (compact, confirm  */
+  /* before destructive op, disabled while POST is in flight).               */
+  .peer-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+  .peer-actions button {
+    font-size: 11px; line-height: 1.2; padding: 4px 8px;
+    border-radius: var(--radius-sm); cursor: pointer;
+    border: 1px solid var(--border); background: var(--bg-elev-2);
+    color: var(--text); font-family: inherit;
+  }
+  .peer-actions button:hover { border-color: var(--accent); }
+  .peer-actions button.distrust {
+    border-color: color-mix(in srgb, var(--bad) 35%, transparent);
+    color: var(--bad);
+  }
+  .peer-actions button.restore {
+    border-color: color-mix(in srgb, var(--good) 35%, transparent);
+    color: var(--good);
+  }
+  .peer-actions button:disabled { opacity: 0.5; cursor: wait; }
+
   /* Mini-timeline for promotion / trust log entries.                         */
   .swarm-timeline { display: flex; flex-direction: column; gap: 0; }
   .swarm-timeline .row {
@@ -3366,14 +3387,14 @@ async function loadSwarm() {
       trustTbl.innerHTML = `<thead><tr><th></th></tr></thead><tbody><tr><td class="empty">keine peers bekannt — der schwarm hat noch genau einen knoten (dich).</td></tr></tbody>`;
     } else {
       trustTbl.innerHTML = `
-        <thead><tr><th>peer</th><th>vertrauen</th><th>letzter kontakt</th><th>grund</th></tr></thead>
+        <thead><tr><th>peer</th><th>vertrauen</th><th>letzter kontakt</th><th>grund</th><th>${tt("swarm.peer.action_col")}</th></tr></thead>
         <tbody>${peersList.map(p => {
           const tw = clamp(Number(p.trust_weight ?? 0), -1, 1);
           const left = ((tw + 1) / 2) * 100;
           const cls = tw > 0.05 ? "pos" : tw < -0.05 ? "neg" : "";
           const quarantined = p.quarantined_until && new Date(p.quarantined_until) > new Date();
           const label = quarantined ? `<span class="tier-badge tier-quarantined">quarantäne</span>` : `<span class="meta">${tw.toFixed(2)}</span>`;
-          return `<tr>
+          return `<tr data-node-id="${escapeHtml(p.node_id || "")}">
             <td class="meta" title="${escapeHtml(p.node_id || "")}">${escapeHtml(p.display_name || shortNode(p.node_id))}</td>
             <td>
               <div class="trust-meter">
@@ -3384,8 +3405,21 @@ async function loadSwarm() {
             </td>
             <td class="meta">${formatDate(p.last_seen_at)}</td>
             <td class="meta">${escapeHtml(p.trust_reason || "—")}</td>
+            <td>
+              <div class="peer-actions">
+                <button class="distrust" data-action="distrust">${tt("swarm.peer.distrust")}</button>
+                <button class="restore" data-action="restore">${tt("swarm.peer.restore")}</button>
+              </div>
+            </td>
           </tr>`;
         }).join("")}</tbody>`;
+      trustTbl.querySelectorAll(".peer-actions button").forEach(btn => {
+        btn.addEventListener("click", () => {
+          const row = btn.closest("tr");
+          if (!row) return;
+          overrideTrust(row.dataset.nodeId, btn.dataset.action, row);
+        });
+      });
     }
 
     // ── Contradicts list ─────────────────────────────────────────────────
@@ -3474,6 +3508,33 @@ async function loadSwarm() {
     if (kpis) {
       kpis.innerHTML = `<div class="card"><div class="kpi"><div class="label">fehler</div><div class="value tone-bad">—</div><div class="hint">${escapeHtml(e.message || String(e))}</div></div></div>`;
     }
+  }
+}
+
+async function overrideTrust(nodeId, action, rowEl) {
+  if (!nodeId || !["distrust", "restore"].includes(action)) return;
+  const promptKey = action === "distrust"
+    ? "swarm.peer.distrust.confirm"
+    : "swarm.peer.restore.confirm";
+  if (!window.confirm(tt(promptKey))) return;
+  const buttons = rowEl ? rowEl.querySelectorAll("button") : [];
+  buttons.forEach(b => { b.disabled = true; });
+  try {
+    const r = await fetch("/swarm/peer-trust-override", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node_id: nodeId, action }),
+    });
+    if (!r.ok) {
+      const err = await r.json().catch(() => ({}));
+      alert(tt("swarm.peer.error", { detail: err.detail || err.error || `HTTP ${r.status}` }));
+      buttons.forEach(b => { b.disabled = false; });
+      return;
+    }
+    await loadSwarm();
+  } catch (e) {
+    alert(tt("swarm.peer.error", { detail: String(e?.message || e) }));
+    buttons.forEach(b => { b.disabled = false; });
   }
 }
 

--- a/mcp-server/src/__tests__/dashboard-server-peer-trust-wiring.test.ts
+++ b/mcp-server/src/__tests__/dashboard-server-peer-trust-wiring.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Contract test for the wiring of POST /swarm/peer-trust-override into
+ * scripts/dashboard-server.mjs and the operator action buttons in
+ * dashboard/index.html (Swarm phase 4, issue #142 frontend slice).
+ *
+ * The substrate (migrations 075 record_trust_edge_change + quarantine_origin)
+ * and the dashboard POST handler shipped in PR #157 with their own coverage.
+ * This test pins the pieces the HTTP host has to assemble so a future
+ * refactor can't silently break the operator round-trip:
+ *
+ *   1. The dispatcher routes POST /swarm/peer-trust-override to the handler.
+ *   2. The handler enforces the {distrust, restore} action whitelist and
+ *      composes the existing audit-trail RPCs (record_trust_edge_change for
+ *      both branches; quarantine_origin for distrust; PATCH /nodes for the
+ *      quarantine-clear on restore — no clear_quarantine RPC exists).
+ *   3. The dashboard renders 2 action buttons per peer row with data-action
+ *      values matching the whitelist, and the click handler POSTs to
+ *      /swarm/peer-trust-override before re-fetching loadSwarm().
+ *
+ * Same shape-pin discipline as dashboard-server-lesson-proof-wiring.test.ts:
+ * neither file is part of the tsc test loop, so we read both as text and
+ * assert structural facts (comments stripped before matching so an
+ * explanatory comment cannot satisfy a structural assertion).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../../..");
+const DASHBOARD_SERVER = resolve(ROOT, "scripts/dashboard-server.mjs");
+const DASHBOARD_HTML = resolve(ROOT, "dashboard/index.html");
+
+const SERVER_RAW = readFileSync(DASHBOARD_SERVER, "utf8");
+const SERVER_NO_COMMENTS = SERVER_RAW
+  .replace(/\/\/[^\n]*/g, "")
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+
+const HTML_RAW = readFileSync(DASHBOARD_HTML, "utf8");
+const HTML_NO_COMMENTS = HTML_RAW
+  .replace(/<!--[\s\S]*?-->/g, "")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/\/\/[^\n]*/g, "");
+
+// ---------------------------------------------------------------------------
+// (1) The dispatcher routes POST /swarm/peer-trust-override to the handler.
+// ---------------------------------------------------------------------------
+
+test("dashboard-server registers the /swarm/peer-trust-override route", () => {
+  assert.match(
+    SERVER_NO_COMMENTS,
+    /req\.url\s*===\s*"\/swarm\/peer-trust-override"\s*\)\s*return\s+handleSwarmPeerTrustOverride/,
+    "dispatcher must route /swarm/peer-trust-override to " +
+      "handleSwarmPeerTrustOverride",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) Handler shape: action whitelist + audit-trail RPCs for both branches.
+// ---------------------------------------------------------------------------
+
+function handlerBody(): string {
+  const start = SERVER_NO_COMMENTS.indexOf(
+    "function handleSwarmPeerTrustOverride",
+  );
+  assert.ok(start > 0, "handleSwarmPeerTrustOverride must exist");
+  const end = SERVER_NO_COMMENTS.indexOf("function handleSwarm", start + 1);
+  return SERVER_NO_COMMENTS.slice(start, end > 0 ? end : start + 6000);
+}
+
+test("handleSwarmPeerTrustOverride enforces the {distrust, restore} action whitelist", () => {
+  // The handler validates at the HTTP boundary — invalid actions get
+  // rejected before any RPC round-trip reaches the database.
+  assert.match(
+    handlerBody(),
+    /\["distrust",\s*"restore"\]|'distrust',\s*'restore'|"distrust"\s*,\s*"restore"/,
+    "handleSwarmPeerTrustOverride must validate action against the " +
+      "{distrust, restore} whitelist before forwarding to the RPCs",
+  );
+});
+
+test("handleSwarmPeerTrustOverride writes to record_trust_edge_change with operator reasons", () => {
+  // record_trust_edge_change is the §10.1 audit-trail entry point. Both
+  // branches must go through it so trust_edge_log captures the operator
+  // override (and not just the underlying weight change).
+  const body = handlerBody();
+  assert.match(
+    body,
+    /callRpc\(\s*"record_trust_edge_change"/,
+    "handleSwarmPeerTrustOverride must invoke record_trust_edge_change " +
+      "to keep trust_edge_log as the single source of truth for trust " +
+      "movements",
+  );
+  assert.match(
+    body,
+    /"operator-override-distrust"/,
+    "distrust branch must annotate the trust_edge_log with the " +
+      "operator-override-distrust reason",
+  );
+  assert.match(
+    body,
+    /"operator-override-restore"/,
+    "restore branch must annotate the trust_edge_log with the " +
+      "operator-override-restore reason",
+  );
+});
+
+test("handleSwarmPeerTrustOverride distrust branch composes quarantine_origin", () => {
+  // §10.2 quarantine state machine. operator-override-distrust pushes the
+  // peer into quarantine immediately; without quarantine_origin the trust
+  // drop alone wouldn't suspend lesson admission.
+  assert.match(
+    handlerBody(),
+    /callRpc\(\s*"quarantine_origin"/,
+    "distrust branch must invoke quarantine_origin so the §10.2 state " +
+      "machine actually suspends lesson admission for the peer",
+  );
+});
+
+test("handleSwarmPeerTrustOverride restore branch clears quarantined_until via PATCH /nodes", () => {
+  // No clear_quarantine RPC exists; quarantine_origin enforces days > 0
+  // so it can't be reused. The restore branch goes through PostgREST with
+  // the same service-role JWT to UPDATE quarantined_until=NULL.
+  const body = handlerBody();
+  assert.match(
+    body,
+    /\/nodes\?node_id=eq\./,
+    "restore branch must PATCH /nodes?node_id=eq.<id> on PostgREST to " +
+      "clear the quarantined_until column directly",
+  );
+  assert.match(
+    body,
+    /quarantined_until:\s*null/,
+    "restore branch must explicitly set quarantined_until: null in the " +
+      "PATCH body — the §10.2 state machine treats NULL as 'not " +
+      "quarantined'",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) Frontend renders both operator buttons and wires the click path.
+// ---------------------------------------------------------------------------
+
+test("dashboard renders peer-trust action buttons with the {distrust, restore} actions", () => {
+  // Both actions must appear as data-action attributes inside the
+  // peer-actions block. A missing one would silently leave the operator
+  // unable to choose that branch.
+  for (const action of ["distrust", "restore"]) {
+    const re = new RegExp(`data-action="${action}"`);
+    assert.match(
+      HTML_NO_COMMENTS,
+      re,
+      `peer-actions must render a button with data-action="${action}" — ` +
+        `missing the ${action} branch would leave the operator unable to ` +
+        `choose it`,
+    );
+  }
+});
+
+test("peer table row carries the node_id for the click handler to forward", () => {
+  // The click handler reads row.dataset.nodeId. Without data-node-id on
+  // the <tr> the handler has nothing to send to /swarm/peer-trust-override
+  // and the POST would 400 with 'node_id required'.
+  assert.match(
+    HTML_NO_COMMENTS,
+    /<tr data-node-id=/,
+    "peer table rows must carry data-node-id so the click handler can " +
+      "forward node_id in the POST body",
+  );
+});
+
+test("overrideTrust posts to /swarm/peer-trust-override and re-fetches loadSwarm", () => {
+  const fnStart = HTML_NO_COMMENTS.indexOf("async function overrideTrust");
+  assert.ok(fnStart > 0, "overrideTrust function must exist");
+  // Bound the body to the next top-level function so this test can't be
+  // satisfied by an unrelated fetch elsewhere.
+  const fnEnd = HTML_NO_COMMENTS.indexOf("\nfunction ", fnStart + 1);
+  const body = HTML_NO_COMMENTS.slice(
+    fnStart,
+    fnEnd > 0 ? fnEnd : fnStart + 2000,
+  );
+  assert.match(
+    body,
+    /fetch\("\/swarm\/peer-trust-override"/,
+    "overrideTrust must POST to /swarm/peer-trust-override",
+  );
+  assert.match(
+    body,
+    /method:\s*"POST"/,
+    "overrideTrust fetch must use POST",
+  );
+  assert.match(
+    body,
+    /node_id:\s*nodeId/,
+    "overrideTrust must forward node_id in the JSON body",
+  );
+  assert.match(
+    body,
+    /action/,
+    "overrideTrust must forward the action in the JSON body",
+  );
+  assert.match(
+    body,
+    /loadSwarm\(\)/,
+    "overrideTrust must re-fetch loadSwarm() on success so the row " +
+      "reflects the new trust weight + cleared quarantine",
+  );
+});


### PR DESCRIPTION
## Summary

Second of three operator surfaces from #142 — wires the §10.1/§10.2 audit-trail RPCs (`record_trust_edge_change` + `quarantine_origin`, both shipped with migration 075) plus the POST handler from PR #157 into the schwarm tab so peer trust can actually be **overridden** by the operator instead of waiting for the §10.2 decay clock.

Companion to PR #167 (contradict-resolve frontend); same pattern, separate JS function + CSS class so the two slices don't conflict at the code level — only at the file level (both touch `dashboard/index.html` + the i18n files), which rebases cleanly.

The third surface (lesson-pin Tier-A) lands as a follow-up slice on the same migration.

## Change

**Frontend (`dashboard/index.html`, +44):**
- Peer-trust table grows a 5th **aktion** column with two buttons per row:
  - **vertrauen aufheben** → distrust (weight → 0.0, 30-day quarantine)
  - **vertrauen wiederherstellen** → restore (weight → 0.5, clear quarantine)
- `<tr data-node-id>` carries the node id; buttons carry `data-action`.
- Click wires to async `overrideTrust(nodeId, action, rowEl)`:
  - `window.confirm()` with action-specific copy
  - POST `/swarm/peer-trust-override` with `{node_id, action}`
  - on success → `loadSwarm()` re-fetch (the peer row reflects the new trust weight and the cleared quarantine immediately)
  - on failure → alert with the handler's error string (`peer-trust-override failed`, missing node, etc.)
- New CSS for `.peer-actions` (small button row, distrust red-tinted, restore green-tinted, disabled-while-pending).

**i18n (`dashboard/i18n/{de,en}.json`, +6 each):**
- 1 column header + 2 button labels + 2 confirm prompts + 1 error template, both locales.

**Contract test (`dashboard-server-peer-trust-wiring.test.ts`, new, 8 tests):**
- Pins the dispatcher route to `handleSwarmPeerTrustOverride`.
- Pins the `{distrust, restore}` whitelist on the HTTP boundary.
- Pins the audit-trail RPCs: `record_trust_edge_change` with the `operator-override-{distrust,restore}` reasons, `quarantine_origin` on the distrust branch, `PATCH /nodes` with `quarantined_until: null` on restore (no `clear_quarantine` RPC exists; `quarantine_origin` enforces `days > 0` so it can't be reused for the clear).
- Pins the frontend renders both `data-action` values + `data-node-id` on the `<tr>` + the `overrideTrust` POST + `loadSwarm()` re-fetch.

Same shape-pin discipline as `dashboard-server-contradict-resolve-wiring.test.ts` from PR #167 — neither file is in the tsc loop, both are read as text with comments stripped before structural matches.

## Constitution check

- **Pillar 3 (swarm intelligence — diversity & disagreement):** strengthened. Operator override closes the §10.2 quarantine release-valve gap — without this surface, only the decay clock could rehabilitate a peer flagged in error.
- **Pillar 6 (cyber security — substrate firebreak):** no new attack surface. Reuses the existing service-role JWT, the `{distrust, restore}` whitelist is enforced at the HTTP boundary, and the underlying writes go through `record_trust_edge_change` (audit-logged) + `quarantine_origin` (state-machine validated) or a PostgREST `PATCH` with the same JWT.
- No pillar weakened.

## Issue #142 status (after this lands)

| Operator surface | Substrate | Backend handler | Frontend | PR |
|---|---|---|---|---|
| Contradict resolve (a / b / park) | migration 086 | #157 | #167 | #167 |
| Peer-trust override (distrust / restore) | migration 075 | #157 | **THIS PR** | this |
| Lesson-pin (Tier-A pin) | migration 075 | #157 | — | open |

## Test plan

- [x] `npm test` in mcp-server: **836/836 green** (was 828 on main, +8 from this slice)
- [x] Contract test isolated: 8/8 pass
- [x] No conflicts with #167 at the JS-function or CSS-class level (`peer-actions` / `overrideTrust` vs `contradicts-actions` / `resolveContradict`)
- [ ] Live click test on local dashboard once Reed merges either #167 or this

🤖 Generated with [Claude Code](https://claude.com/claude-code)