### PR TITLE
fix(federation): null-guard mTLS listener when deferred build missing — W2 follow-up to #6706161

### DIFF
--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -50,6 +50,8 @@ if (process.env.MYCELIUM_FEATURE_FEDERATION === "1") {
     ({ GuardService: FedGuardService } = await import(path.join(FED_DIST, "guard.js")));
   } catch (err) {
     console.error("federation imports failed — feature flag set but dist missing:", err.message);
+    console.error("  → re-include src/deferred/** in mcp-server/tsconfig.json + rebuild, or unset MYCELIUM_FEATURE_FEDERATION.");
+    console.error("  → continuing in HTTP-swarm-only mode; mTLS federation listener will NOT start.");
     FederationService = null;
     FedGuardService = null;
   }
@@ -2366,7 +2368,7 @@ if (FEATURE.federation) {
   }
 }
 
-if (hostCert && FEATURE.federation) {
+if (hostCert && FEATURE.federation && FederationService && FedGuardService) {
   // Register host_identity in DB (best-effort; non-fatal).
   try {
     const r = await fetch(`${UPSTREAM}/rpc/host_identity_set`, {

--- a/scripts/dashboard-server.mjs
+++ b/scripts/dashboard-server.mjs
@@ -50,7 +50,7 @@ if (process.env.MYCELIUM_FEATURE_FEDERATION === "1") {
     ({ GuardService: FedGuardService } = await import(path.join(FED_DIST, "guard.js")));
   } catch (err) {
     console.error("federation imports failed — feature flag set but dist missing:", err.message);
-    console.error("  → re-include src/deferred/** in mcp-server/tsconfig.json + rebuild, or unset MYCELIUM_FEATURE_FEDERATION.");
+    console.error("  → re-include 'src/deferred' in mcp-server/tsconfig.json + rebuild, or unset MYCELIUM_FEATURE_FEDERATION.");
     console.error("  → continuing in HTTP-swarm-only mode; mTLS federation listener will NOT start.");
     FederationService = null;
     FedGuardService = null;


### PR DESCRIPTION
## Summary

- Closes the loop on W2 doc drift commit 6706161: the doc flagged the crash, this PR ships the minimal fix.
- One-line guard at `scripts/dashboard-server.mjs:2369` plus two extra hint lines on the existing import-failure error.
- Net effect: `MYCELIUM_FEATURE_FEDERATION=1` against today's build no longer crashes the dashboard at startup. Reed's second-peer bring-up (`docs/wave-2-second-peer.md`) can now exercise the HTTP-swarm path (steps 1–7) without disabling the flag first.

## Why this is needed

`mcp-server/tsconfig.json` excludes `src/deferred/**`, so `dist/services/federation.js` is never emitted. The lazy import at `dashboard-server.mjs:49` catches the missing module and sets `FederationService=null` and `FedGuardService=null`, but `scripts/deferred/lib/tls-host.mjs` still loads (JS module, not TS-deferred) and `hostCert` initializes successfully. The block at line 2369 then enters with both services null and `new FedGuardService(...)` at 2452 throws `TypeError: FedGuardService is not a constructor`.

## What changed

```diff
- if (hostCert && FEATURE.federation) {
+ if (hostCert && FEATURE.federation && FederationService && FedGuardService) {
```

Plus two `console.error` lines on the existing import-failure path so the user sees what to do (rebuild with `src/deferred/**` re-included, or unset the flag) and what mode they're actually in (HTTP-swarm only, no mTLS listener).

## Validation

```
$ MYCELIUM_FEATURE_FEDERATION=1 JWT_SECRET=test PORT=18787 FEDERATION_PORT=18788 \
    node scripts/dashboard-server.mjs
federation imports failed — feature flag set but dist missing: Cannot find module '…/federation.js'
  → re-include src/deferred/** in mcp-server/tsconfig.json + rebuild, or unset MYCELIUM_FEATURE_FEDERATION.
  → continuing in HTTP-swarm-only mode; mTLS federation listener will NOT start.
federation host cert ready: …
vectormemory dashboard listening on http://0.0.0.0:18787
```

Default path (no federation flag) unchanged.

## Out of scope (intentionally)

- Re-including `src/deferred/**` in the tsconfig — that is a roadmap step 5 ("Schwarm + Vererbung + Föderation") decision, not a bugfix.
- Adding tests for `dashboard-server.mjs` — the file has no test harness today; adding one would dwarf the fix.

## Test plan

- [x] Manual smoke: flag-set + missing-dist no longer crashes
- [x] Manual smoke: default path (flag unset) still boots
- [ ] Reed reviews and merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)