### PR TITLE
feat(native): migrate SwarmPinService onto DbClient (#176, stacked on #209)

### DIFF
--- a/mcp-server/src/__tests__/swarm-pin.test.ts
+++ b/mcp-server/src/__tests__/swarm-pin.test.ts
@@ -6,10 +6,15 @@ import {
   type LessonTier,
   type SwarmPinDeps,
 } from "../services/swarm-pin.js";
+import type { DbClient } from "../services/db-client.js";
 import {
   swarmPinLesson,
   swarmPinLessonSchema,
 } from "../tools/swarm-pin.js";
+
+// Orchestration tests inject SwarmPinDeps so the underlying DbClient is
+// never touched — a typed-but-unused stub keeps the constructor happy.
+const STUB_DB = {} as unknown as DbClient;
 
 // ---------------------------------------------------------------------------
 // swarm_pin_lesson — first write-side slice of issue #143
@@ -120,7 +125,7 @@ function makeDeps(
 const FAKE_ID = "11111111-2222-3333-4444-555555555555";
 
 test("pinLesson promotes B → A and writes the audit row first", async () => {
-  const svc = new SwarmPinService("http://stub", "stub");
+  const svc = new SwarmPinService(STUB_DB);
   const { deps, calls } = makeDeps("B");
   const out = await svc.pinLesson(FAKE_ID, "A", undefined, deps);
 
@@ -139,7 +144,7 @@ test("pinLesson promotes B → A and writes the audit row first", async () => {
 });
 
 test("pinLesson demotes A → B and threads the caller note into the audit reason", async () => {
-  const svc = new SwarmPinService("http://stub", "stub");
+  const svc = new SwarmPinService(STUB_DB);
   const { deps, calls } = makeDeps("A");
   const out = await svc.pinLesson(FAKE_ID, "B", "contested by local logs", deps);
 
@@ -150,7 +155,7 @@ test("pinLesson demotes A → B and threads the caller note into the audit reaso
 });
 
 test("pinLesson rejects a no-op (current tier already equals target)", async () => {
-  const svc = new SwarmPinService("http://stub", "stub");
+  const svc = new SwarmPinService(STUB_DB);
   const { deps, calls } = makeDeps("A");
   await assert.rejects(
     svc.pinLesson(FAKE_ID, "A", undefined, deps),
@@ -163,7 +168,7 @@ test("pinLesson rejects a no-op (current tier already equals target)", async () 
 });
 
 test("pinLesson rejects when the lesson does not exist", async () => {
-  const svc = new SwarmPinService("http://stub", "stub");
+  const svc = new SwarmPinService(STUB_DB);
   const { deps, calls } = makeDeps(null);
   await assert.rejects(
     svc.pinLesson(FAKE_ID, "A", undefined, deps),
@@ -177,7 +182,7 @@ test("pinLesson skips the tier UPDATE when the audit-log INSERT fails", async ()
   // §10.6 traceability: losing the audit is worse than a stuck tier.
   // If the audit-log INSERT fails, the UPDATE must NOT run (otherwise we'd
   // have a silent transition that the operator cannot retrace).
-  const svc = new SwarmPinService("http://stub", "stub");
+  const svc = new SwarmPinService(STUB_DB);
   const { deps, calls } = makeDeps("B", { recordFails: true });
   await assert.rejects(
     svc.pinLesson(FAKE_ID, "A", undefined, deps),
@@ -191,7 +196,7 @@ test("pinLesson surfaces a failed UPDATE after the audit row is durable", async 
   // Symmetric: audit row IS in the log (durable transition record), but
   // the tier flip itself failed. Caller must see the error so they can
   // retry; the log entry now serves as the trail of the attempt.
-  const svc = new SwarmPinService("http://stub", "stub");
+  const svc = new SwarmPinService(STUB_DB);
   const { deps, calls } = makeDeps("B", { updateFails: true });
   await assert.rejects(
     svc.pinLesson(FAKE_ID, "A", undefined, deps),

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -158,6 +158,7 @@ import { NodeIdentityService } from "./services/node-identity.js";
 import {
   nodeIdentityGetSchema, nodeIdentityGet,
 } from "./tools/node-identity.js";
+import { PostgrestClient } from "@supabase/postgrest-js";
 import { SwarmPinService } from "./services/swarm-pin.js";
 import {
   swarmPinLessonSchema, swarmPinLessonHandler,
@@ -247,7 +248,16 @@ const guardService = new GuardService(
 const neurochemistryService = new NeurochemistryService(SUPABASE_URL, SUPABASE_KEY);
 const relationsService      = new RelationsService(SUPABASE_URL, SUPABASE_KEY);
 const nodeIdentityService   = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY);
-const swarmPinService       = new SwarmPinService(SUPABASE_URL, SUPABASE_KEY);
+// First service migrated onto the DbClient surface (#176 native-app track,
+// follow-up to PR #209). Constructed inline as a PostgrestClient until the
+// rest of index.ts is moved to async boot via createDbClient() — the
+// mode-switch (MYCELIUM_USE_PGLITE=1) lights up once that refactor lands.
+const swarmPinDbClient = new PostgrestClient(SUPABASE_URL, {
+  headers: SUPABASE_KEY
+    ? { Authorization: `Bearer ${SUPABASE_KEY}`, apikey: SUPABASE_KEY }
+    : {},
+});
+const swarmPinService       = new SwarmPinService(swarmPinDbClient);
 const swarmPeersService     = new SwarmPeersService(SUPABASE_URL, SUPABASE_KEY);
 const swarmAdmitService     = new SwarmAdmitService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPublishService   = new SwarmPublishService(SUPABASE_URL, SUPABASE_KEY);

--- a/mcp-server/src/services/swarm-pin.ts
+++ b/mcp-server/src/services/swarm-pin.ts
@@ -29,7 +29,7 @@
  * after a `:` separator.
  */
 
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { DbClient } from "./db-client.js";
 
 export type LessonTier = "A" | "B";
 
@@ -93,10 +93,15 @@ function truncateToOctets(text: string, maxOctets: number): string {
 }
 
 export class SwarmPinService {
-  private db: SupabaseClient;
+  private db: DbClient;
 
-  constructor(supabaseUrl: string, supabaseKey: string) {
-    this.db = createClient(supabaseUrl, supabaseKey);
+  // Accepts a DbClient (PostgrestClient | PGliteAdapter) so this service
+  // works against both the Docker/Supabase backend and the in-process PGlite
+  // adapter shipped with the native app. The two share the `.from(t)
+  // .select|insert|update().eq().maybeSingle()` chain used in defaultDeps —
+  // the adapter contract tests gate that surface.
+  constructor(db: DbClient) {
+    this.db = db;
   }
 
   /**
@@ -136,11 +141,16 @@ export class SwarmPinService {
   }
 
   /**
-   * Default deps wired against the service's own SupabaseClient. The MCP
-   * tool uses this when running in-process; tests inject mocks instead.
+   * Default deps wired against the service's own DbClient. The MCP tool uses
+   * this when running in-process; tests inject mocks instead.
+   *
+   * `db` is widened from `DbClient` because TypeScript can't unify the
+   * PostgrestClient and PGliteAdapter `.from()` generic signatures even
+   * though both speak the same chain shape at runtime — pglite-adapter
+   * contract tests gate that runtime equivalence.
    */
   defaultDeps(): SwarmPinDeps {
-    const db = this.db;
+    const db = this.db as { from(table: string): any };
     return {
       async fetchCurrentTier(lessonId) {
         const { data, error } = await db


### PR DESCRIPTION
## Summary

First service migrated off the `(supabaseUrl, supabaseKey)` constructor pattern and onto the shared `DbClient` surface that PR #209 introduced. Stacked on `agent/db-client-factory` — that PR must merge first.

## Why

PR #209 landed the `DbClient` factory + `MYCELIUM_USE_PGLITE` switch as the foundation. The next step is migrating ~17 services off the legacy `(url, key)` pattern, one at a time, so each migration is reviewable on its own. SwarmPinService is the smallest service still on the legacy shape (~250 LOC, 14 tests, narrow surface) — ideal first target.

## Changes

- **`mcp-server/src/services/swarm-pin.ts`**:
  - Constructor takes `DbClient` (PostgrestClient | PGliteAdapter) instead of url + key. Service no longer constructs its own SupabaseClient.
  - `defaultDeps()` widens `db` locally because TypeScript can't unify the `.from()` generics across the two backends. Runtime chain shape is identical (gated by `pglite-adapter.contract.test.ts`). Widening is local to the closure — does not leak.
  - Dropped `@supabase/supabase-js` import.
- **`mcp-server/src/index.ts`**:
  - Constructs a single PostgrestClient inline for swarm-pin, in the same style as `middleware/{absorber,digester,prime-fetcher}.ts`. The other ~17 service constructors still take `(url, key)` — they will migrate one-by-one.
  - Comment marker explains why `MYCELIUM_USE_PGLITE` mode-switch isn't yet wired here: it lights up when `index.ts` boot goes async (`await createDbClient()`), and the async refactor is worth doing once enough services consume DbClient to make the blast radius pay off.
- **`mcp-server/src/__tests__/swarm-pin.test.ts`**:
  - Constructor calls now pass a typed-but-empty STUB_DB cast. Orchestration tests inject `SwarmPinDeps` so the underlying client is never touched — the cast purely satisfies the new signature.

## Validation

```
rm -rf dist && npm run build                  → clean
node --test dist/__tests__/swarm-pin.test.js  → 14/14 passed (buildPinReason 5, pinLesson 6, swarmPinLesson 2, schema 1)
node --test dist/__tests__/db-client.test.js  → 4/4 passed (no regression in the parent factory)
```

## Stacking

Base: `agent/db-client-factory` (PR #209). When #209 merges to main, GitHub will auto-rebase this PR's base to main.

## Test plan

- [ ] CI green on the stacked branch
- [ ] After #209 merges, PR auto-retargets to main and tests still pass
- [ ] Visual review: middleware + service layer style consistency

## Related

- PR #209 — DbClient factory (parent)
- Issue #176 — Native standalone app epic (sub-task 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)