### PR TITLE
feat(embeddings): LlamaCppEmbeddingProvider behind MYCELIUM_LLM_PROVIDER — #178 part 1

### DIFF
--- a/docs/native-llm-spike.md
+++ b/docs/native-llm-spike.md
@@ -161,3 +161,22 @@ Follow-up issue #178 part 1 (PR pending). Lands the embedding side of the spike'
 **Default not flipped.** Per the tokenizer-divergence warning above, switching the default would invalidate stored vectors on existing installs. The default stays `ollama`; native installs (#176 sub-task 4, Tauri shell) will set the env explicitly when they ship a fresh data dir.
 
 **Out of this PR.** Cosine-similarity cross-validation against Ollama (deferred to a CI gate before any default flip), automatic model SHA-256 verification (Pillar 6 follow-up #4 above), chat provider, and the REM-digest re-route.
+
+---
+
+## Implementation 2 — GGUF SHA-256 verification (Pillar 6)
+
+Closes the SHA-256 gap from Implementation 1. Lives in `mcp-server/src/services/llama-gguf-checksum.ts`; `LlamaCppEmbeddingProvider.init()` calls it after `resolveModelFile` and before `loadModel`.
+
+**Manifest.** `KNOWN_GGUF_CHECKSUMS` maps the exact `hf:` URI to `{ sha256, size }`. Entries are sourced from each repo's HF Hub LFS metadata (`/api/models/<repo>/tree/main` — the `lfs.oid` field IS the file's SHA-256). Adding a new default model is a 3-line PR. Captured 2026-05-02 for the default `nomic-embed-text-v1.5.Q5_K_M.gguf`.
+
+**Override.** `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256` overrides the manifest. Reason: power users running custom GGUFs via `MYCELIUM_LLAMA_EMBEDDING_MODEL_URI` should still be able to opt into verification with their own known-good hash.
+
+**Unknown URI policy.** Custom URI without override: WARN to stderr and skip the check. Fail-closed would lock out anyone running a non-bundled GGUF — the manifest can never enumerate every Hugging Face repo. Default URIs always resolve via the manifest, so the happy-path install gets verification for free.
+
+**Mismatch behaviour.** Stream-hash the file, compare against expected, on mismatch `fs.rm(file, { force: true })` and throw `GgufChecksumMismatch` with both expected/actual hex (and sizes if pre-check caught it). The next process start re-downloads cleanly. Streamed chunk-by-chunk — a 100 MB GGUF never lives in RAM.
+
+**Knobs.** Same as Implementation 1, plus:
+- `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256` — opt-in hash for custom URIs (lower-cased, stripped).
+
+**Tests.** `mcp-server/src/__tests__/llama-gguf-checksum.test.ts` — 11 unit tests covering: hash match, size pre-check + delete, hash mismatch + delete, idempotent rm on race, lookup precedence (override > manifest > null), case folding, and a structural assertion that the default URI is always in the manifest (so a future URI bump can't silently lose its check).

--- a/docs/native-llm-spike.md
+++ b/docs/native-llm-spike.md
@@ -138,3 +138,26 @@ gpu=metal · build=prebuilt · MTL EMBED_LIBRARY · NEON · ACCELERATE · LLAMAF
 
 - **Pillar 1 (decentralised AI)** — strengthened. Removing the daemon dependency moves the entire LLM stack into the user's own process; no separate service to misconfigure or compromise.
 - **Pillar 6 (cyber security)** — neutral with required follow-up. Model files come from Hugging Face; we must add SHA-256 verification before flipping the default. The `node-llama-cpp` package itself is npm-distributed and audit-trackable like any other dep.
+
+---
+
+## Implementation 1 — `LlamaCppEmbeddingProvider` shipped
+
+Follow-up issue #178 part 1 (PR pending). Lands the embedding side of the spike's recommendation as a real provider in `mcp-server/src/services/embeddings.ts`. Chat provider + REM-digest re-route stays a separate sub-task.
+
+**Selection.** Set `MYCELIUM_LLM_PROVIDER=llama-cpp` (or alias `llamacpp`). Default remains `ollama` so no existing install changes behaviour. Unknown values throw at startup rather than silently falling back.
+
+**Knobs.**
+- `MYCELIUM_LLAMA_MODELS_DIR` — absolute path; defaults to OS app-data (`~/Library/Application Support/mycelium/models` on macOS, `%APPDATA%\mycelium\models` on Windows, `$XDG_DATA_HOME/mycelium/models` on Linux). Same convention as the PGlite data dir from #185 — both consumed by the future Tauri shell.
+- `MYCELIUM_LLAMA_EMBEDDING_MODEL_URI` — Hugging Face URI for the GGUF; defaults to `hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q5_K_M.gguf` (the dim-768 variant the schema expects).
+- `EMBEDDING_DIMENSIONS` — checked against the loaded model's `embeddingVectorSize`; mismatch throws with a clear message instead of silently producing the wrong-shaped vector.
+
+**Lifecycle.** Lazy init: the first `embed()` call triggers model download (cached) and embedding-context creation. Subsequent calls reuse the same context. `dispose()` releases the runtime — long-lived MCP processes simply let the process exit drop it.
+
+**Concurrency.** PGlite-style Promise-chain serializer (matches PR #185's adapter). The embedding context handles one call at a time; the queue keeps a failed embed from poisoning subsequent ops, so a single malformed input does not take down the provider.
+
+**Packaging.** `node-llama-cpp` is added as an `optionalDependencies` entry, not a hard dep. Reasoning: it pulls per-platform native binaries on `npm install`, so `optionalDependencies` lets niche or unsupported platforms (e.g., a future linux-musl runner) still install the rest of mycelium. The dynamic import inside the provider throws a clear "install node-llama-cpp or switch to ollama" error if the runtime tries to use llama-cpp without the binding present.
+
+**Default not flipped.** Per the tokenizer-divergence warning above, switching the default would invalidate stored vectors on existing installs. The default stays `ollama`; native installs (#176 sub-task 4, Tauri shell) will set the env explicitly when they ship a fresh data dir.
+
+**Out of this PR.** Cosine-similarity cross-validation against Ollama (deferred to a CI gate before any default flip), automatic model SHA-256 verification (Pillar 6 follow-up #4 above), chat provider, and the REM-digest re-route.

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vectormemory-mcp-server",
+  "name": "mycelium-mcp-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vectormemory-mcp-server",
+      "name": "mycelium-mcp-server",
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -19,6 +19,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "node-llama-cpp": "^3.4.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -32,6 +35,46 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.8.tgz",
+      "integrity": "sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -71,6 +114,413 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-arm64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.18.1.tgz",
+      "integrity": "sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-armv7l": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-armv7l/-/linux-armv7l-3.18.1.tgz",
+      "integrity": "sha512-BrJL2cGo0pN5xd5nw+CzTn2rFMpz9MJyZZPUY81ptGkF2uIuXT2hdCVh56i9ImQrTwBfq1YcZL/l/Qe/1+HR/Q==",
+      "cpu": [
+        "arm",
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64/-/linux-x64-3.18.1.tgz",
+      "integrity": "sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.18.1.tgz",
+      "integrity": "sha512-qOaYP4uwsUoBHQ/7xSOvyJIuXapS57Al+Sudgi00f96ldNZLKe1vuSGptAi5LTM2lIj66PKm6h8PlRWctwsZ2g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.18.1.tgz",
+      "integrity": "sha512-VqyKhAVHPCpFzh0f1koCBgpThL+04QOXwv0oDQ8s8YcpfMMOXQlBhTB0plgTh0HrPExoObfTS4ohkrbyGgmztQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-vulkan": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.18.1.tgz",
+      "integrity": "sha512-SIaNTK5pUPhwJD0gmiQfHa8OrRctVMmnqu+slJrz2Mzgg/XrwFndJlS9hvc+jSjTXCouwf7sYeQaaJWvQgBh/A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-arm64-metal": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-arm64-metal/-/mac-arm64-metal-3.18.1.tgz",
+      "integrity": "sha512-cyZTdsUMlvuRlGmkkoBbN3v/DT6NuruEqoQYd9CqIrPyLa1xLNBTSKIZ9SgRnw23iCOj4URfITvRP+2pu63LuQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-x64/-/mac-x64-3.18.1.tgz",
+      "integrity": "sha512-GfCPgdltaIpBhEnQ7WfsrRXrZO9r9pBtDUAQMXRuJwOPP5q7xKrQZUXI6J6mpc8tAG0//CTIuGn4hTKoD/8V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-arm64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-arm64/-/win-arm64-3.18.1.tgz",
+      "integrity": "sha512-S05YUzBMVSRS5KNbOS26cDYugeQHqogI3uewtTUBVC0tPbTHRSKjsdicmgWru1eNAry399LWWhzOf/3St/qsAw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64/-/win-x64-3.18.1.tgz",
+      "integrity": "sha512-QLDVphPl+YDI+x/VYYgIV1N9g0GMXk3PqcoopOUG3cBRUtce7FO+YX903YdRJezs4oKbIp8YaO+xYBgeUSqhpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.18.1.tgz",
+      "integrity": "sha512-drgJmBhnxGQtB/SLo4sf4PPSuxRv3MdNP0FF6rKPY9TtzEOV293bRQyYEu/JYwvXfVApAIsRaJUTGvCkA9Qobw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda-ext": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.18.1.tgz",
+      "integrity": "sha512-u0FzJBQsJA355ksKERxwPJhlcWl3ZJSNkU2ZUwDEiKNOCbv3ybvSCIEyDvB63wdtkfVUuCRJWijZnpDZxrCGqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-vulkan": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.18.1.tgz",
+      "integrity": "sha512-PjmxrnPToi7y0zlP7l+hRIhvOmuEv94P6xZ11vjqICEJu8XdAJpvTfPKgDW4W0p0v4+So8ZiZYLUuwIHcsseyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@reflink/reflink": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
+      "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink-darwin-arm64": "0.1.19",
+        "@reflink/reflink-darwin-x64": "0.1.19",
+        "@reflink/reflink-linux-arm64-gnu": "0.1.19",
+        "@reflink/reflink-linux-arm64-musl": "0.1.19",
+        "@reflink/reflink-linux-x64-gnu": "0.1.19",
+        "@reflink/reflink-linux-x64-musl": "0.1.19",
+        "@reflink/reflink-win32-arm64-msvc": "0.1.19",
+        "@reflink/reflink-win32-x64-msvc": "0.1.19"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-arm64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
+      "integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-x64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
+      "integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
+      "integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
+      "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
+      "integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
+      "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-arm64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
+      "integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-x64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
+      "integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -159,6 +609,20 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tinyhttp/content-disposition": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
+      "integrity": "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -223,6 +687,55 @@
         }
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -283,6 +796,224 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chmodrp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chmodrp/-/chmodrp-1.0.2.tgz",
+      "integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cmake-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-8.0.0.tgz",
+      "integrity": "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fs-extra": "^11.3.3",
+        "node-api-headers": "^1.8.0",
+        "rc": "1.2.8",
+        "semver": "^7.7.3",
+        "tar": "^7.5.6",
+        "url-join": "^4.0.1",
+        "which": "^6.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cmake-js/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/content-disposition": {
@@ -373,6 +1104,16 @@
         }
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -402,6 +1143,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -409,6 +1157,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/env-var": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
+      "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/es-define-property": {
@@ -441,6 +1199,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -455,6 +1223,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -560,6 +1335,35 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -599,6 +1403,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -606,6 +1425,29 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -656,6 +1498,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -735,11 +1584,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -759,11 +1625,147 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ipull": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.5.tgz",
+      "integrity": "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tinyhttp/content-disposition": "^2.2.0",
+        "async-retry": "^1.3.3",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "commander": "^10.0.0",
+        "eventemitter3": "^5.0.1",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.1.1",
+        "is-unicode-supported": "^2.0.0",
+        "lifecycle-utils": "^2.0.1",
+        "lodash.debounce": "^4.0.8",
+        "lowdb": "^7.0.1",
+        "pretty-bytes": "^6.1.0",
+        "pretty-ms": "^8.0.0",
+        "sleep-promise": "^9.1.0",
+        "slice-ansi": "^7.1.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.1.0"
+      },
+      "bin": {
+        "ipull": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/ido-pluto/ipull?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink": "^0.1.16"
+      }
+    },
+    "node_modules/ipull/node_modules/lifecycle-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.1.0.tgz",
+      "integrity": "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ipull/node_modules/parse-ms": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/pretty-ms": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "parse-ms": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -791,6 +1793,66 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lifecycle-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.1.tgz",
+      "integrity": "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowdb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
+      "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "steno": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -847,11 +1909,76 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -860,6 +1987,121 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.8.0.tgz",
+      "integrity": "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-llama-cpp": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/node-llama-cpp/-/node-llama-cpp-3.18.1.tgz",
+      "integrity": "sha512-w0zfuy/IKS2fhrbed5SylZDXJHTVz4HnkwZ4UrFPgSNwJab3QIPwIl4lyCKHHy9flLrtxsAuV5kXfH3HZ6bb8w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "async-retry": "^1.3.3",
+        "bytes": "^3.1.2",
+        "chalk": "^5.6.2",
+        "chmodrp": "^1.0.2",
+        "cmake-js": "^8.0.0",
+        "cross-spawn": "^7.0.6",
+        "env-var": "^7.5.0",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.3.4",
+        "ignore": "^7.0.4",
+        "ipull": "^3.9.5",
+        "is-unicode-supported": "^2.1.0",
+        "lifecycle-utils": "^3.1.1",
+        "log-symbols": "^7.0.1",
+        "nanoid": "^5.1.6",
+        "node-addon-api": "^8.6.0",
+        "ora": "^9.3.0",
+        "pretty-ms": "^9.3.0",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.7.1",
+        "simple-git": "^3.33.0",
+        "slice-ansi": "^8.0.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.2.0",
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "nlc": "dist/cli/cli.js",
+        "node-llama-cpp": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/giladgd"
+      },
+      "optionalDependencies": {
+        "@node-llama-cpp/linux-arm64": "3.18.1",
+        "@node-llama-cpp/linux-armv7l": "3.18.1",
+        "@node-llama-cpp/linux-x64": "3.18.1",
+        "@node-llama-cpp/linux-x64-cuda": "3.18.1",
+        "@node-llama-cpp/linux-x64-cuda-ext": "3.18.1",
+        "@node-llama-cpp/linux-x64-vulkan": "3.18.1",
+        "@node-llama-cpp/mac-arm64-metal": "3.18.1",
+        "@node-llama-cpp/mac-x64": "3.18.1",
+        "@node-llama-cpp/win-arm64": "3.18.1",
+        "@node-llama-cpp/win-x64": "3.18.1",
+        "@node-llama-cpp/win-x64-cuda": "3.18.1",
+        "@node-llama-cpp/win-x64-cuda-ext": "3.18.1",
+        "@node-llama-cpp/win-x64-vulkan": "3.18.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/object-assign": {
@@ -913,6 +2155,71 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -948,6 +2255,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/proxy-addr": {
@@ -1002,6 +2360,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1009,6 +2393,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/router": {
@@ -1032,6 +2456,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1177,6 +2614,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/sleep-promise": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
+      "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1184,6 +2670,133 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdout-update": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stdout-update/-/stdout-update-4.0.1.tgz",
+      "integrity": "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-escapes": "^6.2.0",
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/stdout-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stdout-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/steno": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
+      "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/toidentifier": {
@@ -1219,7 +2832,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1235,6 +2848,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1242,6 +2865,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/vary": {
@@ -1274,6 +2914,88 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1299,6 +3021,116 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -17,6 +17,9 @@
     "ollama": "^0.5.16",
     "zod": "^3.25.1"
   },
+  "optionalDependencies": {
+    "node-llama-cpp": "^3.4.0"
+  },
   "devDependencies": {
     "@types/node": "^22.15.17",
     "typescript": "^5.8.3"

--- a/mcp-server/src/__tests__/llama-cpp-embedding.test.ts
+++ b/mcp-server/src/__tests__/llama-cpp-embedding.test.ts
@@ -4,6 +4,7 @@ import {
   LlamaCppEmbeddingProvider,
   createEmbeddingProvider,
   defaultLlamaModelsDir,
+  parseBoolEnv,
 } from "../services/embeddings.js";
 
 test("LlamaCppEmbeddingProvider exposes default 768d (matches schema)", () => {
@@ -66,6 +67,47 @@ test("createEmbeddingProvider rejects unknown provider names", () => {
   } finally {
     if (prev === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
     else process.env.MYCELIUM_LLM_PROVIDER = prev;
+  }
+});
+
+test("parseBoolEnv: recognises canonical truthy spellings, ignores noise", () => {
+  for (const v of ["1", "true", "TRUE", "yes", "YES", "on", "  on  "]) {
+    assert.equal(parseBoolEnv(v), true, `expected truthy for ${JSON.stringify(v)}`);
+  }
+  for (const v of [undefined, "", "0", "false", "no", "off", "anything-else"]) {
+    assert.equal(parseBoolEnv(v), false, `expected falsy for ${JSON.stringify(v)}`);
+  }
+});
+
+test("createEmbeddingProvider: MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1 enables fail-closed mode", async () => {
+  const prevProvider = process.env.MYCELIUM_LLM_PROVIDER;
+  const prevRequire  = process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM;
+  const prevUri      = process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI;
+  const prevHash     = process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256;
+  process.env.MYCELIUM_LLM_PROVIDER = "llama-cpp";
+  process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM = "1";
+  // Point at a URI that is NOT in the manifest, with no override hash, so
+  // init() must refuse rather than warn-and-skip.
+  process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI =
+    "hf:not-real/no-such-repo/no-such-file.gguf";
+  delete process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256;
+  try {
+    const p = createEmbeddingProvider();
+    assert.ok(p instanceof LlamaCppEmbeddingProvider);
+    // We never load the model — init() throws before resolveModelFile().
+    // The error must mention REQUIRE_CHECKSUM so the operator can correlate.
+    await assert.rejects(
+      () => p.embed("smoke"),
+      (err: unknown) => /MYCELIUM_LLAMA_REQUIRE_CHECKSUM/.test((err as Error).message)
+    );
+  } finally {
+    if (prevProvider === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
+    else process.env.MYCELIUM_LLM_PROVIDER = prevProvider;
+    if (prevRequire === undefined) delete process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM;
+    else process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM = prevRequire;
+    if (prevUri === undefined) delete process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI;
+    else process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI = prevUri;
+    if (prevHash !== undefined) process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 = prevHash;
   }
 });
 

--- a/mcp-server/src/__tests__/llama-cpp-embedding.test.ts
+++ b/mcp-server/src/__tests__/llama-cpp-embedding.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  LlamaCppEmbeddingProvider,
+  createEmbeddingProvider,
+  defaultLlamaModelsDir,
+} from "../services/embeddings.js";
+
+test("LlamaCppEmbeddingProvider exposes default 768d (matches schema)", () => {
+  const p = new LlamaCppEmbeddingProvider();
+  assert.equal(p.dimensions, 768);
+});
+
+test("LlamaCppEmbeddingProvider honours explicit dimensions option", () => {
+  const p = new LlamaCppEmbeddingProvider({ dimensions: 1024 });
+  assert.equal(p.dimensions, 1024);
+});
+
+test("defaultLlamaModelsDir returns an OS-appropriate absolute path", () => {
+  const dir = defaultLlamaModelsDir();
+  assert.ok(dir.length > 0);
+  assert.ok(dir.endsWith("models"), `expected …/models, got ${dir}`);
+});
+
+test("createEmbeddingProvider returns Llama provider when MYCELIUM_LLM_PROVIDER=llama-cpp", () => {
+  const prev = process.env.MYCELIUM_LLM_PROVIDER;
+  process.env.MYCELIUM_LLM_PROVIDER = "llama-cpp";
+  try {
+    const p = createEmbeddingProvider();
+    assert.ok(p instanceof LlamaCppEmbeddingProvider);
+    assert.equal(p.dimensions, 768);
+  } finally {
+    if (prev === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
+    else process.env.MYCELIUM_LLM_PROVIDER = prev;
+  }
+});
+
+test("createEmbeddingProvider accepts the 'llamacpp' alias", () => {
+  const prev = process.env.MYCELIUM_LLM_PROVIDER;
+  process.env.MYCELIUM_LLM_PROVIDER = "llamacpp";
+  try {
+    const p = createEmbeddingProvider();
+    assert.ok(p instanceof LlamaCppEmbeddingProvider);
+  } finally {
+    if (prev === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
+    else process.env.MYCELIUM_LLM_PROVIDER = prev;
+  }
+});
+
+test("createEmbeddingProvider defaults to Ollama when env unset", () => {
+  const prev = process.env.MYCELIUM_LLM_PROVIDER;
+  delete process.env.MYCELIUM_LLM_PROVIDER;
+  try {
+    const p = createEmbeddingProvider();
+    assert.ok(!(p instanceof LlamaCppEmbeddingProvider));
+  } finally {
+    if (prev !== undefined) process.env.MYCELIUM_LLM_PROVIDER = prev;
+  }
+});
+
+test("createEmbeddingProvider rejects unknown provider names", () => {
+  const prev = process.env.MYCELIUM_LLM_PROVIDER;
+  process.env.MYCELIUM_LLM_PROVIDER = "openai";
+  try {
+    assert.throws(() => createEmbeddingProvider(), /Unknown MYCELIUM_LLM_PROVIDER/);
+  } finally {
+    if (prev === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
+    else process.env.MYCELIUM_LLM_PROVIDER = prev;
+  }
+});
+
+// End-to-end test gated on env: downloads the GGUF (~84 MB) on first run,
+// then runs three embeds to verify dimensions, queue serialization, and
+// reuse of the cached embedding context. Skipped in CI by default — flip
+// MYCELIUM_TEST_LLAMA_CPP=1 to exercise locally.
+test(
+  "LlamaCppEmbeddingProvider produces 768d vectors against a real GGUF",
+  { skip: process.env.MYCELIUM_TEST_LLAMA_CPP !== "1" },
+  async () => {
+    const provider = new LlamaCppEmbeddingProvider();
+    try {
+      const a = await provider.embed("Reed bevorzugt deutsche Antworten.");
+      assert.equal(a.length, 768);
+      assert.ok(a.some((x) => x !== 0), "embedding should not be all-zero");
+      // Queued back-to-back calls must both resolve.
+      const [b, c] = await Promise.all([
+        provider.embed("Pillar 1 — decentralised, networked AI."),
+        provider.embed("Memory IDs are UUIDs."),
+      ]);
+      assert.equal(b.length, 768);
+      assert.equal(c.length, 768);
+    } finally {
+      await provider.dispose();
+    }
+  }
+);

--- a/mcp-server/src/__tests__/llama-gguf-checksum.test.ts
+++ b/mcp-server/src/__tests__/llama-gguf-checksum.test.ts
@@ -1,0 +1,153 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, writeFile, stat, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  KNOWN_GGUF_CHECKSUMS,
+  GgufChecksumMismatch,
+  lookupExpectedChecksum,
+  verifyGgufChecksum,
+} from "../services/llama-gguf-checksum.js";
+
+async function tmpFile(content: Buffer | string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "mycelium-gguf-test-"));
+  const file = path.join(dir, "fake.gguf");
+  await writeFile(file, content);
+  return file;
+}
+
+function sha256Hex(content: Buffer | string): string {
+  const buf = typeof content === "string" ? Buffer.from(content) : content;
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+test("verifyGgufChecksum: passes when SHA-256 + size match", async () => {
+  const content = Buffer.from("pretend this is a GGUF file");
+  const file = await tmpFile(content);
+  await verifyGgufChecksum(file, {
+    sha256: sha256Hex(content),
+    size: content.byteLength,
+  });
+  // File must still exist after a successful verify.
+  assert.ok(existsSync(file), "verified file should not be removed");
+  const persisted = await readFile(file);
+  assert.equal(persisted.toString(), content.toString());
+});
+
+test("verifyGgufChecksum: passes without size when only hash is provided", async () => {
+  const content = Buffer.from("only-hash check");
+  const file = await tmpFile(content);
+  await verifyGgufChecksum(file, { sha256: sha256Hex(content) });
+  assert.ok(existsSync(file));
+});
+
+test("verifyGgufChecksum: case-insensitive on the expected hex", async () => {
+  const content = Buffer.from("hello mixed-case world");
+  const file = await tmpFile(content);
+  await verifyGgufChecksum(file, { sha256: sha256Hex(content).toUpperCase() });
+  assert.ok(existsSync(file));
+});
+
+test("verifyGgufChecksum: throws + deletes file on size mismatch (no hash compute)", async () => {
+  const content = Buffer.from("bytes");
+  const file = await tmpFile(content);
+  const before = await stat(file);
+  await assert.rejects(
+    verifyGgufChecksum(file, {
+      sha256: sha256Hex(content),
+      size: before.size + 1,
+    }),
+    (err: unknown) => {
+      assert.ok(err instanceof GgufChecksumMismatch);
+      assert.equal((err as GgufChecksumMismatch).expectedSize, before.size + 1);
+      assert.equal((err as GgufChecksumMismatch).actualSize, before.size);
+      return true;
+    }
+  );
+  assert.equal(existsSync(file), false, "file must be removed on mismatch");
+});
+
+test("verifyGgufChecksum: throws + deletes file on hash mismatch", async () => {
+  const content = Buffer.from("real content");
+  const file = await tmpFile(content);
+  const wrong = "0".repeat(64);
+  await assert.rejects(
+    verifyGgufChecksum(file, { sha256: wrong, size: content.byteLength }),
+    (err: unknown) => {
+      assert.ok(err instanceof GgufChecksumMismatch);
+      assert.equal((err as GgufChecksumMismatch).expected, wrong);
+      assert.equal((err as GgufChecksumMismatch).actual, sha256Hex(content));
+      return true;
+    }
+  );
+  assert.equal(existsSync(file), false, "file must be removed on mismatch");
+});
+
+test("verifyGgufChecksum: idempotent rm — does not throw if file vanished", async () => {
+  // Race scenario: file is removed by something else between size check and
+  // hash stream. fs.rm({ force: true }) absorbs the ENOENT — the
+  // GgufChecksumMismatch must still surface, not a stray ENOENT.
+  const content = Buffer.from("content");
+  const file = await tmpFile(content);
+  // Pre-remove to simulate the race.
+  const { promises: fsp } = await import("node:fs");
+  await fsp.unlink(file);
+  await assert.rejects(
+    verifyGgufChecksum(file, {
+      sha256: sha256Hex(content),
+      size: content.byteLength,
+    }),
+    // Expect ENOENT from the size pre-check (file is gone) — not GgufChecksumMismatch.
+    (err: unknown) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      return code === "ENOENT";
+    }
+  );
+});
+
+test("lookupExpectedChecksum: env-style override wins over manifest", () => {
+  const knownUri = Object.keys(KNOWN_GGUF_CHECKSUMS)[0];
+  assert.ok(knownUri, "manifest must have at least one entry");
+  const override = "abc123";
+  const result = lookupExpectedChecksum(knownUri, override);
+  assert.deepEqual(result, { sha256: "abc123" });
+});
+
+test("lookupExpectedChecksum: empty override falls back to manifest", () => {
+  const knownUri = Object.keys(KNOWN_GGUF_CHECKSUMS)[0];
+  assert.ok(knownUri);
+  const fromManifest = KNOWN_GGUF_CHECKSUMS[knownUri];
+  assert.deepEqual(lookupExpectedChecksum(knownUri, ""), fromManifest);
+  assert.deepEqual(lookupExpectedChecksum(knownUri, "   "), fromManifest);
+  assert.deepEqual(lookupExpectedChecksum(knownUri, undefined), fromManifest);
+  assert.deepEqual(lookupExpectedChecksum(knownUri, null), fromManifest);
+});
+
+test("lookupExpectedChecksum: unknown URI returns null", () => {
+  assert.equal(lookupExpectedChecksum("hf:not-a-real/model/file.gguf"), null);
+});
+
+test("lookupExpectedChecksum: lower-cases override hashes", () => {
+  const result = lookupExpectedChecksum(
+    "hf:not-a-real/model/file.gguf",
+    "DEADBEEF"
+  );
+  assert.equal(result?.sha256, "deadbeef");
+});
+
+test("KNOWN_GGUF_CHECKSUMS: default embedding URI is in the manifest", () => {
+  // The default Llama embedding URI in services/embeddings.ts must always
+  // resolve to a manifest entry — otherwise out-of-the-box installs lose
+  // their Pillar 6 verification.
+  const defaultUri =
+    "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q5_K_M.gguf";
+  const entry = KNOWN_GGUF_CHECKSUMS[defaultUri];
+  assert.ok(entry, `default URI ${defaultUri} missing from manifest`);
+  assert.equal(entry.sha256.length, 64, "SHA-256 must be 64 hex chars");
+  assert.match(entry.sha256, /^[0-9a-f]+$/, "SHA-256 must be lower-case hex");
+  assert.ok(entry.size && entry.size > 0, "size must be present and positive");
+});

--- a/mcp-server/src/services/embeddings.ts
+++ b/mcp-server/src/services/embeddings.ts
@@ -2,6 +2,10 @@ import { Ollama } from "ollama";
 import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import {
+  lookupExpectedChecksum,
+  verifyGgufChecksum,
+} from "./llama-gguf-checksum.js";
 
 export interface EmbeddingProvider {
   embed(text: string): Promise<number[]>;
@@ -91,6 +95,21 @@ export interface LlamaCppEmbeddingProviderOptions {
   modelUri?: string;
   dimensions?: number;
   charBudget?: number;
+  /**
+   * Override / supply the expected SHA-256 of the model GGUF.
+   * If absent, falls back to the built-in `KNOWN_GGUF_CHECKSUMS` manifest.
+   * If neither resolves a hash, integrity check is skipped with a warning
+   * (or refused entirely when `requireChecksum` is true).
+   */
+  expectedSha256?: string | null;
+  /**
+   * Fail closed when no SHA-256 can be resolved (no manifest entry AND no
+   * override). Off by default — power users running custom GGUFs are not
+   * locked out. Security-conscious deployments flip this on via
+   * `MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1` so an unknown URI is refused
+   * outright instead of warned-and-skipped.
+   */
+  requireChecksum?: boolean;
 }
 
 const DEFAULT_LLAMA_EMBEDDING_MODEL_URI =
@@ -121,6 +140,8 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
   private readonly modelsDir: string;
   private readonly modelUri: string;
   private readonly charBudget: number;
+  private readonly expectedSha256: string | null;
+  private readonly requireChecksum: boolean;
   private ready: Promise<{
     ctx: { getEmbeddingFor: (text: string) => Promise<{ vector: number[] }> };
     dispose: () => Promise<void>;
@@ -132,6 +153,8 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
     this.modelUri = opts.modelUri ?? DEFAULT_LLAMA_EMBEDDING_MODEL_URI;
     this.dimensions = opts.dimensions ?? 768;
     this.charBudget = opts.charBudget ?? 6000;
+    this.expectedSha256 = opts.expectedSha256 ?? null;
+    this.requireChecksum = opts.requireChecksum ?? false;
   }
 
   private async init() {
@@ -156,9 +179,38 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
       }
       const { getLlama, LlamaLogLevel, resolveModelFile } = llamaCpp;
 
+      // Pillar 6 — resolve the manifest BEFORE downloading. Strict mode
+      // refuses unknown URIs outright instead of pulling a 100 MB GGUF
+      // that we'd then reject anyway.
+      const expected = lookupExpectedChecksum(this.modelUri, this.expectedSha256);
+      if (expected === null && this.requireChecksum) {
+        throw new Error(
+          `LlamaCppEmbeddingProvider: MYCELIUM_LLAMA_REQUIRE_CHECKSUM is ` +
+            `set but no SHA-256 is known for '${this.modelUri}'. Add the ` +
+            `URI to KNOWN_GGUF_CHECKSUMS or supply ` +
+            `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 with the expected hash.`
+        );
+      }
+
       await mkdir(this.modelsDir, { recursive: true });
       const llama = await getLlama({ logLevel: LlamaLogLevel.warn });
       const modelPath = await resolveModelFile(this.modelUri, this.modelsDir);
+
+      // Verify the (now-resolved) GGUF before loadModel touches it.
+      // Mismatch deletes the file and throws; the next run re-downloads.
+      if (expected !== null) {
+        await verifyGgufChecksum(modelPath, expected);
+      } else {
+        console.error(
+          `LlamaCppEmbeddingProvider: no SHA-256 manifest entry for ` +
+            `'${this.modelUri}' and no override supplied — skipping ` +
+            `integrity check (Pillar 6). Set ` +
+            `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 to enable verification ` +
+            `for custom models, or MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1 to ` +
+            `refuse unverified GGUFs outright.`
+        );
+      }
+
       const model = await llama.loadModel({ modelPath });
       if (model.embeddingVectorSize !== this.dimensions) {
         await model.dispose();
@@ -210,6 +262,16 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+/**
+ * Parse a boolean env var. Truthy: 1, true, yes, on (case-insensitive).
+ * Anything else (including undefined / empty) is false.
+ */
+export function parseBoolEnv(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
 export function createEmbeddingProvider(): EmbeddingProvider {
   const provider = (process.env.MYCELIUM_LLM_PROVIDER ?? "ollama")
     .toLowerCase()
@@ -226,6 +288,10 @@ export function createEmbeddingProvider(): EmbeddingProvider {
       modelUri: process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI,
       dimensions,
       charBudget,
+      expectedSha256: process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256,
+      requireChecksum: parseBoolEnv(
+        process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM
+      ),
     });
   }
 

--- a/mcp-server/src/services/embeddings.ts
+++ b/mcp-server/src/services/embeddings.ts
@@ -1,4 +1,7 @@
 import { Ollama } from "ollama";
+import { mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 export interface EmbeddingProvider {
   embed(text: string): Promise<number[]>;
@@ -62,13 +65,178 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+/**
+ * In-process embedding provider backed by node-llama-cpp + a GGUF model.
+ *
+ * Spike #178 (PR #182, docs/native-llm-spike.md) validated this as a
+ * drop-in replacement for the external Ollama daemon. Same `embed()`
+ * contract, same 768d output for `nomic-embed-text-v1.5`, ~1.27× slower
+ * but no second daemon required — the centerpiece of the native
+ * standalone-app track (#176, Welle 1).
+ *
+ * Selected by setting `MYCELIUM_LLM_PROVIDER=llama-cpp`. Ollama remains
+ * the default until cross-path embedding parity is verified end-to-end
+ * (see "Tokenizer warning" in the spike doc — switching the default on
+ * an existing install would invalidate stored vectors).
+ *
+ * `node-llama-cpp` is dynamically imported on first `embed()` call so
+ * the native binding is not loaded for installs that stay on Ollama.
+ *
+ * Concurrency: PGlite-style serializer. The embedding context processes
+ * one request at a time; queueing avoids contention and keeps a failed
+ * embed from poisoning subsequent calls.
+ */
+export interface LlamaCppEmbeddingProviderOptions {
+  modelsDir?: string;
+  modelUri?: string;
+  dimensions?: number;
+  charBudget?: number;
+}
+
+const DEFAULT_LLAMA_EMBEDDING_MODEL_URI =
+  "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q5_K_M.gguf";
+
+export function defaultLlamaModelsDir(): string {
+  if (process.platform === "darwin") {
+    return path.join(
+      os.homedir(),
+      "Library",
+      "Application Support",
+      "mycelium",
+      "models"
+    );
+  }
+  if (process.platform === "win32") {
+    const appData =
+      process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "mycelium", "models");
+  }
+  const xdg =
+    process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share");
+  return path.join(xdg, "mycelium", "models");
+}
+
+export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
+  readonly dimensions: number;
+  private readonly modelsDir: string;
+  private readonly modelUri: string;
+  private readonly charBudget: number;
+  private ready: Promise<{
+    ctx: { getEmbeddingFor: (text: string) => Promise<{ vector: number[] }> };
+    dispose: () => Promise<void>;
+  }> | null = null;
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(opts: LlamaCppEmbeddingProviderOptions = {}) {
+    this.modelsDir = opts.modelsDir ?? defaultLlamaModelsDir();
+    this.modelUri = opts.modelUri ?? DEFAULT_LLAMA_EMBEDDING_MODEL_URI;
+    this.dimensions = opts.dimensions ?? 768;
+    this.charBudget = opts.charBudget ?? 6000;
+  }
+
+  private async init() {
+    if (this.ready) return this.ready;
+    this.ready = (async () => {
+      // Dynamic import keeps the native binding off the cold-start path
+      // for installs that stay on Ollama. Use a runtime-computed specifier
+      // so TypeScript does not require node-llama-cpp's type defs to be
+      // resolvable in every consumer build.
+      const specifier = "node-llama-cpp";
+      let llamaCpp: any;
+      try {
+        llamaCpp = await import(specifier);
+      } catch (err) {
+        throw new Error(
+          `LlamaCppEmbeddingProvider: failed to load 'node-llama-cpp'. ` +
+            `Install it (npm i node-llama-cpp) or switch back to ` +
+            `MYCELIUM_LLM_PROVIDER=ollama. Underlying: ${
+              (err as Error).message ?? err
+            }`
+        );
+      }
+      const { getLlama, LlamaLogLevel, resolveModelFile } = llamaCpp;
+
+      await mkdir(this.modelsDir, { recursive: true });
+      const llama = await getLlama({ logLevel: LlamaLogLevel.warn });
+      const modelPath = await resolveModelFile(this.modelUri, this.modelsDir);
+      const model = await llama.loadModel({ modelPath });
+      if (model.embeddingVectorSize !== this.dimensions) {
+        await model.dispose();
+        await llama.dispose();
+        throw new Error(
+          `LlamaCppEmbeddingProvider: model embedding dim ` +
+            `${model.embeddingVectorSize} != configured ${this.dimensions}. ` +
+            `Adjust EMBEDDING_DIMENSIONS or pick a different GGUF.`
+        );
+      }
+      const ctx = await model.createEmbeddingContext();
+      return {
+        ctx,
+        dispose: async () => {
+          await ctx.dispose();
+          await model.dispose();
+          await llama.dispose();
+        },
+      };
+    })();
+    return this.ready;
+  }
+
+  private enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.queue.then(fn, fn);
+    this.queue = next.catch(() => undefined);
+    return next;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const sampled = sampleForEmbedding(text, this.charBudget);
+    if (sampled.length < text.length) {
+      console.error(
+        `Embedding input sampled: ${text.length} → ${sampled.length} chars (head+middle+tail)`
+      );
+    }
+    const { ctx } = await this.init();
+    return this.enqueue(async () => {
+      const result = await ctx.getEmbeddingFor(sampled);
+      return Array.from(result.vector);
+    });
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.ready) return;
+    const handle = await this.ready.catch(() => null);
+    this.ready = null;
+    if (handle) await handle.dispose();
+  }
+}
+
 export function createEmbeddingProvider(): EmbeddingProvider {
-  const url = process.env.OLLAMA_URL ?? "http://localhost:11434";
-  const model = process.env.EMBEDDING_MODEL ?? "nomic-embed-text";
+  const provider = (process.env.MYCELIUM_LLM_PROVIDER ?? "ollama")
+    .toLowerCase()
+    .trim();
   const dimensions = parseInt(
     process.env.EMBEDDING_DIMENSIONS ?? "768",
     10
   );
   const charBudget = parseInt(process.env.EMBEDDING_CHAR_BUDGET ?? "6000", 10);
+
+  if (provider === "llama-cpp" || provider === "llamacpp") {
+    return new LlamaCppEmbeddingProvider({
+      modelsDir: process.env.MYCELIUM_LLAMA_MODELS_DIR,
+      modelUri: process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI,
+      dimensions,
+      charBudget,
+    });
+  }
+
+  if (provider !== "ollama") {
+    throw new Error(
+      `Unknown MYCELIUM_LLM_PROVIDER='${provider}'. ` +
+        `Expected 'ollama' or 'llama-cpp'.`
+    );
+  }
+
+  const url = process.env.OLLAMA_URL ?? "http://localhost:11434";
+  const model = process.env.EMBEDDING_MODEL ?? "nomic-embed-text";
   return new OllamaEmbeddingProvider(url, model, dimensions, charBudget);
 }

--- a/mcp-server/src/services/llama-gguf-checksum.ts
+++ b/mcp-server/src/services/llama-gguf-checksum.ts
@@ -1,0 +1,151 @@
+/**
+ * GGUF integrity verification for the in-process llama-cpp provider.
+ *
+ * Why this exists (Pillar 6 — cyber security): models are downloaded over
+ * HTTPS from Hugging Face on first run. TLS authenticates the connection,
+ * but does not protect against an upstream replacement of the model file.
+ * A swapped GGUF could embed adversarial vectors that drift `recall()` in
+ * subtle ways. SHA-256 verification with a hard-coded manifest of known
+ * good hashes raises the bar to "compromise both Hugging Face *and* this
+ * repo" — the same bar npm package-lock integrity hashes, Homebrew
+ * bottles, and Linux distro signed packages set.
+ *
+ * Design:
+ *   - Manifest of known URI → checksum lives in this file. Keys are the
+ *     exact `hf:` URIs node-llama-cpp's `resolveModelFile` accepts.
+ *   - Source for the hashes is each repo's HF Hub LFS metadata (the LFS
+ *     oid IS the file's SHA-256). Adding a new entry is a 3-line PR.
+ *   - Users can override / supply a hash for a custom URI via env
+ *     (`MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256`).
+ *   - Unknown URI without override: we WARN and skip rather than fail
+ *     closed, so power users running custom GGUFs are not locked out.
+ *     Default model URIs always resolve via the manifest, so the
+ *     happy-path install gets verification for free.
+ *   - Mismatch deletes the file (so the next run re-downloads cleanly)
+ *     and throws — partial / corrupt GGUFs are not left lying around.
+ */
+
+import { createHash } from "node:crypto";
+import { createReadStream, promises as fs } from "node:fs";
+
+export interface GgufChecksum {
+  /** Hex-encoded SHA-256 of the file. Lower-case, no prefix. */
+  sha256: string;
+  /** Expected size in bytes. Cheap pre-check before the hash stream. */
+  size?: number;
+}
+
+/**
+ * Manifest of known-good checksums. Source: HF Hub LFS metadata
+ * (`https://huggingface.co/api/models/<repo>/tree/main`). The LFS oid
+ * field IS the SHA-256 of the LFS-pointed file.
+ *
+ * Captured 2026-05-02 for `nomic-ai/nomic-embed-text-v1.5-GGUF`.
+ */
+export const KNOWN_GGUF_CHECKSUMS: Record<string, GgufChecksum> = {
+  "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q5_K_M.gguf": {
+    sha256: "0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6",
+    size: 99588928,
+  },
+};
+
+export class GgufChecksumMismatch extends Error {
+  readonly filePath:     string;
+  readonly expected:     string;
+  readonly actual:       string;
+  readonly expectedSize: number | undefined;
+  readonly actualSize:   number | undefined;
+
+  constructor(opts: {
+    filePath:      string;
+    expected:      string;
+    actual:        string;
+    expectedSize?: number;
+    actualSize?:   number;
+  }) {
+    const sizeNote =
+      opts.expectedSize !== undefined && opts.actualSize !== undefined
+        ? ` (size: expected ${opts.expectedSize} B, got ${opts.actualSize} B)`
+        : "";
+    super(
+      `GGUF integrity check failed for ${opts.filePath}${sizeNote}: ` +
+        `expected SHA-256 ${opts.expected}, got ${opts.actual}. ` +
+        `File removed; re-running will re-download. If you trust the new ` +
+        `upstream, update KNOWN_GGUF_CHECKSUMS or set ` +
+        `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 to the new hash.`
+    );
+    this.name = "GgufChecksumMismatch";
+    this.filePath     = opts.filePath;
+    this.expected     = opts.expected;
+    this.actual       = opts.actual;
+    this.expectedSize = opts.expectedSize;
+    this.actualSize   = opts.actualSize;
+  }
+}
+
+/**
+ * Stream the file at `filePath` and compare its SHA-256 (and size if
+ * provided) against `expected`. On mismatch: removes the file with
+ * `force: true` (idempotent — safe if the file vanished mid-check) and
+ * throws `GgufChecksumMismatch`.
+ *
+ * Streams chunk-by-chunk — a 100 MB GGUF never lives in RAM as one
+ * buffer. Resolves only after the stream's `end` event.
+ */
+export async function verifyGgufChecksum(
+  filePath: string,
+  expected: GgufChecksum
+): Promise<void> {
+  const expectedHex = expected.sha256.toLowerCase();
+
+  if (expected.size !== undefined) {
+    const stat = await fs.stat(filePath);
+    if (stat.size !== expected.size) {
+      const actualSize = stat.size;
+      await fs.rm(filePath, { force: true });
+      throw new GgufChecksumMismatch({
+        filePath,
+        expected: expectedHex,
+        actual: "(size mismatch — not hashed)",
+        expectedSize: expected.size,
+        actualSize,
+      });
+    }
+  }
+
+  const hash = createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve());
+    stream.on("error", reject);
+  });
+  const actual = hash.digest("hex");
+
+  if (actual !== expectedHex) {
+    await fs.rm(filePath, { force: true });
+    throw new GgufChecksumMismatch({
+      filePath,
+      expected: expectedHex,
+      actual,
+    });
+  }
+}
+
+/**
+ * Resolve the expected checksum for a model URI.
+ *
+ * Lookup order:
+ *   1. Explicit `override` (env-supplied hash for custom URIs).
+ *   2. Built-in `KNOWN_GGUF_CHECKSUMS` manifest.
+ *   3. `null` — caller decides whether to fail closed or warn and skip.
+ */
+export function lookupExpectedChecksum(
+  modelUri: string,
+  override?: string | null | undefined
+): GgufChecksum | null {
+  if (override !== undefined && override !== null && override.trim() !== "") {
+    return { sha256: override.trim().toLowerCase() };
+  }
+  return KNOWN_GGUF_CHECKSUMS[modelUri] ?? null;
+}


### PR DESCRIPTION
## Summary

- Lands the **embedding side** of Spike 2's recommendation (PR #182, `docs/native-llm-spike.md`) as a real provider — the centerpiece of the native-app track (#176, Welle 1).
- Sets `MYCELIUM_LLM_PROVIDER=llama-cpp` to swap the in-process `node-llama-cpp` provider in for Ollama. Default stays `ollama`, so existing installs are unaffected.
- Identical `EmbeddingProvider` contract → all consumers (`MemoryService`, `import_markdown`, REM digest pre-stage) work unchanged.

## What changes

- **`LlamaCppEmbeddingProvider`** (new) — lazy-init, dynamic import of `node-llama-cpp`, OS-native models dir (`~/Library/Application Support/mycelium/models` on macOS, `%APPDATA%\mycelium\models` on Windows, `$XDG_DATA_HOME/mycelium/models` on Linux), 768d default to match `VECTOR(768)` schema, dim-mismatch guard, PGlite-style queue serializer (matches PR #185).
- **`createEmbeddingProvider()`** — env-driven factory: `ollama` (default) | `llama-cpp` (alias `llamacpp`). Unknown values throw at startup.
- **Packaging** — `node-llama-cpp@^3.4.0` added as `optionalDependencies` so niche/unsupported platforms can still install the rest of mycelium. Dynamic import inside the provider yields a clear "install node-llama-cpp or switch to ollama" error if the runtime is absent.
- **Tests** — 7 new unit tests (selection, dim, path defaults, alias, error path) plus an opt-in real-GGUF e2e test gated on `MYCELIUM_TEST_LLAMA_CPP=1` (downloads ~84 MB on first run, skipped in CI).
- **Docs** — `docs/native-llm-spike.md` adds an "Implementation 1" section documenting the integration contract.

## Why default is *not* flipped

The spike (`docs/native-llm-spike.md` §3) flagged a tokenizer-config warning on the nomic-embed-text GGUF: cross-path embedding parity with Ollama is **not yet validated**, and divergence below ~0.95 cosine would invalidate stored vectors on existing installs. Default-flip waits until a CI gate verifies parity. Fresh native-app installs (#176 sub-task 4, Tauri shell) start empty, so they can opt in safely.

## Out of scope

- Cosine-similarity cross-validation against Ollama (deferred CI gate)
- SHA-256 verification of GGUF downloads (Pillar 6 follow-up)
- Chat provider + REM-digest re-route (separate sub-task of #178)

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 946 pass, 1 skipped (gated e2e), 0 fail
- [ ] Local opt-in: `MYCELIUM_TEST_LLAMA_CPP=1 npm test -- --test-name-pattern 'real GGUF'` (verifies first-run download, 768d, queued concurrent embeds)
- [ ] Manual: `MYCELIUM_LLM_PROVIDER=llama-cpp npm run dev`, `remember()` a memory, `recall()` it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)