### PR TITLE
fix(dashboard): synapses search expands the loaded subgraph (was visual-only)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6392,6 +6392,11 @@ const SYN = (() => {
     const q = new URLSearchParams({ limit: lim, min_weight: minW, hebbian: String(hebb) });
     if (cat) q.set("category", cat);
     if (br)  q.set("bridges", "1");
+    // Forward the search term so the server can pull in matching memories
+    // (and their relations) even when the recency-ordered top-N missed
+    // them. The frontend matcher then highlights the result in the
+    // expanded subgraph.
+    if (state.searchTerm) q.set("q", state.searchTerm);
     try {
       const r = await fetch(`/relations-graph?${q}`);
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -6719,7 +6724,20 @@ const SYN = (() => {
       });
     }
     refreshViewBadges();
-    $("syn-search").addEventListener("input", (e) => { state.searchTerm = e.target.value.trim(); });
+    // Search input — the frontend matcher highlights matching nodes already
+    // in the loaded subgraph (computeSearchHits, render-time). To make the
+    // search useful for memories that the recency-ordered top-N didn't load
+    // (typical for topic-class memories when project / decision relations
+    // dominate), we also debounce-trigger a server reload via load(): the
+    // backend's `q` expansion fetches matching memories + their relations
+    // and merges them into the next ingest. The 350 ms debounce keeps the
+    // graph from re-flying every keystroke.
+    let _synSearchTimer = null;
+    $("syn-search").addEventListener("input", (e) => {
+      state.searchTerm = e.target.value.trim();
+      if (_synSearchTimer) clearTimeout(_synSearchTimer);
+      _synSearchTimer = setTimeout(() => { load(); }, 350);
+    });
     $("syn-details-close").addEventListener("click", () => {
       state.selected = null;
       state.selDepth = null;

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -1261,6 +1261,21 @@ async function handleRelationsGraph(req, res) {
       parseFloat(url.searchParams.get("bridge_min_weight") || "0.5")));
     const bridgeTopK   = Math.min(500, parseInt(url.searchParams.get("bridge_top") || "300", 10) || 300);
 
+    // Search expansion. Without it, the recency-ordered limit budget (default
+    // 400 relations) is dominated by whatever has been moving lately —
+    // typically project / decision class memories — and topic-class memories
+    // can be entirely absent from the loaded subgraph. The frontend matcher
+    // can only highlight what is already loaded, so a search for a domain
+    // term ("audio", "rigging", …) silently returns zero hits even when the
+    // memory exists. When `q` is set we additionally fetch matching memories
+    // by content ILIKE / category EQ and pull their relations into the
+    // result set. Trim PostgREST control chars so an accidental "(" or ","
+    // can't break the or() grouping below.
+    const queryStr = (url.searchParams.get("q") || "")
+      .replace(/[(),*]/g, " ")
+      .trim()
+      .slice(0, 80);
+
     // --- 1) typed relations --------------------------------------------------
     const relsUrl = new URL("/memory_relations", UPSTREAM);
     relsUrl.searchParams.set("select", "a_id,b_id,type,weight,evidence_count,reason");
@@ -1280,6 +1295,57 @@ async function handleRelationsGraph(req, res) {
       weight: r.weight, evidence: r.evidence_count,
       reason: r.reason, kind: "typed",
     }));
+
+    // --- 1b) search expansion ------------------------------------------------
+    // Pull in memories that match the user's search and their relations, so
+    // they show up in the graph even if the recency-ordered top-N didn't
+    // happen to include them. Dedupe edges via the same (lo|hi|type) key the
+    // bridge step uses so we don't double-render an existing relation.
+    const searchHitIds = new Set();
+    if (queryStr) {
+      try {
+        const enc = encodeURIComponent(queryStr);
+        const sUrl = new URL(`/memories?select=id&or=(content.ilike.*${enc}*,category.eq.${enc})&limit=200`, UPSTREAM);
+        if (category) sUrl.searchParams.set("category", `eq.${category}`);
+        const sResp = await fetch(sUrl, {
+          headers: { Authorization: `Bearer ${SERVICE_JWT}`, apikey: SERVICE_JWT, Accept: "application/json" }
+        });
+        if (sResp.ok) {
+          const sRows = await sResp.json();
+          for (const r of sRows) searchHitIds.add(r.id);
+        }
+      } catch { /* best-effort — graph still renders without expansion */ }
+
+      if (searchHitIds.size > 0) {
+        const idList = [...searchHitIds].slice(0, 200).join(",");
+        const seen = new Set(edges.map(e => {
+          const lo = e.a < e.b ? e.a : e.b, hi = e.a < e.b ? e.b : e.a;
+          return `${lo}|${hi}|${e.type}`;
+        }));
+        try {
+          const erUrl = new URL(`/memory_relations?select=a_id,b_id,type,weight,evidence_count,reason&or=(a_id.in.(${idList}),b_id.in.(${idList}))&limit=400`, UPSTREAM);
+          if (types) erUrl.searchParams.set("type", `in.(${types})`);
+          const erResp = await fetch(erUrl, {
+            headers: { Authorization: `Bearer ${SERVICE_JWT}`, apikey: SERVICE_JWT, Accept: "application/json" }
+          });
+          if (erResp.ok) {
+            const erRows = await erResp.json();
+            for (const r of erRows) {
+              const lo = r.a_id < r.b_id ? r.a_id : r.b_id;
+              const hi = r.a_id < r.b_id ? r.b_id : r.a_id;
+              const k = `${lo}|${hi}|${r.type}`;
+              if (seen.has(k)) continue;
+              seen.add(k);
+              edges.push({
+                a: r.a_id, b: r.b_id, type: r.type,
+                weight: r.weight, evidence: r.evidence_count,
+                reason: r.reason, kind: "typed",
+              });
+            }
+          }
+        } catch { /* best-effort */ }
+      }
+    }
 
     // --- 2) optional Hebbian (undirected) -----------------------------------
     if (includeHebb) {
@@ -1369,6 +1435,10 @@ async function handleRelationsGraph(req, res) {
     const wantIds = new Set();
     for (const e of edges) { wantIds.add(e.a); wantIds.add(e.b); }
     for (const b of bridgeCandidates) { wantIds.add(b.a); wantIds.add(b.b); }
+    // Include search-matching memories even if they have zero relations — an
+    // isolated topic still belongs in the graph when its content matches the
+    // user's query, just as a single un-connected node.
+    for (const id of searchHitIds) wantIds.add(id);
 
     if (focusId && wantIds.has(focusId)) {
       // keep only edges reachable within `depth` hops from focusId


### PR DESCRIPTION
## Symptom (Reed)

> die suche im Tab Synapsen liefert keine Ergebnisse zu Themen

The synapsen tab's search input only highlighted nodes already in `state.nodes`. `/relations-graph` orders by `last_reinforced_at.desc` and caps at `limit` (default 400), so the loaded subgraph is dominated by recently-moved relations — typically project / decision class. Topic-class memories ("audio", "rigging", domain terms) often miss the cut entirely, and a search for them silently returns zero hits even when the memory exists.

## Fix

Wires the search input to the server so it actually pulls in matching memories.

**Backend (`scripts/dashboard-server.mjs handleRelationsGraph`)** — new `?q=<term>` parameter. When set:
- Pre-fetch up to 200 memories matching `content ILIKE *term*` OR `category EQ term`, optionally narrowed by the existing `category=` filter.
- Pull their relations via a separate `or=(a_id.in.(…),b_id.in.(…))` query (limit 400) and merge into the edges list, deduped against the recency-ordered top-N via the same `(lo|hi|type)` key the bridge step uses.
- Add the matching memory IDs to `wantIds` even when they have zero relations, so an isolated topic still appears as a floating hit.
- PostgREST control chars (`( ) , *`) stripped from the user query before it lands in the `or()` grouping; length capped at 80.

**Frontend (`dashboard/index.html`)** — the `#syn-search` input now debounce-triggers `load()` after 350 ms instead of only setting `state.searchTerm`. The matcher's `computeSearchHits` continues to drive the visual highlight on the freshly-ingested subgraph.

## Test plan

- [x] `node -c scripts/dashboard-server.mjs` — clean parse.
- [x] `npm test` in `mcp-server`: **872/872 green** (no behavioural change in the MCP server).
- [ ] Live: type a topic term in the synapses search field; the graph reloads with that topic's memories + their relations and the matcher highlights them.
- [ ] Live: clear the search; the graph returns to the default recency-ordered subgraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)