### PR TITLE
spike(native-llm): cross-provider cosine — NOT mixable, regen migration required (#178)

### DIFF
--- a/docs/native-llm-spike.md
+++ b/docs/native-llm-spike.md
@@ -30,12 +30,14 @@ npm install                         # ~56 s, prebuilt binaries (no native compil
 node spike-probe.mjs                # ~150 ms — API + GPU detection only
 node spike-embed.mjs                # downloads ~94 MB, runs 20-embed bench
 node spike-chat.mjs                 # downloads ~492 MB, runs 1-prompt smoke
+node spike-cosine.mjs               # cross-provider cosine validation (needs Ollama running)
 ```
 
 Reference reports (this hardware: M4 Mac, 16 GB unified memory, macOS):
 - `experiments/native-llm/report-probe.json`
 - `experiments/native-llm/report-llama-cpp-embed.json`
 - `experiments/native-llm/report-llama-cpp-chat.json`
+- `experiments/native-llm/report-cross-cosine.json`
 
 ## Findings
 
@@ -68,7 +70,7 @@ The p95 spike on llama.cpp is the tokenisation+kernel cost on the longest sample
 
 Embedding **dimension is 768** (matches `VECTOR(768)` on `memories.embedding`). No migration required.
 
-### 3. Tokenizer warning — must be validated end-to-end
+### 3. Tokenizer warning — measured: providers are NOT vector-compatible
 
 `node-llama-cpp` emits a startup warning on the nomic-embed-text GGUF:
 
@@ -77,12 +79,32 @@ load: special_eos_id is not in special_eog_ids - the tokenizer config may be inc
 Using this model to tokenize text and then detokenize it resulted in a different text.
 ```
 
-This means: **embeddings produced by node-llama-cpp may diverge from those produced by Ollama for the same input**, because one path applies a slightly different tokenisation. We did not measure cross-path cosine similarity in this spike. Before flipping the default provider on existing installs, we must:
+This warns that **embeddings produced by node-llama-cpp may diverge from those produced by Ollama for the same input**, because one path applies a slightly different tokenisation. The follow-up spike (`spike-cosine.mjs` → `report-cross-cosine.json`) measured the divergence end-to-end on the same 20-sample mycelium corpus, same Q5_K_M GGUF.
 
-1. Generate the same input through both providers, compute cosine — if it's below ~0.95 we cannot mix providers in one DB.
-2. If divergence is real, embedding regeneration becomes a one-shot migration when an install switches providers.
+**Verdict: NOT MIXABLE — switching providers requires embedding regeneration.**
 
-This is filed as a sub-task in the integration ticket recommendation below. For greenfield native-app installs (#176's primary target) it doesn't matter — the DB starts empty.
+| | value | accept threshold |
+|---|---|---|
+| diagonal cosine **avg** | **0.888** | ≥ 0.95 ❌ |
+| diagonal cosine **median** | 0.910 | ≥ 0.95 ❌ |
+| diagonal cosine **p05** | 0.756 | ≥ 0.95 ❌ |
+| diagonal cosine **min** | 0.727 | ≥ 0.95 ❌ |
+| diagonal cosine **max** | 0.959 | ≥ 0.95 ✅ (single sample) |
+| off-diagonal cosine avg | 0.475 | reference: noise floor |
+
+The diagonal is substantially above the off-diagonal noise floor (0.888 vs 0.475), so the two providers produce **semantically aligned** vector spaces — just not tightly enough for per-input identity. Existing memories embedded with one provider will recall correctly *most of the time* under the other, but with quality decay big enough to violate user expectation on top-k results.
+
+**Side observation:** Ollama returns L2-normalised vectors (norm ≈ 1.0); `node-llama-cpp` returns raw vectors (norm ≈ 18–20). Cosine is invariant to scale, so this is a presentation difference and not the source of the divergence. Adapter code that consumes raw `vector` fields from llama-cpp may want to normalise before storage to keep `<->` distance arithmetic interchangeable across the codebase.
+
+**German text suffers more divergence than English.** The lowest-cosine samples in the corpus are all German (0.727, 0.756, 0.815). Likely tokeniser handling of compound nouns + non-ASCII; worth noting because mycelium's user-facing memory bodies are mixed-language.
+
+**Operational consequences:**
+
+1. The `MYCELIUM_LLM_PROVIDER` env switch must be **install-time only** for existing installs, with a one-shot embedding-regeneration migration when it flips.
+2. For greenfield native-app installs (#176's primary target) the DB starts empty — no migration needed.
+3. The follow-up issue #1 in the list below MUST include the regeneration migration, not just the provider class. Suggested CI gate: a smoke test that asserts the *configured* provider's embeddings reach cosine ≥ 0.95 against a frozen reference set, so a future provider/quant swap that breaks compatibility fails the build instead of silently degrading recall.
+
+Reproduce: `cd experiments/native-llm && node spike-cosine.mjs` (Ollama with `nomic-embed-text` pulled + the cached GGUF; ~30 s).
 
 ### 4. Chat path: the protocol works, model size determines quality
 
@@ -129,7 +151,7 @@ gpu=metal · build=prebuilt · MTL EMBED_LIBRARY · NEON · ACCELERATE · LLAMAF
 
 ## Suggested follow-up issues
 
-1. **feat(embeddings): add `LlamaCppEmbeddingProvider` behind `MYCELIUM_LLM_PROVIDER`.** Keeps the existing `EmbeddingProvider` interface; default stays `ollama`. Includes a cosine-similarity cross-validation test that fails the build if the two providers' embeddings diverge by more than the agreed threshold for our test corpus.
+1. **feat(embeddings): add `LlamaCppEmbeddingProvider` behind `MYCELIUM_LLM_PROVIDER`.** Keeps the existing `EmbeddingProvider` interface; default stays `ollama`. Embedding-regeneration is required when the env switches on an existing install (proven by `spike-cosine.mjs`: diagonal cosine avg 0.888, below the 0.95 mix threshold) — ship the regeneration migration in the same PR, not as a follow-up. CI gate: a smoke test that asserts the *configured* provider's embeddings reach cosine ≥ 0.95 against a frozen reference set, so a future provider/quant swap that breaks compatibility fails the build instead of silently degrading recall.
 2. **feat(chat): add `LlamaCppChatProvider` and route REM digest through it when `MYCELIUM_LLM_PROVIDER=llama-cpp`.** Same env switch.
 3. **feat(install): native-app default profile selects `llama-cpp` automatically; surface model-download progress in the Tauri shell.** Depends on #176 sub-task 4 (Tauri shell).
 4. **feat(security): verify Hugging Face SHA-256 on first model download; refuse to load on mismatch.** Pillar 6.

--- a/experiments/native-llm/report-cross-cosine.json
+++ b/experiments/native-llm/report-cross-cosine.json
@@ -1,0 +1,202 @@
+{
+  "spike": "issue-178-cross-cosine",
+  "started_at": "2026-05-02T17:05:04.463Z",
+  "platform": "darwin-arm64",
+  "node": "v25.9.0",
+  "quant": "Q5_K_M",
+  "sample_count": 20,
+  "accept_threshold": 0.95,
+  "steps": {
+    "runtime": {
+      "gpu": "metal"
+    },
+    "model_load": {
+      "ok": true,
+      "ms": 223.7684999999983,
+      "uri": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q5_K_M.gguf",
+      "embedding_vector_size": 768
+    },
+    "cross_cosine": {
+      "dim_llama": 768,
+      "dim_ollama": 768,
+      "dim_match": true,
+      "diagonal": {
+        "min": 0.7273857032192723,
+        "avg": 0.8875090255600208,
+        "median": 0.9095007333547184,
+        "p05": 0.7558068276987447,
+        "max": 0.9585269438239092
+      },
+      "off_diagonal": {
+        "min": 0.3036005990369242,
+        "avg": 0.47475722677237286,
+        "median": 0.4681591927992074,
+        "max": 0.7469818894953382
+      },
+      "per_sample": [
+        {
+          "idx": 0,
+          "chars": 57,
+          "llama_norm": 20.411014054374647,
+          "ollama_norm": 0.9999998007457381,
+          "cosine": 0.8147768921700829,
+          "sample": "Reed bevorzugt deutsche Antworten im technischen Kontext."
+        },
+        {
+          "idx": 1,
+          "chars": 167,
+          "llama_norm": 19.539470282533156,
+          "ollama_norm": 1.000000076492689,
+          "cosine": 0.7273857032192723,
+          "sample": "Wenn die PR-Queue mehrere agent/* PRs enthält, prüfe vor jeder neuen Migration d"
+        },
+        {
+          "idx": 2,
+          "chars": 172,
+          "llama_norm": 18.915541089248386,
+          "ollama_norm": 0.9999999221628791,
+          "cosine": 0.9155616207359596,
+          "sample": "Spike 1 (issue #177): embedded-postgres bundle ships vanilla Postgres 18.3 only."
+        },
+        {
+          "idx": 3,
+          "chars": 174,
+          "llama_norm": 19.439673444345893,
+          "ollama_norm": 1.000000136643342,
+          "cosine": 0.9566769553592539,
+          "sample": "agent_affect tracks four dimensions: frustration, satisfaction, curiosity, fatig"
+        },
+        {
+          "idx": 4,
+          "chars": 75,
+          "llama_norm": 19.830532188221834,
+          "ollama_norm": 1.0000001120929642,
+          "cosine": 0.8767223352441247,
+          "sample": "Pillar 1 — decentralised, networked AI. mycelium belongs to no single host."
+        },
+        {
+          "idx": 5,
+          "chars": 102,
+          "llama_norm": 18.5068571507017,
+          "ollama_norm": 0.999999688148446,
+          "cosine": 0.8452873760416464,
+          "sample": "Memory IDs are UUIDs. Embedding dimension is 768. HNSW index on memories(embeddi"
+        },
+        {
+          "idx": 6,
+          "chars": 156,
+          "llama_norm": 18.208887739771704,
+          "ollama_norm": 1.0000000495659918,
+          "cosine": 0.8996594042455898,
+          "sample": "REM digest synthesizes lessons from clustered experiences using qwen3:8b. Gate: "
+        },
+        {
+          "idx": 7,
+          "chars": 133,
+          "llama_norm": 19.620718351912767,
+          "ollama_norm": 0.9999998989486372,
+          "cosine": 0.8704843494840656,
+          "sample": "Tier-A lesson: signed by producer, admitted by consumer's swarm_admit_lesson, pi"
+        },
+        {
+          "idx": 8,
+          "chars": 154,
+          "llama_norm": 18.7946796104651,
+          "ollama_norm": 0.9999998735833053,
+          "cosine": 0.8813904978461748,
+          "sample": "Trust edge between two peer nodes is established via mTLS cert pinning + initial"
+        },
+        {
+          "idx": 9,
+          "chars": 150,
+          "llama_norm": 18.29110354317924,
+          "ollama_norm": 1.0000000489367358,
+          "cosine": 0.8422289168433172,
+          "sample": "Reed wants the standalone-app initiative (issue #176) prioritised: embedded Post"
+        },
+        {
+          "idx": 10,
+          "chars": 143,
+          "llama_norm": 19.479943638309212,
+          "ollama_norm": 0.9999999198911687,
+          "cosine": 0.9585269438239092,
+          "sample": "Lesson reinforcement: when an experience is recalled and marked useful, evidence"
+        },
+        {
+          "idx": 11,
+          "chars": 153,
+          "llama_norm": 19.356866952391908,
+          "ollama_norm": 1.000000012753666,
+          "cosine": 0.9095007333547184,
+          "sample": "Spreading activation: when a memory is recalled, neighbours within 2 hops get a "
+        },
+        {
+          "idx": 12,
+          "chars": 161,
+          "llama_norm": 19.413262415042787,
+          "ollama_norm": 1.0000004107767257,
+          "cosine": 0.9405672872524441,
+          "sample": "Conflict synthesis: when two memories disagree on the same topic, mark both, inc"
+        },
+        {
+          "idx": 13,
+          "chars": 162,
+          "llama_norm": 19.17816372265742,
+          "ollama_norm": 1.0000000008294476,
+          "cosine": 0.9406445938519489,
+          "sample": "Affect-from-observables (issue #11): compute_affect() runs as a trigger over exp"
+        },
+        {
+          "idx": 14,
+          "chars": 147,
+          "llama_norm": 18.901355200446847,
+          "ollama_norm": 0.9999998715338682,
+          "cosine": 0.866347948927252,
+          "sample": "Genome keys are ed25519. Public key fingerprint = node id. Federation handshake:"
+        },
+        {
+          "idx": 15,
+          "chars": 164,
+          "llama_norm": 18.647456991878972,
+          "ollama_norm": 1.0000002792413347,
+          "cosine": 0.9355861454330294,
+          "sample": "Soul-state digest collapses last 24 h of episodes into mood (valence + arousal a"
+        },
+        {
+          "idx": 16,
+          "chars": 160,
+          "llama_norm": 19.080684974668067,
+          "ollama_norm": 0.9999999812908313,
+          "cosine": 0.9323320297742509,
+          "sample": "Active inference loop: predict next state, observe, compute prediction error, ad"
+        },
+        {
+          "idx": 17,
+          "chars": 144,
+          "llama_norm": 19.041185566499387,
+          "ollama_norm": 0.9999999969404465,
+          "cosine": 0.9222950092849591,
+          "sample": "Long-text embedding sampling: head 50% + middle 25% + tail 25% under a 6000-char"
+        },
+        {
+          "idx": 18,
+          "chars": 166,
+          "llama_norm": 18.601217250221268,
+          "ollama_norm": 0.9999999768951885,
+          "cosine": 0.9583989406096711,
+          "sample": "Pre-existing migration bug (#180): 040_signed_revocations.sql references revoked"
+        },
+        {
+          "idx": 19,
+          "chars": 133,
+          "llama_norm": 19.27957644015616,
+          "ollama_norm": 0.9999998889723786,
+          "cosine": 0.7558068276987447,
+          "sample": "Ein Schwarm lokaler Agents trainiert eine Population auf die spezifische gelebte"
+        }
+      ]
+    }
+  },
+  "verdict": "NOT MIXABLE — diagonal avg 0.8875 < 0.95; switching providers requires embedding regeneration",
+  "finished_at": "2026-05-02T17:05:20.696Z"
+}

--- a/experiments/native-llm/spike-cosine.mjs
+++ b/experiments/native-llm/spike-cosine.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Spike 2c — cross-provider cosine validation (issue #178, doc §3 follow-up).
+//
+// Question: do node-llama-cpp and Ollama produce *compatible* embeddings for
+// the same nomic-embed-text-v1.5 model+quant, or does the tokeniser
+// divergence flagged in spike-embed.mjs break per-input vector identity?
+//
+// If cosine(llama_v, ollama_v) >= 0.95 across the corpus, an existing install
+// can flip MYCELIUM_LLM_PROVIDER=llama-cpp without re-embedding its memories.
+// Below that, switching providers becomes a one-shot embedding regeneration.
+//
+// Output: report-cross-cosine.json with per-sample cosine + aggregate stats.
+//
+// Reuses SAMPLES from spike-embed.mjs (same corpus → comparable benchmarks).
+
+import { getLlama, LlamaLogLevel, resolveModelFile } from "node-llama-cpp";
+import { performance } from "node:perf_hooks";
+import { writeFile, mkdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MODELS_DIR = path.join(__dirname, "models");
+
+const SAMPLES = [
+  "Reed bevorzugt deutsche Antworten im technischen Kontext.",
+  "Wenn die PR-Queue mehrere agent/* PRs enthält, prüfe vor jeder neuen Migration die nächste freie Nummer auf main UND in den offenen PRs — sonst kollidiert die Sequenz.",
+  "Spike 1 (issue #177): embedded-postgres bundle ships vanilla Postgres 18.3 only. Migration 001 stirbt an CREATE EXTENSION vector. Pivot: pglite mit pgvector 0.8.1 built-in.",
+  "agent_affect tracks four dimensions: frustration, satisfaction, curiosity, fatigue. Plus valence (-1..1) and arousal (0..1). Updated by compute_affect() trigger, not LLM-fed.",
+  "Pillar 1 — decentralised, networked AI. mycelium belongs to no single host.",
+  "Memory IDs are UUIDs. Embedding dimension is 768. HNSW index on memories(embedding vector_cosine_ops).",
+  "REM digest synthesizes lessons from clustered experiences using qwen3:8b. Gate: at least 3 experiences with shared task_type and matching emotional valence.",
+  "Tier-A lesson: signed by producer, admitted by consumer's swarm_admit_lesson, pinned via swarm_pin_lesson. Tier-B: same but unpinned.",
+  "Trust edge between two peer nodes is established via mTLS cert pinning + initial signed handshake. Revocation propagates through signed_revocations table.",
+  "Reed wants the standalone-app initiative (issue #176) prioritised: embedded Postgres + llama.cpp + Tauri shell. No Docker, no external Ollama install.",
+  "Lesson reinforcement: when an experience is recalled and marked useful, evidence count increments. At evidence>=3 a lesson promotes to a trait.",
+  "Spreading activation: when a memory is recalled, neighbours within 2 hops get a small activation boost — Hebbian: cells that fire together wire together.",
+  "Conflict synthesis: when two memories disagree on the same topic, mark both, increase salience, and let the next reflect cycle propose a higher-order resolution.",
+  "Affect-from-observables (issue #11): compute_affect() runs as a trigger over experiences/memory_events/skill_outcomes/stimuli — no MCP affect_apply call required.",
+  "Genome keys are ed25519. Public key fingerprint = node id. Federation handshake: sign current epoch number, peer verifies + checks revocation list.",
+  "Soul-state digest collapses last 24 h of episodes into mood (valence + arousal averages) and a recent-pattern summary (last 10 tasks, success rate, avg difficulty).",
+  "Active inference loop: predict next state, observe, compute prediction error, adjust both world-model and policy. Free energy minimisation over the whole stack.",
+  "Long-text embedding sampling: head 50% + middle 25% + tail 25% under a 6000-char budget. Better than naive truncate, which loses the conclusion.",
+  "Pre-existing migration bug (#180): 040_signed_revocations.sql references revoked_keys but its CREATE is in deferred 038. Fresh installs fail. PR #181 lifts the table.",
+  "Ein Schwarm lokaler Agents trainiert eine Population auf die spezifische gelebte Realität ihrer Operatoren — das ist der ganze Punkt.",
+];
+
+const ACCEPT_THRESHOLD = 0.95; // doc §3 — below this we cannot mix providers in one DB
+
+async function main() {
+  const QUANT = process.env.MYCELIUM_GGUF_QUANT ?? "Q5_K_M";
+  await mkdir(MODELS_DIR, { recursive: true });
+
+  const report = {
+    spike: "issue-178-cross-cosine",
+    started_at: new Date().toISOString(),
+    platform: `${process.platform}-${process.arch}`,
+    node: process.version,
+    quant: QUANT,
+    sample_count: SAMPLES.length,
+    accept_threshold: ACCEPT_THRESHOLD,
+    steps: {},
+  };
+
+  // ---- llama.cpp embeddings ----------------------------------------------
+  const llama = await getLlama({ logLevel: LlamaLogLevel.warn });
+  report.steps.runtime = { gpu: llama.gpu };
+  const modelUri = `hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.${QUANT}.gguf`;
+  const modelPath = await resolveModelFile(modelUri, MODELS_DIR);
+  const t_load = performance.now();
+  const model = await llama.loadModel({ modelPath });
+  report.steps.model_load = {
+    ok: true,
+    ms: performance.now() - t_load,
+    uri: modelUri,
+    embedding_vector_size: model.embeddingVectorSize,
+  };
+  const ctx = await model.createEmbeddingContext();
+  await ctx.getEmbeddingFor(SAMPLES[0]); // warm-up
+
+  const llamaVecs = [];
+  for (const s of SAMPLES) {
+    const e = await ctx.getEmbeddingFor(s);
+    llamaVecs.push(Array.from(e.vector ?? e));
+  }
+  await ctx.dispose();
+  await model.dispose();
+  await llama.dispose();
+
+  // ---- ollama embeddings -------------------------------------------------
+  const { Ollama } = await import("ollama");
+  const url = process.env.OLLAMA_URL ?? "http://localhost:11434";
+  const ollamaModel = process.env.EMBEDDING_MODEL ?? "nomic-embed-text";
+  const o = new Ollama({ host: url });
+  const probe = await fetch(url + "/api/tags").then((r) => r.json());
+  const hasModel = (probe?.models ?? []).some((m) => m.name?.startsWith(ollamaModel));
+  if (!hasModel) {
+    report.steps.ollama_embed = { skipped: true, reason: `model ${ollamaModel} not in local Ollama` };
+    return finalize(report);
+  }
+  await o.embed({ model: ollamaModel, input: SAMPLES[0] }); // warm-up
+  const ollamaVecs = [];
+  for (const s of SAMPLES) {
+    const r = await o.embed({ model: ollamaModel, input: s });
+    const v = r.embeddings?.[0] ?? r.embedding;
+    ollamaVecs.push(Array.from(v));
+  }
+
+  // ---- cross cosine + aggregate -----------------------------------------
+  const dimMatch = llamaVecs[0].length === ollamaVecs[0].length;
+  const perSample = SAMPLES.map((s, i) => ({
+    idx: i,
+    chars: s.length,
+    llama_norm: l2norm(llamaVecs[i]),
+    ollama_norm: l2norm(ollamaVecs[i]),
+    cosine: cosine(llamaVecs[i], ollamaVecs[i]),
+    sample: s.slice(0, 80),
+  }));
+  const cosines = perSample.map((p) => p.cosine).sort((a, b) => a - b);
+
+  // Off-diagonal sanity: cosine(llama_i, ollama_j) for i!=j should be much
+  // lower than the diagonal — confirms the spaces are aligned per-input,
+  // not just globally.
+  const offDiag = [];
+  for (let i = 0; i < SAMPLES.length; i++) {
+    for (let j = 0; j < SAMPLES.length; j++) {
+      if (i === j) continue;
+      offDiag.push(cosine(llamaVecs[i], ollamaVecs[j]));
+    }
+  }
+  offDiag.sort((a, b) => a - b);
+
+  const minCos = cosines[0];
+  const avgCos = avg(cosines);
+  const medianCos = cosines[Math.floor(cosines.length / 2)];
+  const p05Cos = cosines[Math.floor(cosines.length * 0.05)];
+
+  report.steps.cross_cosine = {
+    dim_llama: llamaVecs[0].length,
+    dim_ollama: ollamaVecs[0].length,
+    dim_match: dimMatch,
+    diagonal: {
+      min: minCos,
+      avg: avgCos,
+      median: medianCos,
+      p05: p05Cos,
+      max: cosines[cosines.length - 1],
+    },
+    off_diagonal: {
+      min: offDiag[0],
+      avg: avg(offDiag),
+      median: offDiag[Math.floor(offDiag.length / 2)],
+      max: offDiag[offDiag.length - 1],
+    },
+    per_sample: perSample,
+  };
+
+  const verdict = !dimMatch
+    ? `dim mismatch — llama ${llamaVecs[0].length} vs ollama ${ollamaVecs[0].length}, cannot mix`
+    : minCos >= ACCEPT_THRESHOLD
+    ? `MIXABLE — diagonal min ${minCos.toFixed(4)} ≥ ${ACCEPT_THRESHOLD}; existing installs can flip provider without re-embedding`
+    : avgCos >= ACCEPT_THRESHOLD
+    ? `BORDERLINE — diagonal avg ${avgCos.toFixed(4)} ≥ ${ACCEPT_THRESHOLD} but min ${minCos.toFixed(4)} < threshold; per-input outliers exist`
+    : `NOT MIXABLE — diagonal avg ${avgCos.toFixed(4)} < ${ACCEPT_THRESHOLD}; switching providers requires embedding regeneration`;
+  report.verdict = verdict;
+
+  return finalize(report);
+}
+
+function l2norm(v) {
+  let s = 0;
+  for (const x of v) s += x * x;
+  return Math.sqrt(s);
+}
+function cosine(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom === 0 ? 0 : dot / denom;
+}
+function avg(a) {
+  return a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0;
+}
+
+async function finalize(report) {
+  report.finished_at = new Date().toISOString();
+  console.log(JSON.stringify(report, null, 2));
+  console.error(`\nverdict: ${report.verdict ?? "incomplete"}`);
+  await writeFile(
+    path.join(__dirname, "report-cross-cosine.json"),
+    JSON.stringify(report, null, 2)
+  );
+}
+
+main().catch((err) => {
+  console.error("fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- New empirical spike `experiments/native-llm/spike-cosine.mjs` closes the unmeasured gap flagged in `docs/native-llm-spike.md` §3 (\"did not measure cross-path cosine similarity\").
- Same 20-sample mycelium corpus through both `node-llama-cpp` and Ollama, same `nomic-embed-text-v1.5` GGUF (Q5_K_M). Per-input cosine + off-diagonal noise floor reported.
- Doc updated with the verdict and an explicit operational rule for `MYCELIUM_LLM_PROVIDER`.

## Result

**NOT MIXABLE** — switching providers on an existing install requires a one-shot embedding-regeneration migration.

| | value | accept threshold |
|---|---|---|
| diagonal cosine **avg** | **0.888** | ≥ 0.95 ❌ |
| diagonal cosine **median** | 0.910 | ≥ 0.95 ❌ |
| diagonal cosine **p05** | 0.756 | ≥ 0.95 ❌ |
| diagonal cosine **min** | 0.727 | ≥ 0.95 ❌ |
| off-diagonal cosine avg | 0.475 | reference: noise floor |

Diagonal substantially above noise floor (0.888 vs 0.475) → spaces are *semantically aligned* per-input, just not tightly enough for production switching.

## Side observations baked into the doc

- Ollama returns L2-normalised vectors (norm ≈ 1.0); `node-llama-cpp` returns raw vectors (norm ≈ 18–20). Cosine is scale-invariant so this does not cause the divergence, but adapter code consuming raw `vector` may want to normalise before storage to keep `<->` arithmetic interchangeable.
- German text suffers more divergence than English. The three lowest-cosine samples in the corpus are all German (0.727, 0.756, 0.815) — likely tokeniser handling of compound nouns + non-ASCII. Worth knowing because mycelium's user-facing memory bodies are mixed-language.

## Why now

PR queue is full waiting on Reed (5 open PRs, all green). Per the recurring lesson \"PR-Queue voll → empirisch testen statt neue PRs erstellen\" + the doc's own flagged unknown, this is the highest-value move that doesn't grow queue depth: it converts a flagged-but-unmeasured risk into a documented decision with a reproducible script. Future-you can re-run on a different quant, a different model, or a tightened CI gate without re-deriving the methodology.

## Doc deltas

- `docs/native-llm-spike.md` §3 rewritten from \"warning, not measured\" → \"verdict + numbers + operational rule\".
- Suggested follow-up issue #1 tightened: regeneration migration must ship **in-PR**, not as a follow-up. Adds a CI gate suggestion (configured-provider cosine smoke test against a frozen reference set so a future provider/quant swap that breaks compatibility fails the build).
- Reproducibility section gains the new `node spike-cosine.mjs` line.

## Test plan

- [x] `node spike-cosine.mjs` produces `report-cross-cosine.json` (committed) and prints the verdict to stderr.
- [x] No mcp-server source changed → no test surface affected. Spike lives entirely under `experiments/native-llm/`.
- [ ] On Reed merge: spike doc reflects empirical reality; integration ticket for #178 LLM provider switch can now scope the regeneration migration as in-scope rather than \"follow-up\".

## Pillar check

- Pillar 1 (decentralised AI) — neutral. Spike informs the path; no shipping behaviour changes.
- Pillar 6 (security) — neutral. No new dependencies, no new code paths in production.
- Pillar 4 (truthfulness) — strengthened. Replaces \"may diverge\" speculation with measured numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)