### PR TITLE
chore(scripts): move federation e2e scripts to deferred/ — complete b293040

### DIFF
--- a/mcp-server/scripts/deferred/e2e-autosync.mjs
+++ b/mcp-server/scripts/deferred/e2e-autosync.mjs
@@ -2,9 +2,9 @@
 // Wir testen, dass der Loop einen auto_sync_enabled peer tatsächlich syncht
 // und die peers_list-Felder entsprechend updated werden.
 import { execSync } from "node:child_process";
-import { FederationService } from "../dist/services/federation.js";
-import { GuardService } from "../dist/services/guard.js";
-import { IdentityService } from "../dist/services/identity.js";
+import { FederationService } from "../../dist/services/federation.js";
+import { GuardService } from "../../dist/services/guard.js";
+import { IdentityService } from "../../dist/services/identity.js";
 
 const url = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const key = process.env.SUPABASE_KEY ?? "";

--- a/mcp-server/scripts/deferred/e2e-federation-network.mjs
+++ b/mcp-server/scripts/deferred/e2e-federation-network.mjs
@@ -5,9 +5,9 @@ import { execSync } from "node:child_process";
 import { unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { IdentityService } from "../dist/services/identity.js";
-import { FederationService } from "../dist/services/federation.js";
-import { GuardService } from "../dist/services/guard.js";
+import { IdentityService } from "../../dist/services/identity.js";
+import { FederationService } from "../../dist/services/federation.js";
+import { GuardService } from "../../dist/services/guard.js";
 
 const url = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const key = process.env.SUPABASE_KEY ?? "";

--- a/mcp-server/scripts/deferred/e2e-federation.mjs
+++ b/mcp-server/scripts/deferred/e2e-federation.mjs
@@ -22,9 +22,9 @@ function sqlDelete(label) {
   execSync(`docker exec vectormemory-db psql -U postgres -d vectormemory -c "DELETE FROM agent_genomes WHERE label='${label}'"`, { stdio: "ignore" });
 }
 const { PostgrestClient } = pkg;
-import { IdentityService } from "../dist/services/identity.js";
-import { FederationService } from "../dist/services/federation.js";
-import { GuardService } from "../dist/services/guard.js";
+import { IdentityService } from "../../dist/services/identity.js";
+import { FederationService } from "../../dist/services/federation.js";
+import { GuardService } from "../../dist/services/guard.js";
 
 const url = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const key = process.env.SUPABASE_KEY ?? "";

--- a/mcp-server/scripts/deferred/e2e-pom.mjs
+++ b/mcp-server/scripts/deferred/e2e-pom.mjs
@@ -8,9 +8,9 @@ import https from "node:https";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { IdentityService } from "../dist/services/identity.js";
-import { FederationService } from "../dist/services/federation.js";
-import { GuardService } from "../dist/services/guard.js";
+import { IdentityService } from "../../dist/services/identity.js";
+import { FederationService } from "../../dist/services/federation.js";
+import { GuardService } from "../../dist/services/guard.js";
 
 const url = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const key = process.env.SUPABASE_KEY ?? "";

--- a/mcp-server/scripts/deferred/e2e-push-pom.mjs
+++ b/mcp-server/scripts/deferred/e2e-push-pom.mjs
@@ -10,9 +10,9 @@
 //      → cert mismatch detected (simulate via direct challengePom mit falscher expected pubkey)
 
 import { execSync } from "node:child_process";
-import { IdentityService } from "../dist/services/identity.js";
-import { FederationService } from "../dist/services/federation.js";
-import { GuardService } from "../dist/services/guard.js";
+import { IdentityService } from "../../dist/services/identity.js";
+import { FederationService } from "../../dist/services/federation.js";
+import { GuardService } from "../../dist/services/guard.js";
 
 const url = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const key = process.env.SUPABASE_KEY ?? "";

--- a/mcp-server/scripts/deferred/e2e-revocation.mjs
+++ b/mcp-server/scripts/deferred/e2e-revocation.mjs
@@ -9,9 +9,9 @@ import { execSync } from "node:child_process";
 import { unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { IdentityService } from "../dist/services/identity.js";
-import { FederationService } from "../dist/services/federation.js";
-import { GuardService } from "../dist/services/guard.js";
+import { IdentityService } from "../../dist/services/identity.js";
+import { FederationService } from "../../dist/services/federation.js";
+import { GuardService } from "../../dist/services/guard.js";
 
 const url = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const key = process.env.SUPABASE_KEY ?? "";


### PR DESCRIPTION
## Summary

- Move 5 federation-dependent e2e scripts from `mcp-server/scripts/` into the existing `mcp-server/scripts/deferred/` directory, completing the structural intent of commit b293040 which moved only `e2e-push-pom.mjs`.
- Fix the relative `../dist/...` imports → `../../dist/...` in all 6 scripts now living at depth 2.

## Why

These five scripts depend on `dist/services/federation.js`:

- `e2e-federation.mjs`
- `e2e-pom.mjs`
- `e2e-revocation.mjs`
- `e2e-autosync.mjs`
- `e2e-federation-network.mjs`

`mcp-server/tsconfig.json` excludes `src/deferred/**`, so `federation.ts` is not compiled and `dist/services/federation.js` does not exist on the active build. Running any of these scripts today crashes immediately:

```
$ node scripts/e2e-pom.mjs
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/Users/reed/vectormemory-openclaw/mcp-server/dist/services/federation.js'
```

Commit b293040 already moved `e2e-push-pom.mjs` into `scripts/deferred/` for exactly this reason but left its siblings behind — they exercise the same deferred service. Putting them next to the deferred source they use (and to the lone deferred sibling) keeps the convention honest: if it lives in `scripts/deferred/`, it's gated on the federation build.

This is also the same root cause CLAUDE.md flags around the dashboard: "Schwarm + Vererbung + Föderation" is roadmap step 5 (deferred). Wave 2's HTTP path works in the active build; the mTLS path is parked, and these e2e scripts exercise the parked side.

## Path correction (collateral fix)

`e2e-push-pom.mjs` (already in `deferred/`) had `../dist/...` paths, which resolve to `mcp-server/scripts/dist/...` — that directory has never existed. The first import error today is a path mismatch on `identity.js`, not a deferred-build error on `federation.js`. After this PR, all six files use `../../dist/...` and only fail on the actual deferred-build cause.

Verified locally:

```
$ node scripts/deferred/e2e-pom.mjs
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/Users/reed/vectormemory-openclaw/mcp-server/dist/services/federation.js'
  imported from .../scripts/deferred/e2e-pom.mjs
```

`IdentityService` and `GuardService` (both compiled from active code) import-resolve cleanly; only `FederationService` errors — i.e. exactly the gate Reed wants visible when the deferred build is re-emitted.

## Out of scope

- Re-including `src/deferred/**` in `tsconfig.json`. That's the roadmap-step-5 unpark decision, not this PR's concern.
- Touching active e2e scripts (`e2e-pki.mjs`, `e2e-breeding-sim.mjs`, `e2e-experience-coupling.mjs`, `e2e-motivation-coupling.mjs`, `e2e-neurochemistry.mjs`, `smoke-cross-spread.mjs`, `smoke-salience-reactor.mjs`, `backfill-pki.mjs`). They don't import federation and stay where they are.
- Adding any wrapper / no-op stub. The directory placement and the unmodified `ERR_MODULE_NOT_FOUND` are the documentation.

## Test plan

- [x] `cd mcp-server && npm run build` — green.
- [x] No `package.json` script or other source/doc references the moved files (grep confirms only self-mentions inside the scripts themselves).
- [x] Manual run of `node scripts/deferred/e2e-pom.mjs` confirms first failing import is now `dist/services/federation.js`, not a path mismatch.
- [ ] Reed reviews and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)