### PR TITLE
fix(install): minimal trust substrate so fresh installs reach migration 040 (#180)

### DIFF
--- a/supabase/migrations/038_trust_substrate_minimal.sql
+++ b/supabase/migrations/038_trust_substrate_minimal.sql
@@ -1,0 +1,56 @@
+-- 038_trust_substrate_minimal.sql — fresh-install fix for issue #180
+--
+-- Problem (found by spike #179 against PGlite):
+--   active migration 040_signed_revocations.sql does
+--     ALTER TABLE revoked_keys ADD COLUMN ...
+--   but `revoked_keys` (and `trust_roots`) are CREATEd only in
+--   `supabase/migrations.deferred/038_federation_trust.sql`. A fresh install
+--   running the active sequence end-to-end never gets those tables, and 040
+--   dies on `relation "revoked_keys" does not exist`.
+--
+--   039_host_identity.sql also queries both tables inside `peer_seen()`. The
+--   function body survives migration time because PL/pgSQL lazy-resolves
+--   identifiers, but the call would fail at runtime against the same gap.
+--
+-- Fix (option C from the issue):
+--   Park the *minimum* substrate (just the two tables + their indexes +
+--   GRANTs) in an active migration, so 040 has something to ALTER and 039's
+--   peer_seen() can actually be called. The full federation surface — RPCs
+--   trust_add / trust_revoke / trust_list / trust_check / federation_log_*
+--   — stays in deferred 038, gated behind whatever turns Federation on.
+--
+-- Idempotency:
+--   The deferred 038 file already uses CREATE TABLE IF NOT EXISTS for both
+--   tables and CREATE INDEX IF NOT EXISTS for their indexes, so a node that
+--   later opts into Federation by running deferred migrations gets a no-op
+--   here. Schemas are kept *byte-for-byte identical* to deferred 038 so the
+--   two paths can never diverge.
+
+CREATE TABLE IF NOT EXISTS trust_roots (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind          TEXT NOT NULL CHECK (kind IN ('host','genome','group')),
+  identifier    TEXT NOT NULL,
+  pubkey        BYTEA NOT NULL,
+  label         TEXT,
+  added_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  added_by      TEXT,
+  notes         TEXT,
+  status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','revoked')),
+  UNIQUE (pubkey)
+);
+
+CREATE INDEX IF NOT EXISTS trust_roots_kind_idx       ON trust_roots (kind, status);
+CREATE INDEX IF NOT EXISTS trust_roots_identifier_idx ON trust_roots (identifier);
+
+CREATE TABLE IF NOT EXISTS revoked_keys (
+  pubkey        BYTEA PRIMARY KEY,
+  reason        TEXT NOT NULL,
+  revoked_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_by    TEXT,
+  evidence      JSONB NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS revoked_keys_revoked_at_idx ON revoked_keys (revoked_at DESC);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON trust_roots   TO anon, service_role;
+GRANT SELECT, INSERT, UPDATE          ON revoked_keys TO anon, service_role;


### PR DESCRIPTION
## Summary

Fixes #180. Adds `supabase/migrations/038_trust_substrate_minimal.sql` containing just the `trust_roots` + `revoked_keys` table defs + indexes + GRANTs, so the active migration sequence has the substrate that 040 expects.

Found by spike #179 — the same PGlite walk that surfaced this. After the fix, migrations 001..076 all run green on a fresh DB.

## Why option C from the issue

- `trust_roots` and `revoked_keys` are queried at runtime by `039_host_identity.sql`'s `peer_seen()` function. Even without 040, calling `peer_seen()` on a fresh install would fail.
- 040 (`signed_revocations`) is per-host functionality, not strictly federation — `revocations_list_signed` and `revocation_upsert_signed` make sense even on a non-federated node.
- The full federation surface (RPCs `trust_add` / `trust_revoke` / `trust_list` / `trust_check` / `federation_log_*` / audit tables) stays in deferred 038, gated by federation opt-in.

Schemas are byte-for-byte identical to deferred 038. The deferred file already uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so a node that later opts into federation gets a clean no-op for the tables and just adds the RPCs/audit tables on top.

## Verified

Local Postgres 16 (`pgvector/pgvector:0.8.0-pg16`), fresh empty database:

- **Before fix:** 040 fails — `ERROR: relation "revoked_keys" does not exist`
- **After fix:** 040 succeeds. `\d revoked_keys` shows all four columns added by 040 (`signature`, `signer_pubkey`, `signed_payload`, `sync_source`) — proving the ALTER ran. Walk continues to 077, which hits an unrelated latent bug (`position` is a PG reserved word being used as a column name) — separate issue, will file.
- **Deferred 038 applied on top:** idempotent. All 7 federation RPCs created (`trust_add`, `trust_revoke`, `trust_list`, `trust_check`, `federation_log_import`, `federation_log_export`, `federation_recent`).

Reproducer:
\`\`\`bash
export PGPASSWORD=...
psql -h localhost -p 54322 -U postgres -d postgres -c "CREATE DATABASE test_fresh;"
for m in supabase/migrations/*.sql; do psql -h localhost -p 54322 -U postgres -d test_fresh -v ON_ERROR_STOP=1 -f "\$m" || break; done
\`\`\`

(Once #179 lands, `node experiments/native-pg/spike-pglite.mjs --migrate` is the cleaner check — it runs against a throwaway PGlite DB with no Docker.)

## Test plan

- [x] Fresh DB: migrations 001..076 all green
- [x] `revoked_keys` table has all 040 columns
- [x] `trust_roots` table has the right schema + indexes + check constraints
- [x] Deferred 038 still applies cleanly on top (idempotent)
- [x] All 7 federation RPCs from deferred 038 still register

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)