### PR TITLE
feat(security): MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1 fail-closed — Pillar 6 follow-up to #188

### DIFF
--- a/mcp-server/src/__tests__/llama-cpp-embedding.test.ts
+++ b/mcp-server/src/__tests__/llama-cpp-embedding.test.ts
@@ -4,6 +4,7 @@ import {
   LlamaCppEmbeddingProvider,
   createEmbeddingProvider,
   defaultLlamaModelsDir,
+  parseBoolEnv,
 } from "../services/embeddings.js";
 
 test("LlamaCppEmbeddingProvider exposes default 768d (matches schema)", () => {
@@ -66,6 +67,47 @@ test("createEmbeddingProvider rejects unknown provider names", () => {
   } finally {
     if (prev === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
     else process.env.MYCELIUM_LLM_PROVIDER = prev;
+  }
+});
+
+test("parseBoolEnv: recognises canonical truthy spellings, ignores noise", () => {
+  for (const v of ["1", "true", "TRUE", "yes", "YES", "on", "  on  "]) {
+    assert.equal(parseBoolEnv(v), true, `expected truthy for ${JSON.stringify(v)}`);
+  }
+  for (const v of [undefined, "", "0", "false", "no", "off", "anything-else"]) {
+    assert.equal(parseBoolEnv(v), false, `expected falsy for ${JSON.stringify(v)}`);
+  }
+});
+
+test("createEmbeddingProvider: MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1 enables fail-closed mode", async () => {
+  const prevProvider = process.env.MYCELIUM_LLM_PROVIDER;
+  const prevRequire  = process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM;
+  const prevUri      = process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI;
+  const prevHash     = process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256;
+  process.env.MYCELIUM_LLM_PROVIDER = "llama-cpp";
+  process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM = "1";
+  // Point at a URI that is NOT in the manifest, with no override hash, so
+  // init() must refuse rather than warn-and-skip.
+  process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI =
+    "hf:not-real/no-such-repo/no-such-file.gguf";
+  delete process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256;
+  try {
+    const p = createEmbeddingProvider();
+    assert.ok(p instanceof LlamaCppEmbeddingProvider);
+    // We never load the model — init() throws before resolveModelFile().
+    // The error must mention REQUIRE_CHECKSUM so the operator can correlate.
+    await assert.rejects(
+      () => p.embed("smoke"),
+      (err: unknown) => /MYCELIUM_LLAMA_REQUIRE_CHECKSUM/.test((err as Error).message)
+    );
+  } finally {
+    if (prevProvider === undefined) delete process.env.MYCELIUM_LLM_PROVIDER;
+    else process.env.MYCELIUM_LLM_PROVIDER = prevProvider;
+    if (prevRequire === undefined) delete process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM;
+    else process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM = prevRequire;
+    if (prevUri === undefined) delete process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI;
+    else process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_URI = prevUri;
+    if (prevHash !== undefined) process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 = prevHash;
   }
 });
 

--- a/mcp-server/src/services/embeddings.ts
+++ b/mcp-server/src/services/embeddings.ts
@@ -98,9 +98,18 @@ export interface LlamaCppEmbeddingProviderOptions {
   /**
    * Override / supply the expected SHA-256 of the model GGUF.
    * If absent, falls back to the built-in `KNOWN_GGUF_CHECKSUMS` manifest.
-   * If neither resolves a hash, integrity check is skipped with a warning.
+   * If neither resolves a hash, integrity check is skipped with a warning
+   * (or refused entirely when `requireChecksum` is true).
    */
   expectedSha256?: string | null;
+  /**
+   * Fail closed when no SHA-256 can be resolved (no manifest entry AND no
+   * override). Off by default — power users running custom GGUFs are not
+   * locked out. Security-conscious deployments flip this on via
+   * `MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1` so an unknown URI is refused
+   * outright instead of warned-and-skipped.
+   */
+  requireChecksum?: boolean;
 }
 
 const DEFAULT_LLAMA_EMBEDDING_MODEL_URI =
@@ -132,6 +141,7 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
   private readonly modelUri: string;
   private readonly charBudget: number;
   private readonly expectedSha256: string | null;
+  private readonly requireChecksum: boolean;
   private ready: Promise<{
     ctx: { getEmbeddingFor: (text: string) => Promise<{ vector: number[] }> };
     dispose: () => Promise<void>;
@@ -144,6 +154,7 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
     this.dimensions = opts.dimensions ?? 768;
     this.charBudget = opts.charBudget ?? 6000;
     this.expectedSha256 = opts.expectedSha256 ?? null;
+    this.requireChecksum = opts.requireChecksum ?? false;
   }
 
   private async init() {
@@ -168,13 +179,25 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
       }
       const { getLlama, LlamaLogLevel, resolveModelFile } = llamaCpp;
 
+      // Pillar 6 — resolve the manifest BEFORE downloading. Strict mode
+      // refuses unknown URIs outright instead of pulling a 100 MB GGUF
+      // that we'd then reject anyway.
+      const expected = lookupExpectedChecksum(this.modelUri, this.expectedSha256);
+      if (expected === null && this.requireChecksum) {
+        throw new Error(
+          `LlamaCppEmbeddingProvider: MYCELIUM_LLAMA_REQUIRE_CHECKSUM is ` +
+            `set but no SHA-256 is known for '${this.modelUri}'. Add the ` +
+            `URI to KNOWN_GGUF_CHECKSUMS or supply ` +
+            `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 with the expected hash.`
+        );
+      }
+
       await mkdir(this.modelsDir, { recursive: true });
       const llama = await getLlama({ logLevel: LlamaLogLevel.warn });
       const modelPath = await resolveModelFile(this.modelUri, this.modelsDir);
 
-      // Pillar 6 — verify the GGUF matches a known SHA-256 before loading.
+      // Verify the (now-resolved) GGUF before loadModel touches it.
       // Mismatch deletes the file and throws; the next run re-downloads.
-      const expected = lookupExpectedChecksum(this.modelUri, this.expectedSha256);
       if (expected !== null) {
         await verifyGgufChecksum(modelPath, expected);
       } else {
@@ -183,7 +206,8 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
             `'${this.modelUri}' and no override supplied — skipping ` +
             `integrity check (Pillar 6). Set ` +
             `MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256 to enable verification ` +
-            `for custom models.`
+            `for custom models, or MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1 to ` +
+            `refuse unverified GGUFs outright.`
         );
       }
 
@@ -238,6 +262,16 @@ export class LlamaCppEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+/**
+ * Parse a boolean env var. Truthy: 1, true, yes, on (case-insensitive).
+ * Anything else (including undefined / empty) is false.
+ */
+export function parseBoolEnv(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
 export function createEmbeddingProvider(): EmbeddingProvider {
   const provider = (process.env.MYCELIUM_LLM_PROVIDER ?? "ollama")
     .toLowerCase()
@@ -255,6 +289,9 @@ export function createEmbeddingProvider(): EmbeddingProvider {
       dimensions,
       charBudget,
       expectedSha256: process.env.MYCELIUM_LLAMA_EMBEDDING_MODEL_SHA256,
+      requireChecksum: parseBoolEnv(
+        process.env.MYCELIUM_LLAMA_REQUIRE_CHECKSUM
+      ),
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds `MYCELIUM_LLAMA_REQUIRE_CHECKSUM=1` env / `requireChecksum` option to `LlamaCppEmbeddingProvider`. When set and the GGUF URI has neither a manifest entry nor an override hash, init throws instead of warn-and-proceed. Default behaviour unchanged.
- Moves the manifest lookup BEFORE `resolveModelFile()` so strict mode does not pull a ~100 MB GGUF only to reject it.
- Adds `parseBoolEnv` helper and unit tests for both the parser and the fail-closed code-path.

## Why

PR #188 shipped soft Pillar 6: known URIs are verified, unknown URIs warn-and-skip so power users running custom GGUFs aren't locked out. Security-conscious deployments need the opposite default — refuse anything we can't verify. This adds the opt-in switch without changing the default surface.

## Test plan

- [x] `npm test` — 959 pass / 1 skip (full suite)
- [x] New unit test exercises the strict-mode rejection path with a fake URI; verifies the error message mentions `MYCELIUM_LLAMA_REQUIRE_CHECKSUM` so operators can correlate.
- [x] `parseBoolEnv` covers canonical truthy spellings + obvious falsy.

## Stack

Branched off `agent/llama-gguf-sha256` (PR #188). Will rebase to main once #188 lands; the diff against main becomes the same patch (no PR #188 changes are touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)