### PR TITLE
feat(native): PGlite adapter foundation — issue #184 part 1

### DIFF
--- a/docs/native-pg-spike.md
+++ b/docs/native-pg-spike.md
@@ -108,6 +108,33 @@ These are issue-shaped work items, ordered by dependency. Each is its own PR. Es
 5. **Tauri shell wraps Node + PGlite + llama.cpp** — single binary, tray icon, OS data dir. Multi-tick.
 6. **Cross-platform CI** — even with WASM, we still need to build and sign per-platform Tauri installers. Multi-tick.
 
+## Spike 1.5 — adapter shipped
+
+> Status: **adapter foundation landed**
+> Issue: [#184](https://github.com/Dewinator/mycelium/issues/184) (sub-task of [#176](https://github.com/Dewinator/mycelium/issues/176))
+> Code: [`mcp-server/src/native/`](../mcp-server/src/native/), tests under [`mcp-server/src/__tests__/native/`](../mcp-server/src/__tests__/native/)
+
+### What landed
+
+- **`mcp-server/src/native/pglite.ts`** — `PGliteAdapter` class with a `QueryBuilder` that mirrors the slice of `@supabase/postgrest-js`'s surface our services in `mcp-server/src/services/` actually use:
+  - `from(t).select|insert|update|delete().eq|neq|gt|gte|lt|lte|in|or|order|limit().single|maybeSingle()`
+  - `rpc(name, args)` with named-arg call shape and PostgREST-equivalent scalar-vs-set unwrapping.
+  - Returns the same `{ data, error }` envelope as `PostgrestClient`, including `PGRST116` for `single()` misses.
+- **`mcp-server/src/native/factory.ts`** — `createNativeDb({ dataDir, migrationsDir, skipMigrations })` wires the eight contrib extensions (`vector`, `pg_trgm`, `pgcrypto`, `uuid_ossp`, `btree_gin`, `btree_gist`, `citext`, `hstore`, `tablefunc`) and runs migrations on first start. Default data dir per platform: `~/Library/Application Support/mycelium/data` (macOS), `$XDG_DATA_HOME/mycelium/data` (Linux), `%APPDATA%/mycelium/data` (Windows). Override via `MYCELIUM_PGLITE_DATA_DIR`.
+- **`mcp-server/src/native/migration-runner.ts`** — idempotent migration runner. Walks `supabase/migrations/*.sql` lexicographically, tracks applied files in a small `mycelium_pglite_migrations` bookkeeping table, throws on first failure so server bootstrap bails before MCP tools start serving.
+- **`mcp-server/src/__tests__/native/pglite-adapter.test.ts`** — 16 contract tests against a real in-memory PGlite instance. Cover insert/select/update/delete, single/maybeSingle, in() with empty array, neq+gte combinations, or() filter, jsonb round-trip, vector column, rpc scalar + setof, queue serialization, and queue-survives-error. All green.
+
+### Design choices worth flagging
+
+- **Single Promise-chain queue.** PGlite is single-connection by design; concurrent service calls would race on the shared cursor. The adapter serializes every op through one queue and keeps the chain alive past failures (the catch-and-swallow in `run()` is intentional: a SQL error must not poison subsequent ops).
+- **Explicit Postgres casts on serialized parameters.** PGlite is stricter than PostgREST about parameter typing. The `serializeValue` helper emits `$N::vector` for numeric arrays (pgvector textual `[a,b,c]` form), `$N::text[]` for string arrays (Postgres array literal `{"a","b"}`), and `$N::jsonb` for objects / mixed arrays. Without the casts, parametrized inserts into VECTOR / JSONB columns fail with "could not determine data type of parameter $N".
+- **`or()` parser is deliberately narrow.** Accepts the PostgREST `col.op.val,col.op.val` shape with `eq/neq/lt/lte/gt/gte`, throws on anything else. Matches what `services/identity.ts` actually emits today; failing loudly beats silently dropping clauses.
+- **Surface intentionally narrow.** Adding a verb is a few lines; aiming for full PostgREST parity would be expensive scaffolding for behavior nothing exercises. Grep `\.from\(|\.rpc\(` under `mcp-server/src/` to enumerate the live surface.
+
+### Out of scope for this PR (deliberate split)
+
+The full #184 acceptance asks for the `MYCELIUM_DB_BACKEND=pglite` env switch wired through `MemoryService` *and* the other 23 services that construct their own `PostgrestClient`, plus a CI gate running the entire test suite under `MYCELIUM_DB_BACKEND=pglite`. That is a cross-cutting refactor of every service constructor — kept out of this PR so the foundation lands cleanly first. Tracked as the immediate next sub-task; this PR ships the adapter, factory, migration runner, and contract tests so the wire-up has something stable to plug into.
+
 ## Reproducing the measurements
 
 ```bash

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "vectormemory-mcp-server",
+  "name": "mycelium-mcp-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vectormemory-mcp-server",
+      "name": "mycelium-mcp-server",
       "version": "0.1.0",
       "dependencies": {
+        "@electric-sql/pglite": "^0.4.5",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@supabase/supabase-js": "^2.49.4",
         "ollama": "^0.5.16",
@@ -20,6 +21,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.5.tgz",
+      "integrity": "sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==",
+      "license": "Apache-2.0"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.12",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -12,6 +12,7 @@
     "test": "npm run clean && tsc && node --test \"dist/__tests__/**/*.test.js\""
   },
   "dependencies": {
+    "@electric-sql/pglite": "^0.4.5",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@supabase/supabase-js": "^2.49.4",
     "ollama": "^0.5.16",

--- a/mcp-server/src/__tests__/native/pglite-adapter.test.ts
+++ b/mcp-server/src/__tests__/native/pglite-adapter.test.ts
@@ -1,0 +1,314 @@
+// Adapter contract tests — exercise every verb shape MemoryService and the
+// other services in src/services/ actually use, against a real PGlite
+// instance (in-memory data dir). If a chain ever drifts from the
+// PostgrestClient shape these tests will fail before MemoryService does.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+
+import { PGliteAdapter } from "../../native/pglite.js";
+
+async function freshAdapter(): Promise<{ adapter: PGliteAdapter; pg: PGlite }> {
+  // dataDir omitted → PGlite stays in-memory, perfect for unit tests.
+  const pg = await PGlite.create({ extensions: { vector } });
+  await pg.exec(`
+    CREATE TABLE IF NOT EXISTS adapter_test (
+      id   SERIAL PRIMARY KEY,
+      name TEXT NOT NULL,
+      tag  TEXT,
+      n    INT  DEFAULT 0,
+      meta JSONB DEFAULT '{}'::jsonb
+    )
+  `);
+  return { adapter: new PGliteAdapter(pg), pg };
+}
+
+test("adapter: insert + select with eq returns inserted row", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    const ins = await adapter
+      .from("adapter_test")
+      .insert({ name: "alpha", tag: "x", n: 1 })
+      .select()
+      .single();
+    assert.equal(ins.error, null);
+    assert.equal((ins.data as { name: string }).name, "alpha");
+
+    const sel = await adapter
+      .from("adapter_test")
+      .select("name, n")
+      .eq("name", "alpha")
+      .single();
+    assert.equal(sel.error, null);
+    assert.deepEqual(sel.data, { name: "alpha", n: 1 });
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: bulk insert + order + limit returns ordered subset", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert([
+      { name: "a", n: 3 },
+      { name: "b", n: 1 },
+      { name: "c", n: 2 },
+    ]);
+    const r = await adapter
+      .from("adapter_test")
+      .select("name, n")
+      .order("n", { ascending: true })
+      .limit(2);
+    assert.equal(r.error, null);
+    const rows = r.data as Array<{ name: string; n: number }>;
+    assert.deepEqual(rows.map((x) => x.name), ["b", "c"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: update + select + single returns updated row", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert({ name: "u", n: 0 });
+    const upd = await adapter
+      .from("adapter_test")
+      .update({ n: 42 })
+      .eq("name", "u")
+      .select()
+      .single();
+    assert.equal(upd.error, null);
+    assert.equal((upd.data as { n: number }).n, 42);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: delete + eq removes only matching rows", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert([
+      { name: "keep" },
+      { name: "drop" },
+    ]);
+    const del = await adapter.from("adapter_test").delete().eq("name", "drop");
+    assert.equal(del.error, null);
+    const r = await adapter.from("adapter_test").select("name");
+    const rows = r.data as Array<{ name: string }>;
+    assert.deepEqual(rows.map((x) => x.name), ["keep"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: in() filter matches any of provided values", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert([
+      { name: "a" }, { name: "b" }, { name: "c" },
+    ]);
+    const r = await adapter
+      .from("adapter_test")
+      .select("name")
+      .in("name", ["a", "c"])
+      .order("name", { ascending: true });
+    const rows = r.data as Array<{ name: string }>;
+    assert.deepEqual(rows.map((x) => x.name), ["a", "c"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: in() with empty array returns no rows (not all rows)", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert({ name: "any" });
+    const r = await adapter.from("adapter_test").select("name").in("name", []);
+    assert.equal(r.error, null);
+    assert.deepEqual(r.data, []);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: maybeSingle returns null on empty without error", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    const r = await adapter
+      .from("adapter_test")
+      .select("name")
+      .eq("name", "ghost")
+      .maybeSingle();
+    assert.equal(r.error, null);
+    assert.equal(r.data, null);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: single() on empty returns PGRST116 error", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    const r = await adapter
+      .from("adapter_test")
+      .select("name")
+      .eq("name", "ghost")
+      .single();
+    assert.equal(r.data, null);
+    assert.equal(r.error?.code, "PGRST116");
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: neq + gte filters narrow result set", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert([
+      { name: "x", n: 1 }, { name: "y", n: 5 }, { name: "z", n: 10 },
+    ]);
+    const r = await adapter
+      .from("adapter_test")
+      .select("name, n")
+      .neq("name", "x")
+      .gte("n", 6)
+      .order("n", { ascending: true });
+    const rows = r.data as Array<{ name: string; n: number }>;
+    assert.deepEqual(rows, [{ name: "z", n: 10 }]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: or() filter generates valid SQL", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert([
+      { name: "a", n: -1 },
+      { name: "b", n:  1, tag: "conflict" },
+      { name: "c", n:  2, tag: "ok" },
+    ]);
+    const r = await adapter
+      .from("adapter_test")
+      .select("name, n, tag")
+      .or("n.lt.0,tag.eq.conflict")
+      .order("name", { ascending: true });
+    const rows = r.data as Array<{ name: string }>;
+    assert.deepEqual(rows.map((x) => x.name), ["a", "b"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: jsonb metadata round-trips through insert + select", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    const meta = { hits: 3, score: 0.7, query_length: 42 };
+    await adapter.from("adapter_test").insert({ name: "m", meta });
+    const r = await adapter
+      .from("adapter_test")
+      .select("meta")
+      .eq("name", "m")
+      .single();
+    assert.equal(r.error, null);
+    assert.deepEqual((r.data as { meta: typeof meta }).meta, meta);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: rpc() with named args calls a SQL function and unwraps scalar", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await pg.exec(`
+      CREATE OR REPLACE FUNCTION add_two(a INT, b INT) RETURNS INT
+      LANGUAGE SQL IMMUTABLE AS $$ SELECT a + b $$
+    `);
+    const r = await adapter.rpc<number>("add_two", { a: 3, b: 4 });
+    assert.equal(r.error, null);
+    assert.equal(r.data, 7);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: rpc() returning setof rows surfaces array", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await pg.exec(`
+      CREATE OR REPLACE FUNCTION list_names() RETURNS TABLE(name TEXT)
+      LANGUAGE SQL STABLE AS $$ SELECT name FROM adapter_test ORDER BY name $$
+    `);
+    await adapter.from("adapter_test").insert([{ name: "p" }, { name: "q" }]);
+    const r = await adapter.rpc<Array<{ name: string }>>("list_names", {});
+    assert.equal(r.error, null);
+    const data = r.data!;
+    assert.deepEqual(data.map((x) => x.name), ["p", "q"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: vector column accepts numeric array as embedding", async () => {
+  const pg = await PGlite.create({ extensions: { vector } });
+  try {
+    await pg.exec(`CREATE EXTENSION IF NOT EXISTS vector`);
+    await pg.exec(`
+      CREATE TABLE vec_test (
+        id   SERIAL PRIMARY KEY,
+        emb  VECTOR(3)
+      )
+    `);
+    const adapter = new PGliteAdapter(pg);
+    const ins = await adapter
+      .from("vec_test")
+      .insert({ emb: [0.1, 0.2, 0.3] })
+      .select()
+      .single();
+    assert.equal(ins.error, null);
+    const row = ins.data as { id: number; emb: unknown };
+    assert.ok(row.id > 0);
+    // PGlite returns vectors as the textual `[a,b,c]` form — exact equality
+    // would couple the test to the WASM build, so we assert shape only.
+    assert.ok(typeof row.emb === "string");
+    assert.match(row.emb as string, /^\[/);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: queue serializes concurrent calls", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    const ops = await Promise.all([
+      adapter.from("adapter_test").insert({ name: "p1" }),
+      adapter.from("adapter_test").insert({ name: "p2" }),
+      adapter.from("adapter_test").insert({ name: "p3" }),
+    ]);
+    for (const r of ops) assert.equal(r.error, null);
+    const all = await adapter.from("adapter_test").select("name").order("name", { ascending: true });
+    const rows = all.data as Array<{ name: string }>;
+    assert.deepEqual(rows.map((x) => x.name), ["p1", "p2", "p3"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("adapter: query error after success leaves queue alive", async () => {
+  const { adapter, pg } = await freshAdapter();
+  try {
+    await adapter.from("adapter_test").insert({ name: "ok" });
+    // Trigger a SQL error (column does not exist).
+    const bad = await adapter.from("adapter_test").select("nope");
+    assert.notEqual(bad.error, null);
+    // Subsequent legit query still works.
+    const good = await adapter.from("adapter_test").select("name").single();
+    assert.equal(good.error, null);
+    assert.equal((good.data as { name: string }).name, "ok");
+  } finally {
+    await pg.close();
+  }
+});

--- a/mcp-server/src/native/factory.ts
+++ b/mcp-server/src/native/factory.ts
@@ -1,0 +1,104 @@
+// Factory for the PGlite native backend.
+//
+// Wires together the WASM Postgres instance, the eight contrib extensions our
+// migrations depend on, the migration runner and the adapter into one call:
+//
+//   const db = await createNativeDb({ dataDir });
+//   // db is shape-compatible with @supabase/postgrest-js's PostgrestClient
+//   // for the surface the services in src/services/ use.
+
+import path from "node:path";
+import os from "node:os";
+
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
+import { pgcrypto } from "@electric-sql/pglite/contrib/pgcrypto";
+import { uuid_ossp } from "@electric-sql/pglite/contrib/uuid_ossp";
+import { btree_gin } from "@electric-sql/pglite/contrib/btree_gin";
+import { btree_gist } from "@electric-sql/pglite/contrib/btree_gist";
+import { citext } from "@electric-sql/pglite/contrib/citext";
+import { hstore } from "@electric-sql/pglite/contrib/hstore";
+import { tablefunc } from "@electric-sql/pglite/contrib/tablefunc";
+
+import { PGliteAdapter } from "./pglite.js";
+import { applyMigrations, type MigrationReport } from "./migration-runner.js";
+
+export interface NativeDbOptions {
+  /** Data directory; defaults to OS-conventional app-data path. */
+  dataDir?: string;
+  /** Migrations directory; defaults to repo's supabase/migrations. */
+  migrationsDir?: string;
+  /** Skip applying migrations (tests sometimes want a bare instance). */
+  skipMigrations?: boolean;
+}
+
+export interface NativeDb {
+  adapter: PGliteAdapter;
+  raw: PGlite;
+  dataDir: string;
+  migrationReport: MigrationReport | null;
+  close(): Promise<void>;
+}
+
+/**
+ * Default data dir per platform — matches what the Tauri shell will use so
+ * the Node-side path and the future GUI path land on the same files.
+ *
+ *   macOS:   ~/Library/Application Support/mycelium/data
+ *   Linux:   $XDG_DATA_HOME/mycelium/data  (fallback ~/.local/share/mycelium/data)
+ *   Windows: %APPDATA%/mycelium/data
+ */
+export function defaultDataDir(): string {
+  const env = process.env.MYCELIUM_PGLITE_DATA_DIR;
+  if (env) return env;
+  const home = os.homedir();
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "mycelium", "data");
+  }
+  if (process.platform === "win32") {
+    const appdata = process.env.APPDATA ?? path.join(home, "AppData", "Roaming");
+    return path.join(appdata, "mycelium", "data");
+  }
+  const xdg = process.env.XDG_DATA_HOME ?? path.join(home, ".local", "share");
+  return path.join(xdg, "mycelium", "data");
+}
+
+export async function createNativeDb(opts: NativeDbOptions = {}): Promise<NativeDb> {
+  const dataDir = opts.dataDir ?? defaultDataDir();
+
+  const pg = await PGlite.create({
+    dataDir,
+    extensions: {
+      vector,
+      pg_trgm,
+      pgcrypto,
+      uuid_ossp,
+      btree_gin,
+      btree_gist,
+      citext,
+      hstore,
+      tablefunc,
+    },
+  });
+
+  let migrationReport: MigrationReport | null = null;
+  if (!opts.skipMigrations) {
+    const migrationsDir =
+      opts.migrationsDir ??
+      path.resolve(process.cwd(), "..", "supabase", "migrations");
+    migrationReport = await applyMigrations(pg, migrationsDir);
+  }
+
+  const adapter = new PGliteAdapter(pg);
+
+  return {
+    adapter,
+    raw: pg,
+    dataDir,
+    migrationReport,
+    async close() {
+      await pg.close();
+    },
+  };
+}

--- a/mcp-server/src/native/migration-runner.ts
+++ b/mcp-server/src/native/migration-runner.ts
@@ -1,0 +1,98 @@
+// Migration runner for the PGlite native backend.
+//
+// The Docker path applies migrations via `scripts/migrate.sh` (psql against
+// the supabase container). With PGlite there is no psql; we walk the same
+// `supabase/migrations/*.sql` directory and apply each file via the in-process
+// PGlite handle. The applied set is tracked in a small bookkeeping table so
+// re-launches skip migrations that already ran on this data dir.
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { PGlite } from "@electric-sql/pglite";
+
+const MIGRATIONS_TABLE = "mycelium_pglite_migrations";
+
+export interface MigrationOutcome {
+  file: string;
+  ok: boolean;
+  ms: number;
+  error?: string;
+  skipped?: boolean;
+}
+
+export interface MigrationReport {
+  total: number;
+  applied: number;
+  skipped: number;
+  outcomes: MigrationOutcome[];
+}
+
+async function ensureBookkeeping(pg: PGlite): Promise<void> {
+  await pg.exec(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      filename TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+async function alreadyApplied(pg: PGlite, file: string): Promise<boolean> {
+  const r = await pg.query(
+    `SELECT 1 AS hit FROM ${MIGRATIONS_TABLE} WHERE filename = $1`,
+    [file],
+  );
+  return (r as unknown as { rows: unknown[] }).rows.length > 0;
+}
+
+async function recordApplied(pg: PGlite, file: string): Promise<void> {
+  await pg.query(
+    `INSERT INTO ${MIGRATIONS_TABLE} (filename) VALUES ($1)
+     ON CONFLICT (filename) DO NOTHING`,
+    [file],
+  );
+}
+
+/**
+ * Apply every `.sql` migration under `migrationsDir` against `pg`.
+ * Re-running is idempotent: already-applied files are skipped, not replayed.
+ *
+ * Throws on the first failing migration so the caller (factory.ts during
+ * server bootstrap) can bail out before MCP tools start serving.
+ */
+export async function applyMigrations(
+  pg: PGlite,
+  migrationsDir: string,
+): Promise<MigrationReport> {
+  await ensureBookkeeping(pg);
+
+  const files = (await readdir(migrationsDir))
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  const outcomes: MigrationOutcome[] = [];
+  let applied = 0;
+  let skipped = 0;
+
+  for (const file of files) {
+    if (await alreadyApplied(pg, file)) {
+      outcomes.push({ file, ok: true, ms: 0, skipped: true });
+      skipped++;
+      continue;
+    }
+    const sql = await readFile(path.join(migrationsDir, file), "utf8");
+    const t = Date.now();
+    try {
+      await pg.exec(sql);
+      await recordApplied(pg, file);
+      outcomes.push({ file, ok: true, ms: Date.now() - t });
+      applied++;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      outcomes.push({ file, ok: false, ms: Date.now() - t, error: msg });
+      throw new Error(`migration ${file} failed: ${msg}`);
+    }
+  }
+
+  return { total: files.length, applied, skipped, outcomes };
+}

--- a/mcp-server/src/native/pglite.ts
+++ b/mcp-server/src/native/pglite.ts
@@ -1,0 +1,482 @@
+// PGlite adapter — drops in for `@supabase/postgrest-js`'s PostgrestClient
+// where MemoryService and friends consume it. Speaks the same `.from(t).select|
+// insert|update|delete().eq|neq|in|or|order|limit().single|maybeSingle()` chain
+// shape and the same `.rpc(name, args)` shape, returning `{ data, error }`.
+//
+// Why this exists:
+//   Issue #184 (sub-task of #176) graduates the throwaway PGlite spike
+//   (experiments/native-pg/spike-pglite.mjs, validated under #179) into a
+//   first-class production backend, so the native standalone app no longer
+//   needs Docker + PostgREST. PGlite is single-connection by design — every
+//   call gets serialized through one promise queue.
+//
+// Surface intentionally narrow: only the verbs services in src/services/
+// actually call. Adding a verb is a few lines; aiming for full PostgREST
+// parity would be expensive scaffolding for behavior nothing exercises.
+
+import type { PGlite } from "@electric-sql/pglite";
+
+export interface AdapterError {
+  message: string;
+  code?: string;
+  details?: string;
+  hint?: string;
+}
+
+export interface AdapterResult<T> {
+  data: T | null;
+  error: AdapterError | null;
+}
+
+type FilterOp = "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "in";
+interface Filter {
+  op: FilterOp | "or";
+  col?: string;
+  val?: unknown;
+  raw?: string;
+}
+
+type Action =
+  | { kind: "select"; cols: string }
+  | { kind: "insert"; values: Record<string, unknown>[]; returning: string | null }
+  | { kind: "update"; values: Record<string, unknown>; returning: string | null }
+  | { kind: "delete"; returning: string | null };
+
+type Single = "single" | "maybe" | null;
+
+interface OrderClause {
+  col: string;
+  ascending: boolean;
+  nullsFirst?: boolean;
+}
+
+// PGlite's type for query() — kept loose to avoid pinning to a private surface.
+interface PgLikeRow extends Record<string, unknown> {}
+interface PgLikeResult {
+  rows: PgLikeRow[];
+}
+type PgQueryFn = (sql: string, params?: unknown[]) => Promise<PgLikeResult>;
+
+export class QueryBuilder<T = unknown> implements PromiseLike<AdapterResult<T>> {
+  private action: Action | null = null;
+  private filters: Filter[] = [];
+  private orders: OrderClause[] = [];
+  private limitN: number | null = null;
+  private singleMode: Single = null;
+
+  constructor(
+    private readonly table: string,
+    private readonly run: PgQueryFn,
+  ) {}
+
+  // Used by buildSql / filterToSql via the closure passed below — keeps the
+  // value-vs-cast unwrapping in one place so a stray `params.push(serializeValue(x))`
+  // can't reintroduce the "could not determine data type of parameter $N" failure.
+  private pushParam(params: unknown[], v: unknown): string {
+    const s = serializeValue(v);
+    params.push(s.value);
+    return s.cast ? `$${params.length}::${s.cast}` : `$${params.length}`;
+  }
+
+  // -- actions ------------------------------------------------------------
+
+  select(cols: string = "*"): this {
+    if (this.action && this.action.kind !== "select") {
+      // select() chained after insert/update/delete → RETURNING clause.
+      this.action.returning = cols;
+      return this;
+    }
+    this.action = { kind: "select", cols };
+    return this;
+  }
+
+  insert(values: Record<string, unknown> | Record<string, unknown>[]): this {
+    const rows = Array.isArray(values) ? values : [values];
+    this.action = { kind: "insert", values: rows, returning: null };
+    return this;
+  }
+
+  update(values: Record<string, unknown>): this {
+    this.action = { kind: "update", values, returning: null };
+    return this;
+  }
+
+  delete(): this {
+    this.action = { kind: "delete", returning: null };
+    return this;
+  }
+
+  // -- filters ------------------------------------------------------------
+
+  eq(col: string, val: unknown): this { this.filters.push({ op: "eq", col, val }); return this; }
+  neq(col: string, val: unknown): this { this.filters.push({ op: "neq", col, val }); return this; }
+  gt(col: string, val: unknown): this { this.filters.push({ op: "gt", col, val }); return this; }
+  gte(col: string, val: unknown): this { this.filters.push({ op: "gte", col, val }); return this; }
+  lt(col: string, val: unknown): this { this.filters.push({ op: "lt", col, val }); return this; }
+  lte(col: string, val: unknown): this { this.filters.push({ op: "lte", col, val }); return this; }
+  in(col: string, vals: readonly unknown[]): this {
+    this.filters.push({ op: "in", col, val: vals });
+    return this;
+  }
+
+  /**
+   * PostgREST-style "or" filter — accepts a comma-separated string of
+   * `col.op.val,col.op.val` clauses (matching what the services in
+   * `src/services/identity.ts` already pass). This adapter understands
+   * the small subset our codebase actually uses (`eq`, `lt`, `gt`,
+   * `lte`, `gte`, `neq`). Anything else throws — failing fast beats
+   * silently dropping a clause.
+   */
+  or(filterString: string): this {
+    const parts = splitOrClauses(filterString);
+    const sqlParts = parts.map((p) => orClauseToSql(p));
+    this.filters.push({ op: "or", raw: `(${sqlParts.join(" OR ")})` });
+    return this;
+  }
+
+  // -- modifiers ----------------------------------------------------------
+
+  order(col: string, opts?: { ascending?: boolean; nullsFirst?: boolean }): this {
+    this.orders.push({
+      col,
+      ascending: opts?.ascending ?? true,
+      nullsFirst: opts?.nullsFirst,
+    });
+    return this;
+  }
+
+  limit(n: number): this { this.limitN = n; return this; }
+
+  single(): this { this.singleMode = "single"; return this; }
+  maybeSingle(): this { this.singleMode = "maybe"; return this; }
+
+  // -- thenable -----------------------------------------------------------
+
+  then<TR1 = AdapterResult<T>, TR2 = never>(
+    onfulfilled?: ((value: AdapterResult<T>) => TR1 | PromiseLike<TR1>) | null,
+    onrejected?: ((reason: unknown) => TR2 | PromiseLike<TR2>) | null,
+  ): PromiseLike<TR1 | TR2> {
+    return this.execute().then(onfulfilled, onrejected);
+  }
+
+  private async execute(): Promise<AdapterResult<T>> {
+    if (!this.action) {
+      return errResult("no action specified", "MYC_PGLITE_NO_ACTION");
+    }
+    try {
+      const { sql, params } = this.buildSql();
+      const result = await this.run(sql, params);
+      return shapeResult<T>(result.rows, this.action, this.singleMode);
+    } catch (err) {
+      return errResult(formatError(err), "MYC_PGLITE_QUERY_ERROR");
+    }
+  }
+
+  private buildSql(): { sql: string; params: unknown[] } {
+    const params: unknown[] = [];
+    const push = (v: unknown) => this.pushParam(params, v);
+    const action = this.action!;
+    const tbl = quoteIdent(this.table);
+    let sql = "";
+
+    if (action.kind === "select") {
+      sql = `SELECT ${action.cols} FROM ${tbl}`;
+    } else if (action.kind === "insert") {
+      if (action.values.length === 0) {
+        throw new Error("insert(): empty value list");
+      }
+      // Union of column sets across all rows. PostgREST treats a heterogeneous
+      // bulk insert as union-with-NULL-for-absent; taking keys from row 0 only
+      // would silently drop columns that appear in later rows.
+      const colSet = new Set<string>();
+      for (const row of action.values) {
+        for (const k of Object.keys(row)) colSet.add(k);
+      }
+      const cols = [...colSet];
+      const colsSql = cols.map(quoteIdent).join(", ");
+      const rowsSql = action.values
+        .map((row) => {
+          const vals = cols.map((c) =>
+            Object.prototype.hasOwnProperty.call(row, c) ? push(row[c]) : "DEFAULT",
+          );
+          return `(${vals.join(", ")})`;
+        })
+        .join(", ");
+      sql = `INSERT INTO ${tbl} (${colsSql}) VALUES ${rowsSql}`;
+    } else if (action.kind === "update") {
+      const cols = Object.keys(action.values);
+      const setSql = cols
+        .map((c) => `${quoteIdent(c)} = ${push(action.values[c])}`)
+        .join(", ");
+      sql = `UPDATE ${tbl} SET ${setSql}`;
+    } else if (action.kind === "delete") {
+      sql = `DELETE FROM ${tbl}`;
+    }
+
+    if (this.filters.length > 0) {
+      const whereSql = this.filters
+        .map((f) => filterToSql(f, push))
+        .join(" AND ");
+      sql += ` WHERE ${whereSql}`;
+    }
+
+    if (action.kind === "select") {
+      if (this.orders.length > 0) {
+        sql += ` ORDER BY ${this.orders.map(orderToSql).join(", ")}`;
+      }
+      if (this.limitN !== null) {
+        sql += ` LIMIT ${this.limitN}`;
+      }
+    }
+
+    if (action.kind !== "select") {
+      const ret = action.returning;
+      if (ret !== null) {
+        sql += ` RETURNING ${ret || "*"}`;
+      }
+    }
+
+    return { sql, params };
+  }
+}
+
+function shapeResult<T>(
+  rows: PgLikeRow[],
+  action: Action,
+  singleMode: Single,
+): AdapterResult<T> {
+  const isWriteWithoutReturning =
+    action.kind !== "select" && action.kind && (action as { returning: string | null }).returning === null;
+
+  if (isWriteWithoutReturning) {
+    return { data: null, error: null };
+  }
+
+  if (singleMode === "single") {
+    if (rows.length === 0) {
+      return {
+        data: null,
+        error: { message: "JSON object requested, multiple (or no) rows returned", code: "PGRST116" },
+      };
+    }
+    if (rows.length > 1) {
+      return {
+        data: null,
+        error: { message: "more than one row returned by single()", code: "PGRST116" },
+      };
+    }
+    return { data: rows[0] as T, error: null };
+  }
+
+  if (singleMode === "maybe") {
+    if (rows.length === 0) return { data: null, error: null };
+    if (rows.length > 1) {
+      return {
+        data: null,
+        error: { message: "more than one row returned by maybeSingle()", code: "PGRST116" },
+      };
+    }
+    return { data: rows[0] as T, error: null };
+  }
+
+  return { data: rows as unknown as T, error: null };
+}
+
+function filterToSql(
+  f: Filter,
+  push: (v: unknown) => string,
+): string {
+  if (f.op === "or" && f.raw) return f.raw;
+  if (!f.col) throw new Error(`filter has no column: ${f.op}`);
+  const col = quoteIdent(f.col);
+  if (f.op === "in") {
+    const arr = (f.val as unknown[]) ?? [];
+    if (arr.length === 0) {
+      // Postgres rejects empty IN(); produce always-false predicate to match
+      // PostgREST's "no match" semantics.
+      return "FALSE";
+    }
+    const placeholders = arr.map((v) => push(v));
+    return `${col} IN (${placeholders.join(", ")})`;
+  }
+  const opSql: Record<FilterOp, string> = {
+    eq: "=",
+    neq: "<>",
+    gt: ">",
+    gte: ">=",
+    lt: "<",
+    lte: "<=",
+    in: "IN",
+  };
+  return `${col} ${opSql[f.op as FilterOp]} ${push(f.val)}`;
+}
+
+function orderToSql(o: OrderClause): string {
+  let s = `${quoteIdent(o.col)} ${o.ascending ? "ASC" : "DESC"}`;
+  if (o.nullsFirst === true) s += " NULLS FIRST";
+  else if (o.nullsFirst === false) s += " NULLS LAST";
+  return s;
+}
+
+function splitOrClauses(s: string): string[] {
+  // Accepts `col.op.val,col.op.val` and respects parens for nested groups
+  // (we don't actually use them today; this is forward-protection).
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "(") depth++;
+    else if (c === ")") depth--;
+    else if (c === "," && depth === 0) {
+      out.push(s.slice(start, i));
+      start = i + 1;
+    }
+  }
+  out.push(s.slice(start));
+  return out.map((x) => x.trim()).filter(Boolean);
+}
+
+function orClauseToSql(clause: string): string {
+  const m = clause.match(/^([A-Za-z_][A-Za-z0-9_]*)\.([a-z]+)\.(.+)$/);
+  if (!m) throw new Error(`unsupported or() clause: ${clause}`);
+  const [, col, op, raw] = m;
+  const map: Record<string, string> = {
+    eq: "=", neq: "<>", lt: "<", lte: "<=", gt: ">", gte: ">=",
+  };
+  const sqlOp = map[op];
+  if (!sqlOp) throw new Error(`unsupported or() operator: ${op}`);
+  const lit = parseOrLiteral(raw);
+  return `${quoteIdent(col)} ${sqlOp} ${lit}`;
+}
+
+function parseOrLiteral(raw: string): string {
+  // PostgREST or() clauses are urlencoded; our one in-tree caller passes
+  // literal numerics and string enums so the inline-literal path is enough.
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return raw;
+  return `'${raw.replace(/'/g, "''")}'`;
+}
+
+function quoteIdent(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`unsafe identifier: ${name}`);
+  }
+  return `"${name}"`;
+}
+
+interface SerializedParam {
+  value: unknown;
+  /** Optional explicit Postgres cast (e.g. "jsonb", "vector"). PGlite is
+   *  stricter than PostgREST about parameter typing — strings need an
+   *  explicit cast when the column is JSONB or VECTOR. */
+  cast: string | null;
+}
+
+function serializeValue(v: unknown): SerializedParam {
+  if (v === undefined || v === null) return { value: null, cast: null };
+  if (Array.isArray(v)) {
+    if (v.length > 0 && v.every((x) => typeof x === "number")) {
+      // pgvector textual form — handles our VECTOR(N) embedding columns.
+      return { value: `[${v.join(",")}]`, cast: "vector" };
+    }
+    if (v.length > 0 && v.every((x) => typeof x === "string")) {
+      // TEXT[] columns (e.g. memories.tags). Postgres array literal:
+      // {"a","b"}. We escape per the array_in() rules.
+      return { value: encodeTextArray(v as string[]), cast: "text[]" };
+    }
+    // Empty / mixed / structured arrays route through JSONB. Empty arrays
+    // would also satisfy a TEXT[] column, but TEXT[] vs JSONB ambiguity
+    // for `[]` is unresolvable without column metadata; we side with JSONB
+    // because every TEXT[] column in the schema (`tags`, `tools_used`)
+    // also accepts NULL/`{}`-as-empty, while JSONB is the more common shape.
+    return { value: JSON.stringify(v), cast: "jsonb" };
+  }
+  if (typeof v === "object") {
+    return { value: JSON.stringify(v), cast: "jsonb" };
+  }
+  return { value: v, cast: null };
+}
+
+function encodeTextArray(items: string[]): string {
+  // Postgres array literal: `{"a","b"}` with embedded `"` and `\` escaped.
+  const parts = items.map((s) => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`);
+  return `{${parts.join(",")}}`;
+}
+
+function pushParam(params: unknown[], v: unknown): string {
+  const s = serializeValue(v);
+  params.push(s.value);
+  return s.cast ? `$${params.length}::${s.cast}` : `$${params.length}`;
+}
+
+function formatError(err: unknown): string {
+  if (!err) return "unknown";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return JSON.stringify(err);
+}
+
+function errResult<T>(message: string, code: string): AdapterResult<T> {
+  return { data: null, error: { message, code } };
+}
+
+/**
+ * PGlite adapter — single in-process instance with a serialized op queue.
+ *
+ * Concurrency model: PGlite is single-connection. If two services kick off
+ * parallel queries, libpglite serializes them anyway (last write wins on the
+ * shared cursor). We make that explicit with a Promise chain, so every adapter
+ * call observes the database in a deterministic order.
+ */
+export class PGliteAdapter {
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly pg: PGlite) {}
+
+  /** Underlying PGlite handle — escape hatch for migrations / debugging. */
+  raw(): PGlite { return this.pg; }
+
+  from<T = unknown>(table: string): QueryBuilder<T> {
+    return new QueryBuilder<T>(table, (sql, params) => this.run(sql, params));
+  }
+
+  async rpc<T = unknown>(name: string, args: Record<string, unknown> = {}): Promise<AdapterResult<T>> {
+    const argNames = Object.keys(args);
+    const params: unknown[] = [];
+    const argSql = argNames
+      .map((n) => {
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(n)) {
+          throw new Error(`unsafe RPC arg name: ${n}`);
+        }
+        return `${n} := ${pushParam(params, args[n])}`;
+      })
+      .join(", ");
+    const sql = `SELECT * FROM ${quoteIdent(name)}(${argSql})`;
+    try {
+      const result = await this.run(sql, params);
+      // Functions returning a scalar collapse `{ "<name>": value }` to value;
+      // table-returning functions surface row arrays directly. We follow the
+      // PostgREST convention: scalars unwrap, sets stay as arrays.
+      const rows = result.rows as Array<Record<string, unknown>>;
+      if (rows.length === 0) return { data: null, error: null };
+      if (rows.length === 1 && Object.keys(rows[0]).length === 1 && Object.prototype.hasOwnProperty.call(rows[0], name)) {
+        return { data: rows[0][name] as T, error: null };
+      }
+      return { data: rows as unknown as T, error: null };
+    } catch (err) {
+      return errResult(formatError(err), "MYC_PGLITE_RPC_ERROR");
+    }
+  }
+
+  private run(sql: string, params: unknown[] = []): Promise<PgLikeResult> {
+    const next = this.queue.then(async () => {
+      // PGlite's query() resolves to `{ rows, fields, ... }`. Casting via
+      // unknown silences the structural mismatch with our minimal interface.
+      return (await this.pg.query(sql, params)) as unknown as PgLikeResult;
+    });
+    // Keep the chain alive even on failure so subsequent ops don't reject
+    // synchronously through the queue itself.
+    this.queue = next.catch(() => undefined);
+    return next;
+  }
+}


### PR DESCRIPTION
## Summary

Graduates the throwaway PGlite spike from #177/PR #179 into a **first-class adapter** under `mcp-server/src/native/` so the future native standalone app (#176) no longer needs Docker + PostgREST. This is the **adapter foundation only** — the env switch wire-up across all 24 services is the next sub-task (see [Out of scope](#out-of-scope) below).

Closes part of #184. Sub-task of #176.

## What landed

- **`mcp-server/src/native/pglite.ts`** — `PGliteAdapter` + `QueryBuilder` mirroring the slice of `@supabase/postgrest-js`'s surface our services consume:
  - `from(t).select|insert|update|delete().eq|neq|gt|gte|lt|lte|in|or|order|limit().single|maybeSingle()`
  - `rpc(name, args)` with PostgREST-equivalent scalar-vs-set unwrapping
  - Returns the same `{data, error}` envelope as `PostgrestClient`, including `PGRST116` for `single()` misses
  - Single Promise-chain queue (PGlite is single-connection); chain survives errors so a failed op does not poison subsequent ones
- **`mcp-server/src/native/factory.ts`** — `createNativeDb({ dataDir, migrationsDir, skipMigrations })` wires the eight contrib extensions and runs migrations on first start. Honours `MYCELIUM_PGLITE_DATA_DIR`; default per-platform path matches what the future Tauri shell will use.
- **`mcp-server/src/native/migration-runner.ts`** — idempotent runner, walks `supabase/migrations/*.sql` lexicographically, tracks applied files in `mycelium_pglite_migrations`, throws on first failure.
- **`mcp-server/src/__tests__/native/pglite-adapter.test.ts`** — 16 contract tests against a real in-memory PGlite. All green locally (~37s).
- **`docs/native-pg-spike.md`** — appended "Spike 1.5 — adapter shipped" section with design notes.

## Design choices worth flagging

- **Single Promise-chain queue.** PGlite is single-connection. The adapter serializes every op through one queue and keeps the chain alive past failures (the catch-and-swallow in `run()` is intentional: a SQL error must not poison subsequent ops).
- **Explicit Postgres casts on serialized parameters.** PGlite is stricter than PostgREST. `serializeValue` emits `\$N::vector` for numeric arrays (pgvector textual `[a,b,c]`), `\$N::text[]` for string arrays, `\$N::jsonb` for objects/mixed arrays. Without the casts, parametrized inserts into VECTOR / JSONB columns fail with "could not determine data type of parameter \$N".
- **`or()` parser is deliberately narrow.** Accepts the PostgREST `col.op.val,col.op.val` shape with `eq/neq/lt/lte/gt/gte`, throws on anything else. Matches what `services/identity.ts` actually emits today.
- **Surface intentionally narrow.** Adding a verb is a few lines; aiming for full PostgREST parity would be expensive scaffolding for behavior nothing exercises.

## Out of scope

The full #184 acceptance asks for the `MYCELIUM_DB_BACKEND=pglite` env switch wired through `MemoryService` *and* the other 23 services that build their own `PostgrestClient`, plus a CI gate running the entire test suite under `MYCELIUM_DB_BACKEND=pglite`. That is a cross-cutting refactor of every service constructor — kept out of this PR so the foundation lands cleanly first. Tracked as the immediate next sub-task.

## Pillar check

- **Pillar 1** (no cloud dependency): strengthened — production path now optionally has zero daemons.
- **Pillar 6** (security): data dir under user control, no socket exposed.

No pillar weakened. Docker path remains the default until the wire-up sub-task lands.

## Pre-existing main-branch failure (unrelated)

`mcp-server/src/__tests__/migration-077-lesson-evidence-origin.test.ts:140` fails on main and on this branch — PR #183 (`fix(install): quote position in 077 RETURNS TABLE`) updated the SQL to `"position" INT` but the test regex still expects `position INT`. Unrelated to PGlite work; will file as separate one-line test fix.

## Test plan

- [x] `npm run build` clean
- [x] 16 new adapter tests pass (`node --test 'dist/__tests__/native/pglite-adapter.test.js'`)
- [x] Full test suite: 954 pass / 1 fail (the unrelated 077 regex regression on main)
- [ ] Reed merges; follow-up PR wires `MYCELIUM_DB_BACKEND` env switch through services

🤖 Generated with [Claude Code](https://claude.com/claude-code)