### PR TITLE
fix(test): match quoted "position" in get_lesson_evidence regex (unblocks main CI)

### DIFF
--- a/mcp-server/src/__tests__/migration-077-lesson-evidence-origin.test.ts
+++ b/mcp-server/src/__tests__/migration-077-lesson-evidence-origin.test.ts
@@ -182,7 +182,7 @@ test("get_lesson_evidence returns ordered (position, hashed_experience_id) pairs
   // implementation reconstruct the producer-canonical order without
   // relying on PostgreSQL's row-return order accidentally matching.
   // Ordering by position ASC is the §3.7.1 leaf-order contract.
-  assert.match(SQL, /create or replace function get_lesson_evidence\(p_lesson_id uuid\)\s+returns table \(position int, hashed_experience_id text\)\s+language sql stable/);
+  assert.match(SQL, /create or replace function get_lesson_evidence\(p_lesson_id uuid\)\s+returns table \("position" int, hashed_experience_id text\)\s+language sql stable/);
   assert.match(SQL, /select position, hashed_experience_id\s+from lesson_evidence_origin\s+where lesson_id = p_lesson_id\s+order by position asc/);
 });
 


### PR DESCRIPTION
## Why

`main` has been **red on every CI run since #183 / commit `0b853b9`** on a single assertion:

```
not ok 501 - get_lesson_evidence returns ordered (position, hashed_experience_id) pairs
```

That fresh-install fix did the right thing on the migration side — it quoted `"position"` in the `RETURNS TABLE` clause of `get_lesson_evidence` so PostgreSQL stops parsing `position` as the reserved-word call (`position(substring in string)`). But the matching regex in `mcp-server/src/__tests__/migration-077-lesson-evidence-origin.test.ts:185` still expects the **unquoted** form, so the test no longer matches the SQL it's asserting against.

Every downstream agent PR (currently #185 — the PGlite adapter foundation) inherits the red status, which obscures whether the PR's *own* changes broke anything.

## What

One-character regex fix in the existing test:

```diff
- /create or replace function get_lesson_evidence\(p_lesson_id uuid\)\s+returns table \(position int, hashed_experience_id text\)\s+language sql stable/
+ /create or replace function get_lesson_evidence\(p_lesson_id uuid\)\s+returns table \("position" int, hashed_experience_id text\)\s+language sql stable/
```

No migration touched. No production code touched. Just bringing the assertion in line with what `0b853b9` actually shipped.

## Verification

- `npm run build && npm test` locally: **939 / 939 green** (was 938 / 939).
- Targeted run of `migration-077-lesson-evidence-origin.test.js`: 18 / 18 green.

## Pillar check

No pillar touched — pure test alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)