### PR TITLE
feat(native): MYCELIUM_DATA_DIR root + pgdata/models/wire-cert layout — #176 sub-task 3 prep

### DIFF
--- a/mcp-server/src/__tests__/native/data-dir.test.ts
+++ b/mcp-server/src/__tests__/native/data-dir.test.ts
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  defaultRootDir,
+  getDataDirLayout,
+  ensureDataDirs,
+} from "../../native/data-dir.js";
+
+function withEnv(
+  patches: Record<string, string | undefined>,
+  fn: () => Promise<void> | void
+): () => Promise<void> {
+  return async () => {
+    const prev: Record<string, string | undefined> = {};
+    for (const k of Object.keys(patches)) prev[k] = process.env[k];
+    try {
+      for (const [k, v] of Object.entries(patches)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      await fn();
+    } finally {
+      for (const [k, v] of Object.entries(prev)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  };
+}
+
+test(
+  "defaultRootDir returns OS-conventional absolute path ending in mycelium",
+  () => {
+    const root = defaultRootDir();
+    assert.ok(path.isAbsolute(root), `expected absolute path, got ${root}`);
+    assert.equal(path.basename(root), "mycelium");
+  }
+);
+
+test(
+  "MYCELIUM_DATA_DIR override propagates to all subpaths",
+  withEnv(
+    {
+      MYCELIUM_DATA_DIR: "/tmp/mycelium-test-root",
+      MYCELIUM_PGLITE_DATA_DIR: undefined,
+      MYCELIUM_LLAMA_MODELS_DIR: undefined,
+    },
+    () => {
+      const layout = getDataDirLayout();
+      assert.equal(layout.root, "/tmp/mycelium-test-root");
+      assert.equal(layout.pgData, "/tmp/mycelium-test-root/pgdata");
+      assert.equal(layout.models, "/tmp/mycelium-test-root/models");
+      assert.equal(layout.wireCert, "/tmp/mycelium-test-root/wire-cert");
+    }
+  )
+);
+
+test(
+  "MYCELIUM_PGLITE_DATA_DIR overrides pgData independent of root",
+  withEnv(
+    {
+      MYCELIUM_DATA_DIR: "/tmp/mycelium-test-root",
+      MYCELIUM_PGLITE_DATA_DIR: "/var/custom/pglite",
+      MYCELIUM_LLAMA_MODELS_DIR: undefined,
+    },
+    () => {
+      const layout = getDataDirLayout();
+      assert.equal(layout.pgData, "/var/custom/pglite");
+      assert.equal(layout.root, "/tmp/mycelium-test-root");
+      assert.equal(layout.models, "/tmp/mycelium-test-root/models");
+    }
+  )
+);
+
+test(
+  "MYCELIUM_LLAMA_MODELS_DIR overrides models independent of root",
+  withEnv(
+    {
+      MYCELIUM_DATA_DIR: "/tmp/mycelium-test-root",
+      MYCELIUM_PGLITE_DATA_DIR: undefined,
+      MYCELIUM_LLAMA_MODELS_DIR: "/var/custom/models",
+    },
+    () => {
+      const layout = getDataDirLayout();
+      assert.equal(layout.models, "/var/custom/models");
+      assert.equal(layout.pgData, "/tmp/mycelium-test-root/pgdata");
+    }
+  )
+);
+
+test("ensureDataDirs creates root + three subdirs", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "mycelium-data-dir-"));
+  try {
+    const layout = await ensureDataDirs({
+      root: tmp,
+      pgData: path.join(tmp, "pgdata"),
+      models: path.join(tmp, "models"),
+      wireCert: path.join(tmp, "wire-cert"),
+    });
+    for (const dir of [layout.root, layout.pgData, layout.models, layout.wireCert]) {
+      const st = await stat(dir);
+      assert.ok(st.isDirectory(), `${dir} should be a directory`);
+    }
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("ensureDataDirs is idempotent (second call does not throw)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "mycelium-data-dir-"));
+  try {
+    const layout = {
+      root: tmp,
+      pgData: path.join(tmp, "pgdata"),
+      models: path.join(tmp, "models"),
+      wireCert: path.join(tmp, "wire-cert"),
+    };
+    await ensureDataDirs(layout);
+    await ensureDataDirs(layout);
+    const st = await stat(layout.wireCert);
+    assert.ok(st.isDirectory());
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/mcp-server/src/native/data-dir.ts
+++ b/mcp-server/src/native/data-dir.ts
@@ -1,0 +1,66 @@
+// Single source of truth for the native-app data layout.
+//
+// One root directory per install holds three subtrees:
+//
+//   ${MYCELIUM_DATA_DIR}/
+//     ├── pgdata/        PGlite WAL + heap (#185)
+//     ├── models/        GGUF files for node-llama-cpp (#187)
+//     └── wire-cert/     Self-signed mTLS cert for Wave-3 wire port
+//                        (created here, populated by Wave-2/3 ticket)
+//
+// Default root per platform — matches what the Tauri shell will pass in
+// via `MYCELIUM_DATA_DIR` (BaseDirectory::AppLocalData):
+//
+//   macOS:   ~/Library/Application Support/mycelium/
+//   Linux:   $XDG_DATA_HOME/mycelium/  (fallback ~/.local/share/mycelium/)
+//   Windows: %APPDATA%/mycelium/
+//
+// Backward compatibility: the pre-existing `MYCELIUM_PGLITE_DATA_DIR` and
+// `MYCELIUM_LLAMA_MODELS_DIR` env vars still override their respective
+// subpaths. Setting just `MYCELIUM_DATA_DIR` is the new one-knob path.
+
+import { mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface DataDirLayout {
+  root: string;
+  pgData: string;
+  models: string;
+  wireCert: string;
+}
+
+export function defaultRootDir(): string {
+  const home = os.homedir();
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "mycelium");
+  }
+  if (process.platform === "win32") {
+    const appData =
+      process.env.APPDATA ?? path.join(home, "AppData", "Roaming");
+    return path.join(appData, "mycelium");
+  }
+  const xdg =
+    process.env.XDG_DATA_HOME ?? path.join(home, ".local", "share");
+  return path.join(xdg, "mycelium");
+}
+
+export function getDataDirLayout(): DataDirLayout {
+  const root = process.env.MYCELIUM_DATA_DIR ?? defaultRootDir();
+  return {
+    root,
+    pgData: process.env.MYCELIUM_PGLITE_DATA_DIR ?? path.join(root, "pgdata"),
+    models: process.env.MYCELIUM_LLAMA_MODELS_DIR ?? path.join(root, "models"),
+    wireCert: path.join(root, "wire-cert"),
+  };
+}
+
+export async function ensureDataDirs(
+  layout: DataDirLayout = getDataDirLayout()
+): Promise<DataDirLayout> {
+  await mkdir(layout.root, { recursive: true });
+  await mkdir(layout.pgData, { recursive: true });
+  await mkdir(layout.models, { recursive: true });
+  await mkdir(layout.wireCert, { recursive: true });
+  return layout;
+}

--- a/mcp-server/src/native/factory.ts
+++ b/mcp-server/src/native/factory.ts
@@ -8,7 +8,6 @@
 //   // for the surface the services in src/services/ use.
 
 import path from "node:path";
-import os from "node:os";
 
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
@@ -23,6 +22,7 @@ import { tablefunc } from "@electric-sql/pglite/contrib/tablefunc";
 
 import { PGliteAdapter } from "./pglite.js";
 import { applyMigrations, type MigrationReport } from "./migration-runner.js";
+import { getDataDirLayout, ensureDataDirs } from "./data-dir.js";
 
 export interface NativeDbOptions {
   /** Data directory; defaults to OS-conventional app-data path. */
@@ -42,29 +42,19 @@ export interface NativeDb {
 }
 
 /**
- * Default data dir per platform — matches what the Tauri shell will use so
- * the Node-side path and the future GUI path land on the same files.
- *
- *   macOS:   ~/Library/Application Support/mycelium/data
- *   Linux:   $XDG_DATA_HOME/mycelium/data  (fallback ~/.local/share/mycelium/data)
- *   Windows: %APPDATA%/mycelium/data
+ * Default PGlite data dir — delegates to the unified layout in data-dir.ts so
+ * the Node-side path and the Tauri shell land on the same files. Honours
+ * `MYCELIUM_DATA_DIR` (root) and the legacy `MYCELIUM_PGLITE_DATA_DIR`
+ * (subpath override) — see data-dir.ts for precedence.
  */
 export function defaultDataDir(): string {
-  const env = process.env.MYCELIUM_PGLITE_DATA_DIR;
-  if (env) return env;
-  const home = os.homedir();
-  if (process.platform === "darwin") {
-    return path.join(home, "Library", "Application Support", "mycelium", "data");
-  }
-  if (process.platform === "win32") {
-    const appdata = process.env.APPDATA ?? path.join(home, "AppData", "Roaming");
-    return path.join(appdata, "mycelium", "data");
-  }
-  const xdg = process.env.XDG_DATA_HOME ?? path.join(home, ".local", "share");
-  return path.join(xdg, "mycelium", "data");
+  return getDataDirLayout().pgData;
 }
 
 export async function createNativeDb(opts: NativeDbOptions = {}): Promise<NativeDb> {
+  // Materialise pgdata/ + models/ + wire-cert/ before PGlite touches the
+  // filesystem. Wire-cert/ stays empty here — Wave-2/3 populates it.
+  await ensureDataDirs();
   const dataDir = opts.dataDir ?? defaultDataDir();
 
   const pg = await PGlite.create({

--- a/mcp-server/src/services/embeddings.ts
+++ b/mcp-server/src/services/embeddings.ts
@@ -1,11 +1,10 @@
 import { Ollama } from "ollama";
 import { mkdir } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import {
   lookupExpectedChecksum,
   verifyGgufChecksum,
 } from "./llama-gguf-checksum.js";
+import { getDataDirLayout } from "../native/data-dir.js";
 
 export interface EmbeddingProvider {
   embed(text: string): Promise<number[]>;
@@ -116,23 +115,7 @@ const DEFAULT_LLAMA_EMBEDDING_MODEL_URI =
   "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q5_K_M.gguf";
 
 export function defaultLlamaModelsDir(): string {
-  if (process.platform === "darwin") {
-    return path.join(
-      os.homedir(),
-      "Library",
-      "Application Support",
-      "mycelium",
-      "models"
-    );
-  }
-  if (process.platform === "win32") {
-    const appData =
-      process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
-    return path.join(appData, "mycelium", "models");
-  }
-  const xdg =
-    process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share");
-  return path.join(xdg, "mycelium", "models");
+  return getDataDirLayout().models;
 }
 
 export class LlamaCppEmbeddingProvider implements EmbeddingProvider {


### PR DESCRIPTION
## Summary

Implements ticket 2 of `docs/native-tauri-shell-spike.md` "Suggested follow-up issues" — the **headless prerequisite** for the Tauri shell PR. Reed wants to ship a native standalone app (#176, Wave 1, prio 0.98); this PR teaches the mcp-server side to honour a single `MYCELIUM_DATA_DIR` root that the future Tauri sidecar passes in, instead of two unrelated per-OS paths.

## Why

Pre-existing state: `factory.ts` defaulted PGlite to `…/mycelium/data`, `embeddings.ts` defaulted llama.cpp models to `…/mycelium/models`. Two unrelated per-OS branches, both duplicated. The Tauri shell needs to pass ONE env (`MYCELIUM_DATA_DIR`) and have PGlite, llama.cpp, AND the Wave-3 wire-cert all live underneath it (per shell-spike §3 lifecycle, §6 data dir, and the Wave-3 forward-compat table row 4).

## Changes

- **`mcp-server/src/native/data-dir.ts`** *(new)*: single source of truth.
  - `defaultRootDir()` per platform (macOS/Linux/Windows).
  - `getDataDirLayout()` resolves `${root}/pgdata`, `${root}/models`, `${root}/wire-cert`. Legacy env vars still override their own subpath.
  - `ensureDataDirs()` mkdir's all four (root + 3 subdirs), idempotent.
- **`factory.ts`**: `defaultDataDir()` delegates to the layout. `createNativeDb()` calls `ensureDataDirs()` before PGlite touches disk so `wire-cert/` exists empty for Wave-2/3 to populate (per spike: *"reserve the path so the migration wizard does not have to special-case it later"*).
- **`embeddings.ts`**: `defaultLlamaModelsDir()` delegates to the layout. Drops the platform branch duplicated from factory.ts.

## Backward compatibility

- `MYCELIUM_PGLITE_DATA_DIR` still wins over `${root}/pgdata` (Spike-1 installs that pinned the path keep working).
- `MYCELIUM_LLAMA_MODELS_DIR` still wins over `${root}/models`.
- New default for the PGlite subdir flips from `…/mycelium/data` to `…/mycelium/pgdata` — no production users yet (PGlite landed in #185 this week and is dual-build, not the primary backend), but flagged for the migration wizard (#176 sub-task 7) which now writes to `pgdata/`.

## Tests

- 6 new in `mcp-server/src/__tests__/native/data-dir.test.ts`: defaults, root-override propagation, both legacy overrides, mkdir creation, idempotence.
- Full suite: **1028/1029 green** (1 pre-existing skip). No regression in pglite-adapter, llama-cpp-embedding, or embeddings tests.

## Test plan
- [ ] `cd mcp-server && npm test` — full suite green
- [ ] Verify `MYCELIUM_DATA_DIR=/tmp/x npm test` still passes (env propagation)
- [ ] Spot-check `experiments/native-pg/spike-pglite.mjs` still works (uses default path)

## What this unblocks

Ticket 1 (Tauri 2 shell scaffold) — `tauri.conf.json` will spawn the sidecar with `MYCELIUM_DATA_DIR=BaseDirectory::AppLocalData/mycelium` and the mcp-server now knows what to do with it. Tickets 3 + 4 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)