### PR TITLE
feat(chat): ChatProvider abstraction over REM synthesizer — #178 chat-side foundation

### DIFF
--- a/mcp-server/src/__tests__/chat.test.ts
+++ b/mcp-server/src/__tests__/chat.test.ts
@@ -1,0 +1,206 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ChatFetch,
+  OllamaChatProvider,
+  createChatProvider,
+  extractJSON,
+} from "../services/chat.js";
+
+// ---------------------------------------------------------------------------
+// extractJSON — pure helper lifted from synthesize-cluster.mjs
+// ---------------------------------------------------------------------------
+
+test("extractJSON: strips a single <think> block before JSON", () => {
+  const raw = `<think>weighing options</think>{"lesson":"X","confidence":0.8}`;
+  const out = extractJSON(raw) as { lesson: string; confidence: number };
+  assert.equal(out.lesson, "X");
+  assert.equal(out.confidence, 0.8);
+});
+
+test("extractJSON: strips multiple <think> blocks across lines", () => {
+  const raw = `<think>first thought</think>\n<think>second\nmulti-line\nthought</think>\n{"a":1}`;
+  const out = extractJSON(raw) as { a: number };
+  assert.equal(out.a, 1);
+});
+
+test("extractJSON: handles ```json fenced output", () => {
+  const raw = "```json\n{\"a\": 2}\n```";
+  const out = extractJSON(raw) as { a: number };
+  assert.equal(out.a, 2);
+});
+
+test("extractJSON: handles plain ``` fences without language tag", () => {
+  const raw = "```\n{\"a\": 3}\n```";
+  const out = extractJSON(raw) as { a: number };
+  assert.equal(out.a, 3);
+});
+
+test("extractJSON: locates JSON when prose surrounds it", () => {
+  const raw = "Here is the result: {\"lesson\": \"abc\"} — done.";
+  const out = extractJSON(raw) as { lesson: string };
+  assert.equal(out.lesson, "abc");
+});
+
+test("extractJSON: throws on empty input", () => {
+  assert.throws(() => extractJSON(""), /empty model response/);
+});
+
+test("extractJSON: throws when no JSON object is present", () => {
+  assert.throws(
+    () => extractJSON("just prose, no braces here"),
+    /no JSON object found/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// OllamaChatProvider — fetch shape, error path, unload
+// ---------------------------------------------------------------------------
+
+function mockFetch(
+  responder: (input: string, body: unknown) => { ok: boolean; status?: number; json?: unknown; text?: string },
+): { fetchFn: ChatFetch; calls: { url: string; body: unknown }[] } {
+  const calls: { url: string; body: unknown }[] = [];
+  const fetchFn: ChatFetch = async (input, init) => {
+    const body = JSON.parse(init.body);
+    calls.push({ url: input, body });
+    const r = responder(input, body);
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      async text() { return r.text ?? ""; },
+      async json() { return r.json ?? {}; },
+    };
+  };
+  return { fetchFn, calls };
+}
+
+test("OllamaChatProvider.chat sends model+messages and returns content+thinking", async () => {
+  const { fetchFn, calls } = mockFetch(() => ({
+    ok: true,
+    json: { message: { content: "{\"ok\":true}", thinking: "weighed it" } },
+  }));
+  const p = new OllamaChatProvider({ model: "qwen3:8b", url: "http://localhost:11434", fetchFn });
+  const r = await p.chat({
+    messages: [
+      { role: "system", content: "be brief" },
+      { role: "user", content: "go" },
+    ],
+    think: true,
+    options: { temperature: 0.3, num_ctx: 8192 },
+  });
+  assert.equal(r.content, "{\"ok\":true}");
+  assert.equal(r.thinking, "weighed it");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://localhost:11434/api/chat");
+  const sent = calls[0].body as Record<string, unknown>;
+  assert.equal(sent.model, "qwen3:8b");
+  assert.equal(sent.stream, false);
+  assert.equal(sent.think, true);
+  assert.equal(sent.keep_alive, "2m");
+  assert.deepEqual(sent.options, { temperature: 0.3, num_ctx: 8192 });
+  assert.deepEqual(sent.messages, [
+    { role: "system", content: "be brief" },
+    { role: "user", content: "go" },
+  ]);
+});
+
+test("OllamaChatProvider.chat surfaces empty strings when fields missing", async () => {
+  const { fetchFn } = mockFetch(() => ({ ok: true, json: { message: {} } }));
+  const p = new OllamaChatProvider({ fetchFn });
+  const r = await p.chat({ messages: [{ role: "user", content: "x" }] });
+  assert.equal(r.content, "");
+  assert.equal(r.thinking, "");
+});
+
+test("OllamaChatProvider.chat throws with HTTP status + body on non-2xx", async () => {
+  const { fetchFn } = mockFetch(() => ({ ok: false, status: 503, text: "model not loaded" }));
+  const p = new OllamaChatProvider({ fetchFn });
+  await assert.rejects(
+    () => p.chat({ messages: [{ role: "user", content: "x" }] }),
+    /Ollama HTTP 503: model not loaded/,
+  );
+});
+
+test("OllamaChatProvider.chat respects per-request keepAlive override", async () => {
+  const { fetchFn, calls } = mockFetch(() => ({ ok: true, json: { message: { content: "{}" } } }));
+  const p = new OllamaChatProvider({ keepAlive: "2m", fetchFn });
+  await p.chat({ messages: [{ role: "user", content: "x" }], keepAlive: "10s" });
+  assert.equal((calls[0].body as Record<string, unknown>).keep_alive, "10s");
+});
+
+test("OllamaChatProvider.unload posts keep_alive=0 against /api/generate", async () => {
+  const { fetchFn, calls } = mockFetch(() => ({ ok: true, json: {} }));
+  const p = new OllamaChatProvider({ url: "http://localhost:11434", model: "qwen3:8b", fetchFn });
+  await p.unload();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://localhost:11434/api/generate");
+  assert.deepEqual(calls[0].body, { model: "qwen3:8b", keep_alive: 0 });
+});
+
+test("OllamaChatProvider.unload swallows errors (best-effort)", async () => {
+  const fetchFn: ChatFetch = async () => { throw new Error("network down"); };
+  const p = new OllamaChatProvider({ fetchFn });
+  await p.unload();
+});
+
+// ---------------------------------------------------------------------------
+// createChatProvider factory — env routing
+// ---------------------------------------------------------------------------
+
+function withEnv<T>(patches: Record<string, string | undefined>, fn: () => T): T {
+  const prior: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(patches)) {
+    prior[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of Object.entries(prior)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+test("createChatProvider defaults to OllamaChatProvider when env unset", () => {
+  withEnv({ MYCELIUM_LLM_PROVIDER: undefined }, () => {
+    const p = createChatProvider();
+    assert.equal(p.name, "ollama");
+    assert.ok(p instanceof OllamaChatProvider);
+  });
+});
+
+test("createChatProvider returns OllamaChatProvider on MYCELIUM_LLM_PROVIDER=ollama", () => {
+  withEnv({ MYCELIUM_LLM_PROVIDER: "ollama" }, () => {
+    const p = createChatProvider();
+    assert.equal(p.name, "ollama");
+  });
+});
+
+test("createChatProvider treats provider string case-insensitively", () => {
+  withEnv({ MYCELIUM_LLM_PROVIDER: "OLLAMA" }, () => {
+    const p = createChatProvider();
+    assert.equal(p.name, "ollama");
+  });
+});
+
+test("createChatProvider throws a clear stub error for llama-cpp until follow-up lands", () => {
+  withEnv({ MYCELIUM_LLM_PROVIDER: "llama-cpp" }, () => {
+    assert.throws(createChatProvider, /chat side not yet implemented/);
+  });
+});
+
+test("createChatProvider accepts the llamacpp alias (no hyphen) the same way", () => {
+  withEnv({ MYCELIUM_LLM_PROVIDER: "llamacpp" }, () => {
+    assert.throws(createChatProvider, /chat side not yet implemented/);
+  });
+});
+
+test("createChatProvider throws on unknown provider with the supported list", () => {
+  withEnv({ MYCELIUM_LLM_PROVIDER: "nonsense" }, () => {
+    assert.throws(createChatProvider, /Unknown MYCELIUM_LLM_PROVIDER='nonsense'/);
+  });
+});

--- a/mcp-server/src/services/chat.ts
+++ b/mcp-server/src/services/chat.ts
@@ -1,0 +1,191 @@
+/**
+ * ChatProvider abstraction — chat-side foundation for issue #178.
+ *
+ * Mirrors `embeddings.ts` (EmbeddingProvider). Today the only call site is
+ * `scripts/synthesize-cluster.mjs` (REM lesson synthesis); long-term the
+ * native-app track (#176) needs to swap Ollama HTTP for in-process
+ * `node-llama-cpp` (`MYCELIUM_LLM_PROVIDER=llama-cpp`). This file defines
+ * the seam — `OllamaChatProvider` is the existing behaviour extracted
+ * verbatim; `LlamaCppChatProvider` lands as a follow-up once PR #187's
+ * `node-llama-cpp` dependency is on main.
+ *
+ * Why a fetch-based provider instead of the `ollama` npm client:
+ *   the REM synthesizer relies on Ollama 0.20+'s `think:true` + `thinking`
+ *   response field (Qwen3 reasoning pathway). The official client did not
+ *   expose `thinking` cleanly at the time the script was written; raw fetch
+ *   keeps response-shape access explicit. The injectable `fetchFn` keeps
+ *   tests off the network.
+ */
+
+export type ChatRole = "system" | "user" | "assistant";
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ChatOptions {
+  /** Sampling temperature (0..1). Provider may clamp to its supported range. */
+  temperature?: number;
+  /** Context window in tokens. Provider may ignore if not configurable. */
+  num_ctx?: number;
+}
+
+export interface ChatRequest {
+  messages: ChatMessage[];
+  options?: ChatOptions;
+  /**
+   * Activate the model's reasoning pathway if it has one (Qwen3, R1-distills).
+   * Ollama 0.20+ surfaces this as a separate `thinking` response field; the
+   * provider returns it on `ChatResult.thinking` when available.
+   */
+  think?: boolean;
+  /**
+   * Provider-specific hint to keep the model warm across calls. Ollama
+   * accepts a duration string (e.g. "2m"); other providers may ignore it.
+   */
+  keepAlive?: string;
+}
+
+export interface ChatResult {
+  /** Final assistant message text. */
+  content: string;
+  /** Reasoning trace (if the provider exposes it; empty string if not). */
+  thinking: string;
+}
+
+export interface ChatProvider {
+  chat(req: ChatRequest): Promise<ChatResult>;
+  /**
+   * Best-effort cleanup (Ollama: unload model to free RAM). No-op for
+   * stateless providers. Callers should NOT rely on this for correctness —
+   * REM nightly calls it after the cluster loop only as a courtesy.
+   */
+  unload?(): Promise<void>;
+  /** Stable identifier for logs and tests (e.g. "ollama", "llama-cpp"). */
+  readonly name: string;
+}
+
+/**
+ * Strip Qwen3 / R1-distill `<think>…</think>` reasoning blocks from a
+ * response, then locate the JSON object that follows. Robust to:
+ *   - multiple <think> blocks
+ *   - prose before/after the JSON
+ *   - models that occasionally emit ``` json fences
+ *
+ * Pure helper — no provider coupling. Lifted from
+ * `scripts/synthesize-cluster.mjs` so it can be unit-tested independently.
+ */
+export function extractJSON(raw: string): unknown {
+  if (!raw) throw new Error("empty model response");
+  let s = raw.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+  s = s.replace(/```(?:json)?\s*/g, "").replace(/```/g, "").trim();
+  const i = s.indexOf("{");
+  const j = s.lastIndexOf("}");
+  if (i < 0 || j < 0 || j <= i) {
+    throw new Error(`no JSON object found in: ${raw.slice(0, 200)}`);
+  }
+  const body = s.slice(i, j + 1);
+  return JSON.parse(body);
+}
+
+/**
+ * Minimal subset of `fetch` we need. Allows tests to pass a mock without
+ * relying on the global `fetch` and without importing Node's undici types.
+ */
+export type ChatFetch = (
+  input: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; text(): Promise<string>; json(): Promise<unknown> }>;
+
+interface OllamaChatResponse {
+  message?: { content?: string; thinking?: string };
+}
+
+export class OllamaChatProvider implements ChatProvider {
+  readonly name = "ollama";
+  private readonly url: string;
+  private readonly model: string;
+  private readonly defaultKeepAlive: string;
+  private readonly fetchFn: ChatFetch;
+
+  constructor(opts: {
+    url?: string;
+    model?: string;
+    keepAlive?: string;
+    fetchFn?: ChatFetch;
+  } = {}) {
+    this.url = opts.url ?? "http://localhost:11434";
+    this.model = opts.model ?? "qwen3:8b";
+    this.defaultKeepAlive = opts.keepAlive ?? "2m";
+    this.fetchFn = opts.fetchFn ?? ((input, init) => fetch(input, init));
+  }
+
+  async chat(req: ChatRequest): Promise<ChatResult> {
+    const r = await this.fetchFn(`${this.url}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: this.model,
+        messages: req.messages,
+        stream: false,
+        keep_alive: req.keepAlive ?? this.defaultKeepAlive,
+        // Bewusst KEIN format:"json" — würde mit Reasoning kollidieren.
+        // Caller runs extractJSON() on result.content.
+        think: req.think ?? false,
+        options: req.options ?? {},
+      }),
+    });
+    if (!r.ok) {
+      throw new Error(`Ollama HTTP ${r.status}: ${(await r.text()).slice(0, 300)}`);
+    }
+    const j = (await r.json()) as OllamaChatResponse;
+    return {
+      content: j?.message?.content ?? "",
+      thinking: j?.message?.thinking ?? "",
+    };
+  }
+
+  /** Free RAM by unloading the model (Ollama: keep_alive=0 on /api/generate). */
+  async unload(): Promise<void> {
+    try {
+      await this.fetchFn(`${this.url}/api/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: this.model, keep_alive: 0 }),
+      });
+    } catch {
+      // best-effort; nightly must not fail on unload
+    }
+  }
+}
+
+/**
+ * Env-driven factory. Honors the same `MYCELIUM_LLM_PROVIDER` switch as
+ * `createEmbeddingProvider()` so a single env var routes both halves of the
+ * native-app stack. Today only `ollama` is implemented; `llama-cpp` is a
+ * follow-up that lands once PR #187's `node-llama-cpp` dependency is on
+ * main (otherwise it would force the package on installs that don't need
+ * it).
+ */
+export function createChatProvider(): ChatProvider {
+  const raw = (process.env.MYCELIUM_LLM_PROVIDER ?? "ollama").toLowerCase();
+  const provider = raw === "llamacpp" ? "llama-cpp" : raw;
+  switch (provider) {
+    case "ollama":
+      return new OllamaChatProvider({
+        url: process.env.OLLAMA_URL,
+        model: process.env.REM_MODEL,
+        keepAlive: process.env.REM_KEEP_ALIVE,
+      });
+    case "llama-cpp":
+      throw new Error(
+        "MYCELIUM_LLM_PROVIDER=llama-cpp: chat side not yet implemented " +
+          "(LlamaCppChatProvider lands as a follow-up to PR #187). Use ollama for now.",
+      );
+    default:
+      throw new Error(
+        `Unknown MYCELIUM_LLM_PROVIDER='${raw}' (expected 'ollama' or 'llama-cpp')`,
+      );
+  }
+}

--- a/scripts/synthesize-cluster.mjs
+++ b/scripts/synthesize-cluster.mjs
@@ -6,23 +6,25 @@
  *
  * Laufzeit-Verhalten:
  *   - keep_alive: das Modell bleibt zwischen Clustern warm (REM_KEEP_ALIVE)
- *   - unloadQwen() am Ende: POST keep_alive=0 → Ollama entlädt das Modell
- *     sofort, RAM wird wieder frei.
+ *   - provider.unload() am Ende: Ollama-Backend entlädt das Modell sofort,
+ *     RAM wird wieder frei. No-op für stateless Provider.
  *
  * Konfiguration via Umgebungsvariablen:
+ *   MYCELIUM_LLM_PROVIDER — Backend ("ollama" default, "llama-cpp" geplant)
  *   REM_MODEL       — Ollama-Modell-Tag (default: qwen3:8b)
  *   OLLAMA_URL      — Ollama-Endpoint (default: http://localhost:11434)
  *   REM_KEEP_ALIVE  — wie lange das Modell warm bleibt (default: 2m)
  *   REM_NUM_CTX     — Context-Window in Tokens (default: 16384)
  *
- * Prompt-Shape: strict JSON via Ollama `format: "json"`, erwartete Shape:
+ * Prompt-Shape: strict JSON, erwartete Shape:
  *   { "lesson": string, "pattern_name": string, "confidence": 0..1, "reinforce": boolean }
+ *
+ * Der ChatProvider (`mcp-server/src/services/chat.ts`) entkoppelt diesen
+ * Synthesizer von Ollama-spezifischer HTTP-Logik — die Naht für Spike-2's
+ * `LlamaCppChatProvider` (issue #178, native-app track #176).
  */
 
-const MODEL       = process.env.REM_MODEL || "qwen3:8b";
-const OLLAMA_URL  = process.env.OLLAMA_URL || "http://localhost:11434";
-const KEEP_ALIVE  = process.env.REM_KEEP_ALIVE || "2m";
-const NUM_CTX     = Number(process.env.REM_NUM_CTX || 16384);
+const NUM_CTX = Number(process.env.REM_NUM_CTX || 16384);
 
 // /think aktiviert den Reasoning-Pfad in Qwen3 (und in allen R1-Distills).
 // Das Modell schreibt erst <think>…</think> mit interner Schlussfolgerung,
@@ -94,84 +96,78 @@ function buildUserPrompt(cluster, members) {
   return lines.join("\n");
 }
 
-/**
- * Strip Qwen3 / R1-Distill <think>…</think> reasoning blocks from a response,
- * then locate the JSON object that follows. Robust to:
- *   - multiple <think> blocks
- *   - prose before/after the JSON
- *   - models that occasionally emit ``` json fences
- */
-function extractJSON(raw) {
-  if (!raw) throw new Error("empty model response");
-  // 1) Drop think blocks (greedy multi-line).
-  let s = raw.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
-  // 2) Strip code fences if present.
-  s = s.replace(/```(?:json)?\s*/g, "").replace(/```/g, "").trim();
-  // 3) Locate the outermost {…}: first { to last }.
-  const i = s.indexOf("{");
-  const j = s.lastIndexOf("}");
-  if (i < 0 || j < 0 || j <= i) throw new Error(`no JSON object found in: ${raw.slice(0, 200)}`);
-  const body = s.slice(i, j + 1);
-  return JSON.parse(body);
+// Lazy-loaded chat module. We import the compiled TS module (mirrors how
+// this script imports embeddings.js below) so a single env switch
+// (MYCELIUM_LLM_PROVIDER) can route both halves of the LLM stack.
+let _chatModule = null;
+let _chatProvider = null;
+async function loadChatModule() {
+  if (_chatModule) return _chatModule;
+  const path = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(here, "..");
+  _chatModule = await import(
+    path.join(repoRoot, "mcp-server/dist/services/chat.js")
+  );
+  return _chatModule;
 }
 
-async function callQwen({ systemPrompt, userPrompt, keepAlive = KEEP_ALIVE }) {
-  const r = await fetch(`${OLLAMA_URL}/api/chat`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model:       MODEL,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user",   content: userPrompt   },
-      ],
-      stream:      false,
-      keep_alive:  keepAlive,
-      // Ollama 0.20+ separates reasoning into `message.thinking` and the
-      // final answer into `message.content`. Setting think:true activates
-      // Qwen3's reasoning pathway cleanly — no <think> tag parsing
-      // needed (extractJSON below stays as a defensive fallback for
-      // older Ollama versions or models that embed think blocks
-      // anyway). Bewusst KEIN format:"json" — würde mit Reasoning
-      // kollidieren.
-      think:       true,
-      options:     { temperature: 0.3, num_ctx: NUM_CTX },
-    }),
+async function getChatProvider() {
+  if (_chatProvider) return _chatProvider;
+  const mod = await loadChatModule();
+  _chatProvider = mod.createChatProvider();
+  return _chatProvider;
+}
+
+async function synthCallChat({ systemPrompt, userPrompt }) {
+  const provider = await getChatProvider();
+  const { extractJSON } = await loadChatModule();
+  const result = await provider.chat({
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ],
+    think: true,
+    options: { temperature: 0.3, num_ctx: NUM_CTX },
   });
-  if (!r.ok) throw new Error(`Ollama HTTP ${r.status}: ${(await r.text()).slice(0, 300)}`);
-  const j = await r.json();
-  const raw = j?.message?.content ?? "";
-  const thinking = j?.message?.thinking ?? "";
+  let parsed;
   try {
-    const parsed = extractJSON(raw);
-    // Surface a thinking-length signal so nightly-sleep can log whether the
-    // reasoning pathway actually fired. Empty thinking ≠ failure (older
-    // Ollama / non-reasoning models simply don't return the field).
-    if (thinking && parsed && typeof parsed === "object") {
-      parsed._thinking_chars = thinking.length;
-    }
-    return parsed;
+    parsed = extractJSON(result.content);
+  } catch (e) {
+    throw new Error(
+      `${provider.name} response parse failed: ${e?.message ?? e}\nraw: ${result.content.slice(0, 300)}`,
+    );
   }
-  catch (e) { throw new Error(`Qwen response parse failed: ${e.message ?? e}\nraw: ${raw.slice(0, 300)}`); }
+  // Surface a thinking-length signal so nightly-sleep can log whether the
+  // reasoning pathway actually fired. Empty thinking ≠ failure (older
+  // Ollama / non-reasoning models simply don't return the field).
+  if (result.thinking && parsed && typeof parsed === "object") {
+    parsed._thinking_chars = result.thinking.length;
+  }
+  return parsed;
 }
 
-/** Explicitly unload the model from Ollama (free RAM for other workloads). */
-export async function unloadQwen() {
-  try {
-    await fetch(`${OLLAMA_URL}/api/generate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: MODEL, keep_alive: 0 }),
-    });
-  } catch { /* best-effort; nightly must not fail on unload */ }
+/**
+ * Explicitly unload the model from the active provider (free RAM for other
+ * workloads). Best-effort; no-op for stateless providers. Renamed from
+ * `unloadQwen` to reflect that the provider chooses how to dispose.
+ */
+export async function unloadModel() {
+  const provider = await getChatProvider();
+  if (typeof provider.unload === "function") {
+    await provider.unload();
+  }
 }
+// Back-compat re-export for callers still using the Qwen-specific name.
+export { unloadModel as unloadQwen };
 
 /** Synthesize ONE cluster into a lesson payload. No DB writes here — caller decides record vs. reinforce. */
 export async function synthesizeCluster(cluster, { supabaseUrl, supabaseKey }) {
   const members = await loadMembers(cluster.member_ids, { supabaseUrl, supabaseKey });
   if (members.length === 0) return { skipped: "no_members_found", confidence: 0 };
   const userPrompt = buildUserPrompt(cluster, members);
-  const out = await callQwen({ systemPrompt: SYSTEM_PROMPT, userPrompt });
+  const out = await synthCallChat({ systemPrompt: SYSTEM_PROMPT, userPrompt });
   const lesson       = typeof out?.lesson === "string" ? out.lesson.trim() : "";
   const pattern_name = typeof out?.pattern_name === "string" ? out.pattern_name.trim() : "";
   const confidence   = Math.max(0, Math.min(1, Number(out?.confidence) || 0));
@@ -221,6 +217,6 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       console.error(`[dry] seed=${c.seed_id} ERROR ${e?.message ?? e}`);
     }
   }
-  await unloadQwen();
+  await unloadModel();
   console.error("[dry] model unloaded.");
 }


### PR DESCRIPTION
## Summary

- Mirrors PR #187's pattern on the **chat half** of #178 — extracts a `ChatProvider` seam over `scripts/synthesize-cluster.mjs`'s inline Ollama HTTP / `<think>` parsing so the next slice can drop a `LlamaCppChatProvider` in behind the same `MYCELIUM_LLM_PROVIDER` env switch.
- No new deps, no `package.json` change. Keeps the merge surface clean against PR #187 (which adds `node-llama-cpp` as `optionalDependencies`); the actual `LlamaCppChatProvider` lands once that's on `main`.
- Default behaviour unchanged — REM still talks Ollama. Existing installs see no diff.

## What changes

- **`mcp-server/src/services/chat.ts`** (new): `ChatProvider` interface, `OllamaChatProvider` extracted verbatim from `synthesize-cluster.mjs`'s `callQwen` + `unloadQwen`, `extractJSON()` pure helper (Qwen3 `<think>` blocks, ` ```json ` fences, prose-wrapped JSON), `createChatProvider()` env factory honouring `MYCELIUM_LLM_PROVIDER`. The `llama-cpp` branch throws a clear stub error pointing at the follow-up PR — no silent fallthrough.
- **`mcp-server/src/__tests__/chat.test.ts`** (new): 19 unit tests
  - `extractJSON`: think blocks, multiple think blocks, fenced JSON (with/without `json`), prose-wrapped, empty input, no-JSON-found
  - `OllamaChatProvider`: shape sent to `/api/chat` (model/messages/keep_alive/think/options), missing-fields fallback to empty strings, HTTP error path with status + body, per-request `keepAlive` override, `unload()` posts `keep_alive=0` on `/api/generate`, `unload()` swallows network errors (best-effort)
  - `createChatProvider`: default → ollama, case-insensitive, `llama-cpp` stub throws, `llamacpp` alias, unknown provider with helpful list
- **`scripts/synthesize-cluster.mjs`** (refactor): uses `createChatProvider()` + `extractJSON` from the compiled module instead of inline fetch. `unloadModel()` is the new name; `unloadQwen` kept as a back-compat re-export.

## Why this slice now

Spike-2 doc §\"Suggested follow-up issues\" #2: \"add `LlamaCppChatProvider` and route REM digest through it when `MYCELIUM_LLM_PROVIDER=llama-cpp`\". The pre-step is to give `synthesize-cluster.mjs` a swap point — that's this PR. Without it the LlamaCpp impl would have to either fork the script or re-introduce the same hard-coded HTTP shape.

## Out of scope

- `LlamaCppChatProvider` itself (depends on PR #187 landing for the `node-llama-cpp` package)
- REM model upgrade — same model (`qwen3:8b`), same prompts
- Streaming / token-by-token UI

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 958 pass (was 939; +19 new), 0 fail
- [x] `node --check scripts/synthesize-cluster.mjs` — OK
- [ ] Manual: `node scripts/synthesize-cluster.mjs --dry` against a live Ollama (env paths preserved: `OLLAMA_URL`, `REM_MODEL`, `REM_KEEP_ALIVE`, `REM_NUM_CTX`)

## Pillar check

Pillar 1 (decentralised AI) — strengthened indirectly: sets up the seam that lets the native-app build drop the Ollama daemon. No pillar weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)