### PR TITLE
fix(install): quote position in 077 RETURNS TABLE — fresh-install blocker after #181

### DIFF
--- a/supabase/migrations/077_lesson_evidence_origin.sql
+++ b/supabase/migrations/077_lesson_evidence_origin.sql
@@ -202,7 +202,7 @@ GRANT EXECUTE ON FUNCTION record_lesson_evidence(UUID, TEXT[])
 -- table separately — this RPC's job is just the leaf lookup.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION get_lesson_evidence(p_lesson_id UUID)
-RETURNS TABLE (position INT, hashed_experience_id TEXT)
+RETURNS TABLE ("position" INT, hashed_experience_id TEXT)
 LANGUAGE sql STABLE
 AS $$
   SELECT position, hashed_experience_id


### PR DESCRIPTION
## Summary

Third in the chain of fresh-install bug fixes (after PR #174 deferred 036, PR #181 fixes 040). Migration 077 declares `get_lesson_evidence(...)` with `RETURNS TABLE (position INT, ...)`, and PG16 + PG17 both reject the unquoted `position` keyword in the RETURNS TABLE parameter slot. `scripts/migrate.sh` runs psql with `-v ON_ERROR_STOP=1` and aborts the whole walk at the syntax error — so a brand-new install today never gets past 077 to reach the fixup migration 084.

**Fix:** quote `"position"` on line 205. One character pair.

## Why this needed an in-place edit, not fix-forward

Issue #135 was already filed against this. PR #140 added migration `084_get_lesson_evidence_position_quote.sql` which `CREATE OR REPLACE FUNCTION`s the function with quoted `"position"`. That fixup works for existing installs where 077 ran *partway* — committed the table/triggers/`record_lesson_evidence` under autocommit, then died before reaching `get_lesson_evidence`. Migration 084 then catches up on the next migrate.sh run.

It does **not** help fresh installs. ON_ERROR_STOP=1 + psql's autocommit-with-abort means migrate.sh exits 1 the moment 077 hits the syntax error. Migration 084 is in the loop *after* 077 and never runs.

Fix-forward via a new migration is structurally impossible for a syntax error. The choice is: edit 077, or leave fresh installs bricked at 077 forever once PR #174 + #181 land.

The "071-082 are immutable history" discipline (introduced in 084's own header) is preserved for semantic fixes. Syntax errors are the special case — same way PR #174 broke the discipline differently by deferring 036 entirely. Reed accepted that one for the same reason: the discipline must yield when fresh-install correctness is on the other side.

## Migration 084 stays

Migration 084 keeps doing its job for installs whose partially-applied 077 happened *before* this fix. `CREATE OR REPLACE FUNCTION` on top of the corrected 077 is a no-op rewrite of the same definition — idempotent, no harm.

## Empirical verification

Against `pgvector/pgvector:0.8.0-pg16` (the image mycelium ships in `docker/docker-compose.yml`), fresh database:

```bash
docker exec vectormemory-db psql -U postgres -d postgres -c "CREATE DATABASE test_077_fresh;"
docker exec vectormemory-db psql -U postgres -d test_077_fresh -v ON_ERROR_STOP=1 -c \
  "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pgcrypto;"
```

**Before fix** (current main):
```
psql:077_lesson_evidence_origin.sql:205: ERROR:  syntax error at or near "position"
```

**After fix:**
```
CREATE TABLE
CREATE INDEX
CREATE FUNCTION
DROP TRIGGER ... CREATE TRIGGER ... (×2)
CREATE FUNCTION
GRANT
CREATE FUNCTION   ← this one
GRANT
```

Then `\df get_lesson_evidence`:
```
 public | get_lesson_evidence | TABLE("position" integer, hashed_experience_id text) | p_lesson_id uuid
```

And re-running the fixed 077 on the same DB: idempotent (every statement uses IF NOT EXISTS or CREATE OR REPLACE / DROP+CREATE TRIGGER). 084 then applies on top with no errors.

## Test plan

- [x] Fresh PG16 DB: 077 (fixed) applies clean
- [x] `get_lesson_evidence(uuid)` exists and returns 0 rows for unknown lesson
- [x] Re-running fixed 077 on a populated DB: idempotent
- [x] Migration 084 applies on top of fixed 077 without error
- [ ] Reed verifies on his fresh-install run after PR #181 merges

Closes the fresh-install chain that started with #173/#174 (036) → #180/#181 (040) → this (077).

🤖 Generated with [Claude Code](https://claude.com/claude-code)