### PR TITLE
feat(dashboard): update banner — surface 'behind main' + show users how to update

### DIFF
--- a/dashboard/i18n/de.json
+++ b/dashboard/i18n/de.json
@@ -239,5 +239,18 @@
   "setup.client.verify": "So prüfst du, ob es klappt",
   "setup.client.docs": "Offizielle Doku",
 
-  "header.setup": "einrichtung"
+  "header.setup": "einrichtung",
+
+  "update.title": "Update verfügbar",
+  "update.sub_prefix": "Du läufst",
+  "update.commits": "Commits",
+  "update.sub_suffix": "hinter",
+  "update.latest": "Neueste Änderung:",
+  "update.howto": "So aktualisierst du:",
+  "update.step.easy": "am einfachsten",
+  "update.step.dblclick": "<strong>Doppelklick</strong> auf <code>update.command</code> im mycelium-Ordner.",
+  "update.step.terminal": "Terminal",
+  "update.step.cmd_intro": "Im Terminal ausführen:",
+  "update.copy": "kopieren",
+  "update.dismiss.aria": "Banner ausblenden"
 }

--- a/dashboard/i18n/en.json
+++ b/dashboard/i18n/en.json
@@ -239,5 +239,18 @@
   "setup.client.verify": "How to verify it works",
   "setup.client.docs": "Official docs",
 
-  "header.setup": "setup"
+  "header.setup": "setup",
+
+  "update.title": "Update available",
+  "update.sub_prefix": "Your local copy is",
+  "update.commits": "commits",
+  "update.sub_suffix": "behind",
+  "update.latest": "Latest change:",
+  "update.howto": "How to update:",
+  "update.step.easy": "easiest",
+  "update.step.dblclick": "<strong>Double-click</strong> <code>update.command</code> in the mycelium folder.",
+  "update.step.terminal": "Terminal",
+  "update.step.cmd_intro": "Run this in a terminal:",
+  "update.copy": "copy",
+  "update.dismiss.aria": "Dismiss banner"
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -231,6 +231,85 @@
   .empty { color: var(--text-faint); font-size: 13px; padding: 24px 0; text-align: center; }
   .err { color: var(--bad); font-size: 13px; padding: 12px 14px; border: 1px solid var(--bad); border-radius: var(--radius-sm); background: rgba(227,26,26,0.10); margin-bottom: 16px; }
 
+  /* Update banner — populated from /update-status. Sits above the page
+     header until the user dismisses it (per-version) or the local sha
+     catches up with main. Layout: leading icon · body · close button. */
+  .update-banner {
+    display: flex; align-items: flex-start; gap: 14px;
+    margin: 0 0 16px;
+    padding: 14px 18px;
+    background: linear-gradient(135deg, rgba(0,117,255,0.10), rgba(33,212,253,0.06));
+    border: 1px solid var(--accent, #0075FF);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+  }
+  .update-banner .ub-icon {
+    flex: 0 0 auto;
+    width: 32px; height: 32px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+    background: var(--accent-gradient, linear-gradient(135deg,#0075FF,#21D4FD));
+    color: #fff; font-size: 16px; font-weight: 700;
+  }
+  .update-banner .ub-body { flex: 1; min-width: 0; }
+  .update-banner .ub-title { font-size: 14px; font-weight: 700; margin-bottom: 2px; }
+  .update-banner .ub-sub  { font-size: 12.5px; color: var(--text-dim); line-height: 1.5; }
+  .update-banner .ub-sub code { font-family: var(--mono); font-size: 11.5px; padding: 1px 5px; background: var(--bg-elev-2); border-radius: 4px; }
+  .update-banner .ub-latest { display: block; margin-top: 2px; }
+  .update-banner .ub-latest em { font-style: normal; color: var(--text); }
+  .update-banner .ub-howto {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px dashed var(--border);
+  }
+  .update-banner .ub-howto-title {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--text-dim);
+    margin-bottom: 6px;
+  }
+  .update-banner .ub-howto-list {
+    margin: 0; padding-left: 22px;
+    display: flex; flex-direction: column; gap: 8px;
+    font-size: 13px; line-height: 1.5;
+  }
+  .update-banner .ub-howto-list li { padding-left: 4px; }
+  .update-banner .ub-step-tag {
+    display: inline-block; margin-right: 6px;
+    padding: 1px 8px; border-radius: 999px;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: var(--accent-soft, rgba(0,117,255,0.16));
+    color: var(--accent, #0075FF);
+  }
+  .update-banner .ub-howto-list code {
+    font-family: var(--mono); font-size: 11.5px;
+    padding: 2px 6px; background: var(--bg-elev-2);
+    border: 1px solid var(--border); border-radius: 4px;
+    user-select: all; white-space: nowrap;
+  }
+  .update-banner .ub-cmd-row {
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    margin-top: 4px;
+  }
+  .update-banner .ub-cmd-row code {
+    flex: 1; min-width: 200px;
+    overflow-x: auto; white-space: nowrap;
+    padding: 6px 10px;
+  }
+  .update-banner .ub-cmd-row .btn { font-size: 12px; padding: 6px 12px; min-height: 0; }
+  .update-banner .ub-dismiss {
+    flex: 0 0 auto;
+    background: transparent; border: 0; color: var(--text-dim);
+    font-size: 20px; line-height: 1; cursor: pointer;
+    padding: 0 4px; align-self: flex-start;
+  }
+  .update-banner .ub-dismiss:hover { color: var(--text); }
+  @media (max-width: 600px) {
+    .update-banner { flex-direction: column; }
+    .update-banner .ub-dismiss { position: absolute; top: 10px; right: 10px; }
+    .update-banner { position: relative; }
+  }
+
   .health-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; font-size: 12px; }
   .health-grid .k { color: var(--text-dim); }
   .health-grid .v { color: var(--text); font-family: var(--mono); text-align: right; }
@@ -1306,6 +1385,39 @@
   <div class="backdrop" id="sidebar-backdrop"></div>
 
   <main class="main">
+  <!-- Update banner — populated by /update-status, hidden when current.
+       Shows two clearly labelled paths to update so a non-tech user can
+       follow whichever one matches their workflow. The .ub-sub line is
+       built in JS at reveal-time so the placeholder spans (#ub-behind,
+       #ub-msg) survive an i18n re-apply pass. -->
+  <div id="update-banner" class="update-banner" hidden role="status" aria-live="polite">
+    <div class="ub-icon" aria-hidden="true">⬆</div>
+    <div class="ub-body">
+      <div class="ub-title" data-i18n="update.title">Update verfügbar</div>
+      <div class="ub-sub" id="ub-sub"></div>
+      <div class="ub-howto">
+        <div class="ub-howto-title" data-i18n="update.howto">So aktualisierst du:</div>
+        <ol class="ub-howto-list">
+          <li>
+            <span class="ub-step-tag" data-i18n="update.step.easy">am einfachsten</span>
+            <span data-i18n-html="update.step.dblclick">
+              <strong>Doppelklick</strong> auf <code>update.command</code> im mycelium-Ordner.
+            </span>
+          </li>
+          <li>
+            <span class="ub-step-tag" data-i18n="update.step.terminal">Terminal</span>
+            <span data-i18n="update.step.cmd_intro">Im Terminal ausführen:</span>
+            <div class="ub-cmd-row">
+              <code id="ub-cmd">cd ~/mycelium &amp;&amp; bash scripts/update.sh</code>
+              <button class="btn" id="ub-copy" type="button" data-i18n="update.copy">kopieren</button>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <button class="ub-dismiss" id="ub-dismiss" type="button" aria-label="Banner ausblenden" data-i18n-attr="aria-label:update.dismiss.aria">×</button>
+  </div>
+
   <header class="top">
     <button class="burger" id="burger" data-i18n-attr="aria-label:header.burger.aria" aria-label="menü">☰</button>
     <div class="status-line"><span class="status-dot" id="status"></span> <span id="status-text" data-i18n="header.status.connecting">verbinde…</span> &middot; <span id="generated">—</span></div>
@@ -7183,6 +7295,67 @@ if (origTabSwitch) {
 }
 
 initTheme();
+checkForUpdate();
+
+// --- update banner -----------------------------------------------------------
+// One-shot poll on dashboard load. Reveals the floating banner above the
+// header when /update-status reports the local checkout is behind main.
+// Dismissal is per-version (keyed on remote_sha) so a new release brings
+// the banner back without nagging on every page-load.
+async function checkForUpdate() {
+  const banner = document.getElementById("update-banner");
+  if (!banner) return;
+  let data;
+  try {
+    const r = await fetch("/update-status");
+    if (!r.ok) return;
+    data = await r.json();
+  } catch { return; }
+  if (!data || !data.ok || !data.behind_by || data.behind_by < 1) return;
+  if (localStorage.getItem("vm-update-dismissed") === data.remote_sha) return;
+
+  // Build the sub line in JS so the embedded spans aren't clobbered by an
+  // i18n re-apply pass. Three i18n keys cover the prose; everything else
+  // is structure (numbers, message) that comes from the API.
+  const sub = document.getElementById("ub-sub");
+  const behindStr = String(data.behind_by);
+  const subTpl = tt("update.sub_prefix") + " <strong>" + escapeHtml(behindStr) + " " +
+                 tt("update.commits") + "</strong> " +
+                 tt("update.sub_suffix") + " <code>main</code>.";
+  let html = subTpl;
+  if (data.latest_message) {
+    html += ' <span class="ub-latest">' +
+            tt("update.latest") + " <em>" + escapeHtml(data.latest_message) + "</em>" +
+            "</span>";
+  }
+  sub.innerHTML = html;
+
+  // Wire the actual repo path into the copy-and-paste command so the user
+  // doesn't have to figure out where they cloned. data.repo_path is the
+  // dashboard-server's ROOT — the same checkout the dashboard is being
+  // served from, so the command is always correct.
+  const cmdEl = document.getElementById("ub-cmd");
+  if (cmdEl && data.repo_path) {
+    cmdEl.textContent = `cd "${data.repo_path}" && bash scripts/update.sh`;
+  }
+
+  banner.hidden = false;
+
+  document.getElementById("ub-copy").addEventListener("click", async () => {
+    const txt = (cmdEl?.textContent || "").trim();
+    try { await navigator.clipboard.writeText(txt); }
+    catch { /* clipboard API blocked — code is selectable inline as fallback */ }
+    const btn = document.getElementById("ub-copy");
+    const old = btn.textContent;
+    btn.textContent = "✓";
+    setTimeout(() => { btn.textContent = old; }, 1500);
+  });
+  document.getElementById("ub-dismiss").addEventListener("click", () => {
+    if (data.remote_sha) localStorage.setItem("vm-update-dismissed", data.remote_sha);
+    banner.hidden = true;
+  });
+}
+
 window.load = load;
 // Wait for the i18n module to finish loading dictionaries — otherwise the
 // initial render writes raw translation keys ("intro.memory", "kpi.soul.episodes")

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -21,8 +21,11 @@ import https from "node:https";
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+
+const execFileP = promisify(execFile);
 // Federation TLS helpers — only loaded when MYCELIUM_FEATURE_FEDERATION=1.
 // Refocus 2026-04-26 moved tls-host.mjs to scripts/deferred/lib/, so the
 // static import broke the dashboard for everyone else. Loaded lazily below.
@@ -2137,6 +2140,104 @@ async function handleLessonProof(_req, res, lessonId) {
   }
 }
 
+// --- /update-status ---------------------------------------------------------
+// "Are we behind main?" — used by the dashboard's update-banner. Compares the
+// local checkout's HEAD sha against github.com/Dewinator/mycelium main via
+// the public compare API. Cached in-process for 1 h so a refresh-spamming
+// phone can't burn the GitHub-anonymous 60/h rate-limit on this proxy.
+//
+// Returns:
+//   { ok, local_sha, local_short, remote_sha, remote_short, behind_by,
+//     latest_message, latest_at, repo_path, last_check, error?, detail? }
+//
+// `behind_by` semantic: number of commits on origin/main that our checkout
+// does not have yet. (GitHub `compare/A...B` reports `ahead_by` as the count
+// of commits B has past A; mapping that to our "you are N behind" wording.)
+const _updateCache = { sha: null, at: 0, payload: null };
+const UPDATE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 h
+
+async function handleUpdateStatus(req, res) {
+  const last_check = new Date().toISOString();
+  let localSha = null;
+  try {
+    const { stdout } = await execFileP("git", ["rev-parse", "HEAD"], {
+      cwd: ROOT,
+      timeout: 4000,
+    });
+    localSha = stdout.trim();
+  } catch (e) {
+    res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+    res.end(JSON.stringify({
+      ok: false, last_check, repo_path: ROOT,
+      error: "git_local_failed",
+      detail: String(e?.message || e),
+    }));
+    return;
+  }
+
+  // Cache hit when nothing has changed since the last check (same local sha,
+  // within TTL). Post-update the local sha changes and the cache is bypassed
+  // so the banner clears as soon as the new sha matches main.
+  if (
+    _updateCache.payload &&
+    _updateCache.sha === localSha &&
+    Date.now() - _updateCache.at < UPDATE_CACHE_TTL_MS
+  ) {
+    res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+    res.end(JSON.stringify(_updateCache.payload));
+    return;
+  }
+
+  const out = {
+    ok: false,
+    last_check,
+    local_sha: localSha,
+    local_short: localSha.slice(0, 7),
+    repo_path: ROOT,
+    behind_by: 0,
+  };
+
+  try {
+    const r = await fetch(
+      `https://api.github.com/repos/Dewinator/mycelium/compare/${localSha}...main`,
+      {
+        headers: {
+          "User-Agent": "mycelium-dashboard-update-check",
+          "Accept": "application/vnd.github+json",
+        },
+        signal: AbortSignal.timeout(6000),
+      },
+    );
+    if (!r.ok) {
+      // 404 means GitHub doesn't recognise the local sha (fork? not pushed?
+      // detached state). Treat as a soft "can't tell" and clear the banner.
+      throw new Error(`HTTP ${r.status}`);
+    }
+    const data = await r.json();
+    out.ok = true;
+    out.behind_by = data.ahead_by ?? data.total_commits ?? 0;
+    if (Array.isArray(data.commits) && data.commits.length > 0) {
+      const latest = data.commits[data.commits.length - 1];
+      out.remote_sha = latest.sha;
+      out.remote_short = latest.sha.slice(0, 7);
+      out.latest_message = (latest.commit?.message || "").split("\n")[0].slice(0, 140);
+      out.latest_at = latest.commit?.committer?.date || latest.commit?.author?.date || null;
+    } else {
+      out.remote_sha = localSha;
+      out.remote_short = out.local_short;
+    }
+  } catch (e) {
+    out.error = "github_check_failed";
+    out.detail = String(e?.message || e);
+  }
+
+  _updateCache.sha = localSha;
+  _updateCache.at = Date.now();
+  _updateCache.payload = out;
+  res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+  res.end(JSON.stringify(out));
+}
+
 const server = http.createServer((req, res) => {
   // Tiny access log.
   const t = new Date().toISOString();
@@ -2145,6 +2246,7 @@ const server = http.createServer((req, res) => {
   // Swarm discovery — must precede the static fall-through so the
   // .well-known path doesn't get rewritten as a file lookup.
   if (req.url === "/.well-known/mycelium-node") return handleNodeAdvertisement(req, res);
+  if (req.url === "/update-status")              return handleUpdateStatus(req, res);
   // Swarm Phase 4 operator actions (issue #142 backend slice). Frontend
   // buttons that POST these endpoints land in a follow-up PR that builds
   // on the schwarm tab from PR #133.


### PR DESCRIPTION
## Why

Today's update flow is `bash scripts/update.sh` (or double-click `update.command` on macOS), but the dashboard never tells the user a new version exists. They have to know to check. This PR closes that gap with a banner above the page header.

**Scope is intentionally banner-only** — the click-to-update path is deferred. The dashboard process gets reloaded by `update.sh`, so a "trigger update from the browser" button has to detach the subshell, log somewhere durable, and recover gracefully when a migration aborts. The banner alone covers ~90% of the value (discoverability) and skips the runtime-suicide hazards.

## Backend (`scripts/dashboard-server.mjs`)

New `GET /update-status` endpoint:
- Reads the local checkout's HEAD via `git rev-parse HEAD` (4 s timeout, cwd=ROOT).
- Hits the public GitHub compare API `https://api.github.com/repos/Dewinator/mycelium/compare/<localSha>...main` (6 s `AbortSignal`, User-Agent set per GH requirement).
- Returns `{ ok, local_sha, local_short, remote_sha, remote_short, behind_by, latest_message, latest_at, repo_path, last_check }`.
- `behind_by` is GitHub's `ahead_by` field (commits main has past local) so the user-facing wording *"you are N behind"* is direct.
- In-process cache keyed on local sha, TTL 1 h. Post-update the local sha changes and the cache is bypassed automatically — banner clears on next dashboard load without any frontend cache busting.
- Soft-fails on network or 404 (fork / unpushed sha) — returns `{ ok: false, error }` rather than 5xx, so the frontend silently hides the banner.

## Frontend (`dashboard/index.html`)

Banner sits above `<header class="top">` inside `.main`. Hidden by default; shown when `behind_by ≥ 1` and the user hasn't dismissed this exact `remote_sha` yet (key: `localStorage["vm-update-dismissed"]`).

The how-to copy is the load-bearing piece — the goal is *"a non-tech user understands what to do"*. Two clearly tagged routes:

1. `[am einfachsten / easiest]` **Doppelklick** auf `update.command` im mycelium-Ordner.
2. `[Terminal]` `cd "<actual repo path>" && bash scripts/update.sh` with a copy button + checkmark feedback. The `repo_path` comes from the backend (= dashboard-server's `ROOT`) so the user never has to guess where they cloned.

The sub-line is built in JS at reveal-time so the embedded `behind_by` counter and latest-commit message survive an i18n re-apply pass. Banner adapts to <600 px (column layout, dismiss × absolutely positioned).

i18n DE + EN: `update.title`, `update.sub_prefix`, `update.commits`, `update.sub_suffix`, `update.latest`, `update.howto`, `update.step.easy`, `update.step.dblclick`, `update.step.terminal`, `update.step.cmd_intro`, `update.copy`, `update.dismiss.aria`.

## Out of scope (deliberate)

- **Click-to-update from the browser.** See top of message; the detached-subshell + recovery story needs its own PR.
- **Polling.** One-shot on dashboard load is enough; the user typically reloads once per day, the GH cache TTL is 1 h, and a missed update surfaces on the next page-load.
- **Release notes.** `latest_message` is the single newest commit subject; we don't try to render the changelog between local and main. Follow-up.

## Test plan

- [x] `npm test` in `mcp-server`: **920/920 green** (no behavioural change in the MCP server).
- [x] `node -c scripts/dashboard-server.mjs` clean.
- [x] Both i18n JSON files parse.
- [ ] Live: load the dashboard while local sha is behind main → banner appears with correct count, latest commit message, repo path pre-filled in the copy command.
- [ ] Live: hit ✓ on copy, paste in Terminal, run `update.sh`, reload dashboard → banner is gone.
- [ ] Live: hit `×` to dismiss → reload → banner stays gone for this `remote_sha`; once a new commit lands on main the banner returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)