### PR TITLE
fix(install): defer 036_fix_ancestors_trigger — column ancestors does not exist on fresh installs

### DIFF
--- a/supabase/migrations.deferred/036_fix_ancestors_trigger.sql
+++ b/supabase/migrations.deferred/036_fix_ancestors_trigger.sql
@@ -1,5 +1,13 @@
 -- 036_fix_ancestors_trigger.sql — Fix für BEFORE-INSERT-Trigger
 --
+-- DEFERRED 2026-05-02: depends on the `ancestors` column added by
+-- 034_breeding_diversity.sql (which already lives here in
+-- supabase/migrations.deferred/). Ran in active migrations against a
+-- fresh install before the column existed → DO block at line 50–69
+-- failed with `column p.ancestors does not exist`. Moved here so the
+-- whole breeding-related stack travels together; revive together
+-- whenever the breeding/population phase is un-parked.
+--
 -- Bug: _genome_refresh_ancestors_trigger rief _genome_compute_ancestors(NEW.id)
 -- — aber bei BEFORE INSERT ist die Zeile noch nicht in der Tabelle, also gibt
 -- die rekursive Query 0 Ergebnisse. Konsequenz: Kinder hatten ancestors={}


### PR DESCRIPTION
## Reported externally

> psql: …/supabase/migrations/036_fix_ancestors_trigger.sql:72: **ERROR: column p.ancestors does not exist**
> LINE 9: SELECT UNNEST(p.ancestors)
> ERROR: 036_fix_ancestors_trigger.sql failed — aborting.
>
> I looked inside 024_agent_genome.sql and indeed ancestors column is missing from the table.

— Alex (fossura), via Reed.

## Root cause

| migration | status | role |
|---|---|---|
| `024_agent_genome.sql` | active | creates `agent_genomes` table — **no `ancestors` column** |
| `034_breeding_diversity.sql` | **deferred** | `ALTER TABLE … ADD COLUMN ancestors UUID[]` |
| `036_fix_ancestors_trigger.sql` | active | bug-fix for the trigger that **uses** `ancestors` |

`migrate.sh` runs every `*.sql` under `supabase/migrations/` in alpha order. On a fresh Postgres without the deferred breeding stack, 036's `DO $$ … $$` block at lines 50–69 references `g.ancestors` / `p.ancestors` — column doesn't exist → migration aborts → install dies.

The breeding / population stack was deferred per CLAUDE.md "Roadmap (Reed 2026-04-26)" — phases 4 and 5 parked. 033/034/035 already live in `supabase/migrations.deferred/`; 036 stayed behind in active by oversight.

## Fix

Move `036_fix_ancestors_trigger.sql` → `supabase/migrations.deferred/`, next to its 033/034/035 prerequisites. Header gets a `DEFERRED 2026-05-02` note explaining the dependency so the next maintainer sees the chain. When the breeding phase is un-parked, the four files travel together as one contiguous block.

Active install path is now clean: `024 → 025 → 026 → 027 → 028 → 029 → 030 → 031 → 032 → 037 → 039 → 042 → …`

## Out of scope (related observation, non-blocking)

`037_pki_lineage.sql` also references the deferred `profile_embedding` column inside `genome_profile_payload(p_label TEXT)`. PL/pgSQL bodies aren't validated at `CREATE FUNCTION` time, so 037 **installs cleanly** even without the column — but a call to `genome_profile_payload` would fail with the same shape of error. **Not Alex's bug** (his install errors at 036 first), but worth a follow-up to either guard 037 with a column-existence check or also defer it. Filing this as a known gotcha rather than including in this PR — minimum-viable fix unblocks the user.

## Test plan

- [x] Diff is a pure file-move + 8 lines of header note explaining the move. No code change in the migration body.
- [ ] Live: `bash scripts/migrate.sh` against a fresh Postgres reaches "All migrations applied successfully." — pending docker stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)