### PR TITLE
feat(native): docker-migration helpers — Docker → PGlite wizard pure-TS core (#176 sub-task 7)

### DIFF
--- a/mcp-server/src/__tests__/native/docker-migration.test.ts
+++ b/mcp-server/src/__tests__/native/docker-migration.test.ts
@@ -1,0 +1,191 @@
+// Tests for src/native/docker-migration.ts — pure-TS Docker → PGlite
+// migration helpers (sub-task 7 of #176, anchored in
+// `docs/native-migration-spike.md`).
+//
+// Scope:
+//   - Dump-stripper handles the three psql directives the spike calls out
+//     and leaves legitimate SQL alone (including SQL whose string literals
+//     happen to contain the directive token).
+//   - End-to-end: a small synthetic dump (mimics the shape of
+//     `pg_dump --inserts` for a `memories` table including a `vector(768)`
+//     column serialised as plain text) restores cleanly into a fresh
+//     PGlite, with the `\restrict` / `\unrestrict` book-ending the file.
+//   - countTables guards against table-name injection and returns 0 for
+//     empty tables, real counts for populated ones.
+//   - verifyMigration reports row-equality across maps + flags missing
+//     target tables as mismatches.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+
+import {
+  applyDumpToPGlite,
+  countTables,
+  stripPsqlDirectives,
+  verifyMigration,
+} from "../../native/docker-migration.js";
+
+test("stripPsqlDirectives drops \\restrict, \\unrestrict, \\connect", () => {
+  const dump = [
+    "\\restrict urvWDAaJQC0aOAd20lx8m8dYHE93lFhlxad4WUvmEG0WfauNt5Cu2A88d1d8lmH",
+    "\\connect vectormemory",
+    "CREATE TABLE foo (id INT);",
+    "INSERT INTO foo VALUES (1);",
+    "\\unrestrict urvWDAaJQC0aOAd20lx8m8dYHE93lFhlxad4WUvmEG0WfauNt5Cu2A88d1d8lmH",
+  ].join("\n");
+
+  const out = stripPsqlDirectives(dump);
+
+  assert.equal(out.includes("\\restrict"), false);
+  assert.equal(out.includes("\\unrestrict"), false);
+  assert.equal(out.includes("\\connect"), false);
+  assert.equal(out.includes("CREATE TABLE foo"), true);
+  assert.equal(out.includes("INSERT INTO foo"), true);
+});
+
+test("stripPsqlDirectives preserves SQL whose literals look like directives", () => {
+  // Conservative: only lines *starting with* the directive are dropped.
+  // A SQL value containing the directive token is preserved.
+  const dump = [
+    "\\restrict abc",
+    "INSERT INTO notes VALUES ('please \\restrict me later');",
+    "INSERT INTO notes VALUES ('mention \\connect in a comment');",
+  ].join("\n");
+
+  const out = stripPsqlDirectives(dump);
+  assert.equal(out.includes("\\restrict abc"), false, "leading directive must be stripped");
+  assert.equal(
+    out.includes("'please \\restrict me later'"),
+    true,
+    "literal containing directive token must survive",
+  );
+  assert.equal(
+    out.includes("'mention \\connect in a comment'"),
+    true,
+    "literal containing directive token must survive",
+  );
+});
+
+test("stripPsqlDirectives is idempotent", () => {
+  const dump = "\\restrict tok\nSELECT 1;\n\\unrestrict tok\n";
+  const once = stripPsqlDirectives(dump);
+  const twice = stripPsqlDirectives(once);
+  assert.equal(once, twice);
+});
+
+test("applyDumpToPGlite restores a synthetic dump (schema + INSERTs + vector column) into fresh PGlite", async () => {
+  const pg = await PGlite.create({ extensions: { vector } });
+
+  // Synthetic dump mimicking pg_dump --inserts shape for the `memories` table.
+  // Uses a 4-dim vector for readability — pgvector's plain-text format is
+  // dimension-agnostic, so this exercises the same restore path the 768-dim
+  // production dump uses (per spike §1).
+  const synthetic = [
+    "\\restrict synthetic-test-token",
+    "",
+    "CREATE EXTENSION IF NOT EXISTS vector;",
+    "",
+    "CREATE TABLE public.memories (",
+    "  id UUID PRIMARY KEY,",
+    "  content TEXT NOT NULL,",
+    "  category TEXT NOT NULL DEFAULT 'general',",
+    "  tags TEXT[] DEFAULT '{}',",
+    "  embedding vector(4)",
+    ");",
+    "",
+    "INSERT INTO public.memories VALUES",
+    "  ('11111111-1111-1111-1111-111111111111', 'first memory', 'decisions', '{architecture,vector-memory}', '[0.1,0.2,0.3,0.4]'),",
+    "  ('22222222-2222-2222-2222-222222222222', 'second memory', 'general', '{}', '[0.5,0.6,0.7,0.8]'),",
+    "  ('33333333-3333-3333-3333-333333333333', 'third memory', 'people', '{family}', '[0.9,0.0,0.1,0.2]');",
+    "",
+    "\\unrestrict synthetic-test-token",
+  ].join("\n");
+
+  try {
+    const result = await applyDumpToPGlite(pg, synthetic);
+    assert.ok(result.bytes > 0, "expected non-empty stripped dump");
+    assert.ok(result.durationMs >= 0, "duration should be non-negative");
+
+    // Row count survives.
+    const count = await pg.query<{ c: number }>(
+      "SELECT count(*)::int AS c FROM public.memories",
+    );
+    assert.equal(count.rows[0]?.c, 3);
+
+    // Vector column round-tripped (values readable + dimensionality preserved).
+    const vec = await pg.query<{ embedding: string }>(
+      "SELECT embedding::text AS embedding FROM public.memories WHERE id = '11111111-1111-1111-1111-111111111111'",
+    );
+    assert.equal(vec.rows[0]?.embedding, "[0.1,0.2,0.3,0.4]");
+
+    // TEXT[] column round-tripped.
+    const tags = await pg.query<{ tags: string[] }>(
+      "SELECT tags FROM public.memories WHERE id = '11111111-1111-1111-1111-111111111111'",
+    );
+    assert.deepEqual(tags.rows[0]?.tags, ["architecture", "vector-memory"]);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("countTables returns row counts for each named table", async () => {
+  const pg = await PGlite.create();
+  try {
+    await pg.exec("CREATE TABLE alpha (id INT); CREATE TABLE beta (id INT);");
+    await pg.exec("INSERT INTO alpha VALUES (1), (2), (3);");
+    // beta intentionally left empty.
+
+    const counts = await countTables(pg, ["alpha", "beta"]);
+    assert.deepEqual(counts, { alpha: 3, beta: 0 });
+  } finally {
+    await pg.close();
+  }
+});
+
+test("countTables rejects table names that aren't plain identifiers", async () => {
+  const pg = await PGlite.create();
+  try {
+    await assert.rejects(
+      () => countTables(pg, ['memories"; DROP TABLE x; --']),
+      /invalid table name/,
+    );
+    await assert.rejects(() => countTables(pg, ["1leading_digit"]), /invalid table name/);
+    await assert.rejects(() => countTables(pg, ["with-dash"]), /invalid table name/);
+    await assert.rejects(() => countTables(pg, [""]), /invalid table name/);
+  } finally {
+    await pg.close();
+  }
+});
+
+test("verifyMigration: equal counts → ok=true", () => {
+  const r = verifyMigration(
+    { memories: 3, experiences: 7 },
+    { memories: 3, experiences: 7 },
+  );
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.mismatches, []);
+});
+
+test("verifyMigration: count drift on one table reported, others OK", () => {
+  const r = verifyMigration(
+    { memories: 949, experiences: 298 },
+    { memories: 948, experiences: 298 },
+  );
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.mismatches, [{ table: "memories", source: 949, target: 948 }]);
+});
+
+test("verifyMigration: missing target table reported as 0 vs source", () => {
+  const r = verifyMigration({ memories: 3, lessons: 5 }, { memories: 3 });
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.mismatches, [{ table: "lessons", source: 5, target: 0 }]);
+});
+
+test("verifyMigration: extra target tables ignored (PGlite metadata is allowed)", () => {
+  const r = verifyMigration({ memories: 3 }, { memories: 3, _migrations: 79 });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.mismatches, []);
+});

--- a/mcp-server/src/native/docker-migration.ts
+++ b/mcp-server/src/native/docker-migration.ts
@@ -1,0 +1,143 @@
+// Docker → PGlite migration helpers (sub-task 7 of #176).
+//
+// Pure-TS building blocks for the native-app first-run wizard described in
+// `docs/native-migration-spike.md`. The wizard's orchestration (Docker-side
+// probe + `docker exec pg_dump`) is shell-bound and lives closer to the
+// Tauri shell — but the dump-handling, schema-load, and verification steps
+// are pure TS that runs entirely against PGlite, so they are testable here
+// in `mcp-server/` without any Docker dependency.
+//
+// What this module does NOT do:
+//   - probe for an existing Docker stack (shell-out to `psql` / `docker ps`)
+//   - invoke `pg_dump` (shell-out to `docker exec`)
+//   - write the post-migration marker file
+//   - prompt the user
+//
+// All four belong in the Tauri shell — sub-task 3 (#176). The point of this
+// PR is that once `migrateFromDocker()` lives in the shell, it can call into
+// the helpers here without re-implementing dump-handling.
+//
+// Reference: docs/native-migration-spike.md sections "What the wizard
+// implementation has to do" steps 4-7 and "1. Vector serialisation is plain
+// text — confirmed by inspection".
+
+import type { PGlite } from "@electric-sql/pglite";
+
+/**
+ * Strip psql backslash-directives from a `pg_dump --inserts` output so the
+ * remaining text is pure SQL that PGlite's `db.exec(sql)` can parse.
+ *
+ * Modern Debian-packaged pg_dump (PG 16.10+) emits SQL-injection-hardened
+ * `\restrict <token>` / `\unrestrict <token>` pairs at the head and tail of
+ * the dump; older / multi-DB dumps additionally start with `\connect`.
+ * These are psql client commands, not SQL, and PGlite's parser will choke
+ * on them (same way `db.exec("\\restrict abc")` does in plain Postgres).
+ *
+ * The filter is line-based and conservative — only drops lines that *start
+ * with* the three known directives, so legitimate SQL containing the strings
+ * (e.g. inside a string literal `'\\restrict me'`) is preserved verbatim.
+ *
+ * Spec: docs/native-migration-spike.md §"4. \restrict / \unrestrict
+ * directives need a stripper".
+ */
+export function stripPsqlDirectives(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((line) => {
+      return (
+        !line.startsWith("\\restrict") &&
+        !line.startsWith("\\unrestrict") &&
+        !line.startsWith("\\connect")
+      );
+    })
+    .join("\n");
+}
+
+export interface ApplyDumpResult {
+  /** UTF-8 byte size of the SQL actually executed (after stripping). */
+  bytes: number;
+  /** Wall-clock for `pg.exec(sql)` only — excludes the strip pass. */
+  durationMs: number;
+}
+
+/**
+ * Apply a stripped pg_dump output to a fresh PGlite instance in one shot.
+ *
+ * PRECONDITION: `pg` is a fresh PGlite — no migrations applied, no tables
+ * created. The dump carries its own schema (full dump, not `--data-only`,
+ * to dodge the circular-FK warning called out in the spike §3) and walking
+ * a stripped dump through `pg.exec` is single-pass: schema, then INSERTs,
+ * FK constraints deferred until COMMIT.
+ *
+ * Caller is responsible for opening + closing `pg`. We do not own the
+ * lifecycle so the wizard can verify counts before deciding whether to
+ * persist the dataDir or roll back.
+ */
+export async function applyDumpToPGlite(
+  pg: PGlite,
+  rawDump: string,
+): Promise<ApplyDumpResult> {
+  const sql = stripPsqlDirectives(rawDump);
+  const start = Date.now();
+  await pg.exec(sql);
+  return {
+    bytes: Buffer.byteLength(sql, "utf8"),
+    durationMs: Date.now() - start,
+  };
+}
+
+/**
+ * Count rows in each named table — used by the wizard's pre-migration probe
+ * (Docker side) and post-migration verification (PGlite side) to assert
+ * row-equality before declaring success.
+ *
+ * Table names are validated against a strict identifier regex; an invalid
+ * name throws synchronously rather than concatenating into SQL. The wizard
+ * only ever passes a known whitelist (`memories`, `experiences`,
+ * `generated_tasks`, …), but the guard makes the helper safe to expose for
+ * follow-up tooling that might receive less-trusted input.
+ */
+export async function countTables(
+  pg: PGlite,
+  tables: readonly string[],
+): Promise<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  for (const t of tables) {
+    if (!/^[a-z_][a-z0-9_]*$/.test(t)) {
+      throw new Error(`invalid table name: ${t}`);
+    }
+    const r = await pg.query<{ c: number }>(`SELECT count(*)::int AS c FROM "${t}"`);
+    counts[t] = r.rows[0]?.c ?? 0;
+  }
+  return counts;
+}
+
+export interface VerifyMismatch {
+  table: string;
+  source: number;
+  target: number;
+}
+
+export interface VerifyResult {
+  ok: boolean;
+  mismatches: VerifyMismatch[];
+}
+
+/**
+ * Compare two row-count maps and report any table whose target count does
+ * not match the source. Tables present only in `source` count as
+ * mismatches (`target` defaults to 0); tables present only in `target` are
+ * ignored — the wizard might add tables (e.g. PGlite-only metadata) that
+ * the source dump does not carry, and that's fine.
+ */
+export function verifyMigration(
+  source: Record<string, number>,
+  target: Record<string, number>,
+): VerifyResult {
+  const mismatches: VerifyMismatch[] = [];
+  for (const [t, s] of Object.entries(source)) {
+    const tgt = target[t] ?? 0;
+    if (s !== tgt) mismatches.push({ table: t, source: s, target: tgt });
+  }
+  return { ok: mismatches.length === 0, mismatches };
+}


### PR DESCRIPTION
## Summary

Implements the pure-TS building blocks for the native-app first-run **\"Import from Docker install\"** wizard described in [`docs/native-migration-spike.md`](https://github.com/Dewinator/mycelium/blob/main/docs/native-migration-spike.md). Sub-task 7 of #176 (native standalone app, prio 0.98 / Wave 1).

After this lands, the orchestrator (`migrateFromDocker()`) that lives in the Tauri shell can call into these helpers without re-implementing dump-handling. The shell-bound steps (probe + `docker exec pg_dump`) stay where they belong (sub-task 3 / PR #203 follow-up).

## What's in this PR

`mcp-server/src/native/docker-migration.ts` — three pure functions + one helper:

| Function | Purpose | Spec ref |
|---|---|---|
| `stripPsqlDirectives(sql)` | Drop `\\restrict` / `\\unrestrict` / `\\connect` lines that modern pg_dump emits but PGlite's `exec()` can't parse | spike §4 |
| `applyDumpToPGlite(pg, rawDump)` | Single-shot restore of a stripped full dump into a fresh PGlite | spike §3 + step 6 of \"What the wizard implementation has to do\" |
| `countTables(pg, tables)` | Row counts behind an identifier-regex guard, safe to expose | spike step 7 |
| `verifyMigration(source, target)` | Row-equality check pre/post-restore | spike step 7 |

The stripper is conservative — only **line-prefix** matches are dropped, so SQL whose string literals happen to contain the directive token (e.g. `'please \\restrict me'`) is preserved verbatim.

## Tests

`mcp-server/src/__tests__/native/docker-migration.test.ts` — 10 new tests, all green:

- `stripPsqlDirectives` drops the three known directives, preserves literals containing the token, idempotent
- `applyDumpToPGlite` restores a synthetic dump (CREATE EXTENSION vector, CREATE TABLE with `vector(4)`, INSERTs, `\\restrict`/`\\unrestrict` book-end) — row count + vector + TEXT[] all round-trip
- `countTables` returns counts for populated + empty tables, rejects injection attempts (\`memories\"; DROP TABLE x; --\`, leading-digit names, dashes, empty)
- `verifyMigration` ok=true on equality, reports drift, treats missing target tables as 0, ignores extra target tables (PGlite metadata is allowed)

```
✔ 10/10 pass under `node --test dist/__tests__/native/docker-migration.test.js`
✔ Full suite: 1032 pass / 0 fail / 1 pre-existing skip (~46s)
```

## Out of scope (intentional)

These belong in the Tauri shell follow-ups, NOT here:

- Probing for an existing Docker stack (`psql -lqt` / `docker ps`) — shell-bound
- Invoking `pg_dump` (`docker exec ... pg_dump`) — shell-bound
- Writing `.migrated-from-docker.json` post-success marker
- User-facing migration card / EventEmitter progress

Documented in the file header so the next PR knows where the boundary is.

## Test plan

- [ ] `cd mcp-server && npm test` — full suite green
- [ ] `cd mcp-server && node --test dist/__tests__/native/docker-migration.test.js` — 10/10 pass
- [ ] Spot-check: `stripPsqlDirectives` is idempotent on its own output

## Conflict-free with the queue

Touches only new files under `mcp-server/src/native/` and `mcp-server/src/__tests__/native/`. **Zero file overlap** with:
- PR #202 (`data-dir.ts` — also new file in same dir, but different name)
- PR #203 (`app/` — Tauri shell, separate top-level dir)
- PR #204 (`pglite-migration-walk.test.ts` — different test file)

Merge order between #202 / #203 / #204 / this PR is independent.

## Related

- Issue #176 (native standalone app epic, Wave 1)
- `docs/native-migration-spike.md` (the design this implements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)