### PR TITLE
feat(middleware): EmbeddingProvider injection — #178 native-app readiness

### DIFF
--- a/mcp-server/src/__tests__/middleware-embed-override.test.ts
+++ b/mcp-server/src/__tests__/middleware-embed-override.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Middleware embed-override tests — verify each of the three middleware
+ * classes (Absorber, Digester, PrimeFetcher) routes through the injected
+ * `embed` callback when one is provided, instead of fetching Ollama
+ * directly.
+ *
+ * This is the seam that lets the middleware respect
+ * `MYCELIUM_LLM_PROVIDER=llama-cpp` once issue #178 (PR #187) lands —
+ * proxy.ts wires `createEmbeddingProvider().embed.bind(p)` into all three
+ * constructors and the same env-driven swap works for embedding,
+ * absorbing, digesting, and prime-fetching paths uniformly.
+ *
+ * The classes still fall back to direct Ollama fetch when no override is
+ * provided (the existing behaviour the rest of the suite exercises by
+ * pointing at port 1).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Absorber } from "../middleware/absorber.js";
+import { Digester } from "../middleware/digester.js";
+import { SessionTracker } from "../middleware/session-tracker.js";
+import { PrimeFetcher } from "../middleware/prime-fetcher.js";
+
+test("absorber — uses injected embed callback instead of fetching Ollama", async () => {
+  const calls: string[] = [];
+  // Absorber attempts insert AFTER embed; the insert will fail at
+  // port 1 → counted as failure, but the embed call is recorded first.
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:0",   // would error if used
+    embed: async (text) => {
+      calls.push(text);
+      return new Array(768).fill(0.1);
+    },
+  });
+  await a.processTurn("Ich habe gelernt: tests first.", undefined);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0], /tests first/);
+});
+
+test("digester — uses injected embed callback for the experience summary", async () => {
+  let now = 1_000_000;
+  const tracker = new SessionTracker({ idleMs: 1000, now: () => now });
+  const calls: string[] = [];
+  const digester = new Digester(tracker, {
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:0",
+    tickMs:      999_999,
+    embed: async (text) => {
+      calls.push(text);
+      return new Array(768).fill(0.2);
+    },
+  });
+  tracker.touch({ client_key: "k", user_present: true, model: "qwen" });
+  tracker.touch({ client_key: "k", upstream_ok: true });
+  now += 2000;
+  await digester.tick();
+  // Insert at port 1 fails, but embed ran first.
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].length > 0);
+});
+
+test("prime-fetcher — accepts an embed override in the constructor", () => {
+  // PrimeFetcher's `build()` runs `callStatic` and `callAffect` in
+  // Promise.all BEFORE it would call embed(); pointing at port 1 makes
+  // callStatic reject and short-circuits the whole flow before embed is
+  // reached. An end-to-end test would need a real RPC mock (out of scope
+  // for this seam test). Instead: verify the option is accepted by the
+  // constructor signature — the field-set + use-at-top-of-`embed()`
+  // pattern is identical to the absorber + digester cases above, which
+  // DO exercise the override at runtime.
+  const fetcher = new PrimeFetcher({
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:0",
+    embed: async () => new Array(768).fill(0.3),
+    cache: null,
+  });
+  assert.equal(typeof fetcher.cacheStats, "function");
+});
+
+test("absorber — falls back to direct Ollama fetch when no override is provided", async () => {
+  // No `embed` injected → embed() hits port 1 and fails. This guards the
+  // backward-compat path used by the existing test suite + any external
+  // operator scripts that construct Absorber/Digester/PrimeFetcher
+  // without the new option.
+  const a = new Absorber({
+    supabaseUrl: "http://127.0.0.1:1",
+    supabaseKey: "stub",
+    ollamaUrl:   "http://127.0.0.1:1",
+  });
+  const r = await a.processTurn("Ich habe gelernt: fallback path.", undefined);
+  assert.equal(r.absorbed, 0);
+  assert.equal(r.failed, 1);
+});

--- a/mcp-server/src/middleware/absorber.ts
+++ b/mcp-server/src/middleware/absorber.ts
@@ -35,6 +35,14 @@ export interface AbsorberOptions {
   supabaseKey:    string;
   ollamaUrl?:     string;
   embeddingModel?: string;
+  /**
+   * Optional embedding callback. When provided, takes precedence over the
+   * built-in Ollama fetch — wire `createEmbeddingProvider().embed.bind(p)`
+   * here so the middleware respects `MYCELIUM_LLM_PROVIDER=llama-cpp`
+   * (issue #178, native-app track #176). Tests stay on the direct-fetch
+   * failure path by leaving this unset.
+   */
+  embed?:         (text: string) => Promise<number[]>;
   /** TTL for the in-process dedupe Set. Default 10min. */
   dedupeTtlMs?:   number;
   /** Soft cap on absorbs per chat turn — guards against pathological inputs. */
@@ -65,6 +73,7 @@ export class Absorber {
   private db: PostgrestClient;
   private ollamaUrl: string;
   private embeddingModel: string;
+  private embedOverride: ((text: string) => Promise<number[]>) | null;
   private dedupe: TtlLruCache<true>;
   private maxPerTurn: number;
   private absorbedCount = 0;
@@ -82,6 +91,7 @@ export class Absorber {
     });
     this.ollamaUrl      = opts.ollamaUrl ?? "http://127.0.0.1:11434";
     this.embeddingModel = opts.embeddingModel ?? "nomic-embed-text";
+    this.embedOverride  = opts.embed ?? null;
     this.dedupe = new TtlLruCache<true>({
       ttlMs:   opts.dedupeTtlMs ?? DEFAULT_DEDUPE_TTL,
       maxSize: 500,
@@ -155,6 +165,7 @@ export class Absorber {
   }
 
   private async embed(text: string): Promise<number[]> {
+    if (this.embedOverride) return this.embedOverride(text);
     const r = await fetch(new URL("/api/embed", this.ollamaUrl), {
       method:  "POST",
       headers: { "Content-Type": "application/json" },

--- a/mcp-server/src/middleware/digester.ts
+++ b/mcp-server/src/middleware/digester.ts
@@ -23,6 +23,13 @@ export interface DigesterOptions {
   supabaseKey:     string;
   ollamaUrl?:      string;
   embeddingModel?: string;
+  /**
+   * Optional embedding callback. When provided, takes precedence over the
+   * built-in Ollama fetch — wire `createEmbeddingProvider().embed.bind(p)`
+   * here so the digest pipeline respects `MYCELIUM_LLM_PROVIDER=llama-cpp`
+   * (issue #178, native-app track #176).
+   */
+  embed?:          (text: string) => Promise<number[]>;
   /** Tick interval in ms. Default 60s. */
   tickMs?:         number;
 }
@@ -45,6 +52,7 @@ export class Digester {
   private db: PostgrestClient;
   private ollamaUrl: string;
   private embeddingModel: string;
+  private embedOverride: ((text: string) => Promise<number[]>) | null;
   private tracker: SessionTracker;
   private tickMs: number;
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -63,6 +71,7 @@ export class Digester {
     });
     this.ollamaUrl      = opts.ollamaUrl ?? "http://127.0.0.1:11434";
     this.embeddingModel = opts.embeddingModel ?? "nomic-embed-text";
+    this.embedOverride  = opts.embed ?? null;
     this.tickMs         = opts.tickMs ?? 60_000;
   }
 
@@ -190,6 +199,7 @@ export class Digester {
   }
 
   private async embed(text: string): Promise<number[]> {
+    if (this.embedOverride) return this.embedOverride(text);
     const r = await fetch(new URL("/api/embed", this.ollamaUrl), {
       method:  "POST",
       headers: { "Content-Type": "application/json" },

--- a/mcp-server/src/middleware/prime-fetcher.ts
+++ b/mcp-server/src/middleware/prime-fetcher.ts
@@ -22,6 +22,13 @@ export interface PrimeFetcherOptions {
   supabaseKey: string;
   ollamaUrl?:  string;          // for embedding the task_description
   embeddingModel?: string;
+  /**
+   * Optional embedding callback. When provided, takes precedence over the
+   * built-in Ollama fetch — wire `createEmbeddingProvider().embed.bind(p)`
+   * here so the prime fetcher respects `MYCELIUM_LLM_PROVIDER=llama-cpp`
+   * (issue #178, native-app track #176).
+   */
+  embed?:      (text: string) => Promise<number[]>;
   recallLimit?: number;         // experiences + memories per side
   /** Cache configuration (#7, N7). Pass null to disable caching entirely. */
   cache?:      PrimeCacheOptions | null;
@@ -73,6 +80,7 @@ export class PrimeFetcher {
   private db: PostgrestClient;
   private ollamaUrl: string;
   private embeddingModel: string;
+  private embedOverride: ((text: string) => Promise<number[]>) | null;
   private recallLimit: number;
   private cache: TtlLruCache<string> | null;
 
@@ -88,6 +96,7 @@ export class PrimeFetcher {
     });
     this.ollamaUrl      = opts.ollamaUrl ?? "http://127.0.0.1:11434";
     this.embeddingModel = opts.embeddingModel ?? "nomic-embed-text";
+    this.embedOverride  = opts.embed ?? null;
     this.recallLimit    = opts.recallLimit ?? 5;
     this.cache          = opts.cache === null ? null : new TtlLruCache<string>(opts.cache ?? {});
   }
@@ -251,6 +260,7 @@ export class PrimeFetcher {
   }
 
   private async embed(text: string): Promise<number[]> {
+    if (this.embedOverride) return this.embedOverride(text);
     const r = await fetch(new URL("/api/embed", this.ollamaUrl), {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/mcp-server/src/middleware/proxy.ts
+++ b/mcp-server/src/middleware/proxy.ts
@@ -39,6 +39,7 @@ import { Absorber } from "./absorber.js";
 import { SessionTracker } from "./session-tracker.js";
 import { Digester } from "./digester.js";
 import { injectContext, lastUserText, type ChatMessage } from "./inject.js";
+import { createEmbeddingProvider } from "../services/embeddings.js";
 
 // ---------------------------------------------------------------------------
 // docker/.env bootstrap — same pattern as scripts/dashboard-server.mjs.
@@ -117,11 +118,22 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 
 const EMBED_MODEL = envOr("EMBEDDING_MODEL", "nomic-embed-text")!;
 
+// Shared embedding provider — picks Ollama (default) or llama-cpp via
+// MYCELIUM_LLM_PROVIDER. Wiring it here lets the middleware respect the
+// native-app provider switch (issue #178) without each class re-implementing
+// the env-driven selection. The bound `embed` callback also gives us
+// `sampleForEmbedding` (head+middle+tail truncation) for free on long
+// auto-absorbed texts that the previous direct-fetch path silently
+// truncated from the end.
+const embeddingProvider = createEmbeddingProvider();
+const sharedEmbed = (text: string) => embeddingProvider.embed(text);
+
 const fetcher = new PrimeFetcher({
   supabaseUrl:    SUPABASE_URL,
   supabaseKey:    SUPABASE_KEY,
   ollamaUrl:      OLLAMA_URL,
   embeddingModel: EMBED_MODEL,
+  embed:          sharedEmbed,
   recallLimit:    RECALL_LIMIT,
 });
 
@@ -135,6 +147,7 @@ const absorber = AUTO_ABSORB_ON ? new Absorber({
   supabaseKey:    SUPABASE_KEY,
   ollamaUrl:      OLLAMA_URL,
   embeddingModel: EMBED_MODEL,
+  embed:          sharedEmbed,
 }) : null;
 
 // Auto-Digest (#4 + N9 spec). Per-session state, idle-30min trigger.
@@ -150,6 +163,7 @@ const digester = AUTO_DIGEST_ON ? new Digester(tracker, {
   supabaseKey:    SUPABASE_KEY,
   ollamaUrl:      OLLAMA_URL,
   embeddingModel: EMBED_MODEL,
+  embed:          sharedEmbed,
   tickMs:         TICK_MS,
 }) : null;
 digester?.start();


### PR DESCRIPTION
## Summary

- Wires an optional `embed: (text) => Promise<number[]>` callback through `Absorber`, `Digester`, and `PrimeFetcher` constructors.
- `proxy.ts` builds the callback once via `createEmbeddingProvider()` and passes it to all three. When PR #187 lands, flipping `MYCELIUM_LLM_PROVIDER=llama-cpp` will route embedding, absorbing, digesting, and prime-fetching through llama-cpp uniformly — no further wiring needed.
- Falls back to the existing direct Ollama fetch when no callback is provided (back-compat for the existing test suite + any operator scripts).

## Why

The three middleware classes each duplicated a private 11-line `embed()` that hit Ollama's `/api/embed` directly — bypassing the `EmbeddingProvider` factory abstraction. Without this PR, even after #187 lands, the middleware path still depends on Ollama. That blocks the Welle-1 native-app track (#176).

## Side benefit

The shared `OllamaEmbeddingProvider` already does `sampleForEmbedding` (head + middle + tail truncation) for inputs over 6000 chars. The previous direct-fetch path silently truncated from the END — the embedding then only represented the first ~2048 tokens of long auto-absorbed/digested texts. Routing through the provider fixes this for free.

## Out of scope

- Removing `ollamaUrl` / `embeddingModel` constructor options (they remain as fallback for tests + back-compat). A follow-up can require the callback once #187 is merged and the provider abstraction is the sole path.
- Switching the user-facing `/api/chat` proxy to llama-cpp — that's #178 part 2 (chat bridge).

## Pillar check

- Pillar 1 (no cloud dependency) — strengthened: middleware embedding paths now respect the in-process llama-cpp provider when the env says so.
- Pillar 6 (security) — unchanged: same single trust boundary (the provider) handles model selection, GGUF checksum verification (#188/#189) flows through it.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 943 pass, 0 fail (was 942 + 1 skipped)
- [x] 4 new tests in `middleware-embed-override.test.ts`:
  - absorber routes through the override
  - digester routes through the override  
  - prime-fetcher accepts the option (constructor-level — runtime path is identical to absorber/digester)
  - absorber falls back to direct fetch when no override is provided
- [ ] Manual after #187 merges: `MYCELIUM_LLM_PROVIDER=llama-cpp` → middleware proxy auto-absorb confirms llama-cpp is hit (no Ollama traffic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)