### PR TITLE
feat(native): migrate SkillsService onto DbClient + shared dbClient (#176, stacked on #210)

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -232,7 +232,6 @@ const beliefService = new BeliefService(
   parseInt(process.env.BELIEF_TIMEOUT_MS ?? "4000", 10)
 );
 const causalService = new CausalService(SUPABASE_URL, SUPABASE_KEY);
-const skillsService = new SkillsService(SUPABASE_URL, SUPABASE_KEY);
 const projectService = new ProjectService(SUPABASE_URL, SUPABASE_KEY);
 const motivationService = new MotivationService(
   SUPABASE_URL,
@@ -248,16 +247,19 @@ const guardService = new GuardService(
 const neurochemistryService = new NeurochemistryService(SUPABASE_URL, SUPABASE_KEY);
 const relationsService      = new RelationsService(SUPABASE_URL, SUPABASE_KEY);
 const nodeIdentityService   = new NodeIdentityService(SUPABASE_URL, SUPABASE_KEY);
-// First service migrated onto the DbClient surface (#176 native-app track,
-// follow-up to PR #209). Constructed inline as a PostgrestClient until the
-// rest of index.ts is moved to async boot via createDbClient() — the
-// mode-switch (MYCELIUM_USE_PGLITE=1) lights up once that refactor lands.
-const swarmPinDbClient = new PostgrestClient(SUPABASE_URL, {
+// Shared DbClient instance for services migrated onto the DbClient surface
+// (#176 native-app track, started in PR #209/#210). Constructed inline as a
+// PostgrestClient until the rest of index.ts is moved to async boot via
+// createDbClient() — the mode-switch (MYCELIUM_USE_PGLITE=1) lights up once
+// that refactor lands. New services migrating off `(supabaseUrl, supabaseKey)`
+// reuse this instance instead of allocating their own.
+const dbClient = new PostgrestClient(SUPABASE_URL, {
   headers: SUPABASE_KEY
     ? { Authorization: `Bearer ${SUPABASE_KEY}`, apikey: SUPABASE_KEY }
     : {},
 });
-const swarmPinService       = new SwarmPinService(swarmPinDbClient);
+const skillsService         = new SkillsService(dbClient);
+const swarmPinService       = new SwarmPinService(dbClient);
 const swarmPeersService     = new SwarmPeersService(SUPABASE_URL, SUPABASE_KEY);
 const swarmAdmitService     = new SwarmAdmitService(SUPABASE_URL, SUPABASE_KEY);
 const swarmPublishService   = new SwarmPublishService(SUPABASE_URL, SUPABASE_KEY);

--- a/mcp-server/src/services/skills.ts
+++ b/mcp-server/src/services/skills.ts
@@ -1,4 +1,4 @@
-import { PostgrestClient } from "@supabase/postgrest-js";
+import type { DbClient } from "./db-client.js";
 
 /**
  * Skill-performance tracking: which skill worked for which task type?
@@ -77,14 +77,20 @@ export function buildSkillRecordPayload(
 }
 
 export class SkillsService {
-  private db: PostgrestClient;
+  // Accepts a DbClient (PostgrestClient | PGliteAdapter) so this service
+  // works against both the Docker/Supabase backend and the in-process PGlite
+  // adapter shipped with the native app. RPC-only — `.rpc(name, args)` is
+  // shape-identical across both backends and gated by the adapter contract
+  // tests (pglite-adapter.test.ts).
+  //
+  // Local widening: TypeScript can't unify the PostgrestClient and
+  // PGliteAdapter `.rpc()` signatures even though both return
+  // `{ data, error }` at runtime. We widen at each call site so the
+  // type-leak stays scoped to the method body.
+  private db: DbClient;
 
-  constructor(supabaseUrl: string, supabaseKey: string) {
-    this.db = new PostgrestClient(supabaseUrl, {
-      headers: supabaseKey
-        ? { Authorization: `Bearer ${supabaseKey}`, apikey: supabaseKey }
-        : {},
-    });
+  constructor(db: DbClient) {
+    this.db = db;
   }
 
   /** Record an outcome for one or more skills that were used on a task. */
@@ -96,7 +102,8 @@ export class SkillsService {
   ): Promise<number> {
     if (!skills || skills.length === 0) return 0;
     try {
-      const { data, error } = await this.db.rpc(
+      const db = this.db as { rpc(name: string, args: Record<string, unknown>): Promise<{ data: unknown; error: unknown }> };
+      const { data, error } = await db.rpc(
         "skill_record",
         buildSkillRecordPayload(skills, taskType, outcome, difficulty),
       );
@@ -113,7 +120,8 @@ export class SkillsService {
 
   async stats(): Promise<SkillStats | null> {
     try {
-      const { data, error } = await this.db.rpc("skill_stats");
+      const db = this.db as { rpc(name: string, args?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }> };
+      const { data, error } = await db.rpc("skill_stats");
       if (error) {
         console.error("skill_stats failed:", fmtErr(error));
         return null;
@@ -131,7 +139,8 @@ export class SkillsService {
     limit = 5
   ): Promise<SkillRecommendation[]> {
     try {
-      const { data, error } = await this.db.rpc("skill_recommend", {
+      const db = this.db as { rpc(name: string, args: Record<string, unknown>): Promise<{ data: unknown; error: unknown }> };
+      const { data, error } = await db.rpc("skill_recommend", {
         p_task_type: taskType,
         p_min_evidence: minEvidence,
         p_limit: limit,


### PR DESCRIPTION
## Summary

Second service migrated off the `(supabaseUrl, supabaseKey)` constructor pattern and onto the shared `DbClient` surface. Stacked on PR #210 (SwarmPin migration), which is itself stacked on PR #209 (DbClient factory). Both must merge first.

## Why SkillsService is the right next target

RPC-only — 3 methods (`record`, `stats`, `recommend`), all `.rpc(name, args)`, **no** `.from()` chains. The `.rpc()` shape is identical across `PostgrestClient` and `PGliteAdapter` (both return `Promise<{ data, error }>` — the adapter contract tests gate that). So unlike SwarmPin (which had to widen `.from()` chains), Skills has nothing surface-area-y to debate.

149 LOC, 8 contract tests on the pure helper (`buildSkillRecordPayload`), no class-level test to update. Smaller surface than SwarmPin.

## Changes

- **`mcp-server/src/services/skills.ts`**:
  - Constructor takes `DbClient` (`PostgrestClient | PGliteAdapter`) instead of `(url, key)`.
  - Drops `@supabase/postgrest-js` import; pulls `DbClient` type from `db-client.js`.
  - Each `.rpc()` call site widens locally with a typed cast — TypeScript can't unify the two backends' rpc method signatures even though both return `{ data, error }` at runtime. Same pattern as the swarm-pin `.from()` widening in PR #210, just narrower (per-call instead of per-method-block).

- **`mcp-server/src/index.ts`**:
  - Renames `swarmPinDbClient` → `dbClient` (shared instance for all migrated services).
  - `SkillsService` now also takes `dbClient`.
  - Updated comment explains this is the shared instance subsequent migrations will reuse, not a one-off.
  - Reasoning for keeping the inline `PostgrestClient` (instead of `createDbClient()`) is unchanged from #210: `MYCELIUM_USE_PGLITE=1` mode-switch lights up once boot goes async, which is worth doing once enough services consume DbClient to make the blast radius pay off.

## Validation

```
rm -rf dist && npm run build                                  → clean
node --test dist/__tests__/affect-skill-record-payload.test.js → 8/8 passed
node --test dist/__tests__/swarm-pin.test.js                  → 14/14 passed (parent migration intact)
node --test dist/__tests__/db-client.test.js                  → 4/4 passed (grandparent intact)
node --test 'dist/__tests__/*.test.js'                        → 1010 pass / 1 skip / 0 fail
```

## Stacking

Base: `agent/swarm-pin-dbclient-stacked` (PR #210). When #210 merges, GitHub auto-rebases this PR's base to main.

## Test plan

- [ ] CI green on the stacked branch
- [ ] After #209 + #210 merge, this PR auto-retargets to main and tests still pass
- [ ] Visual review: shared `dbClient` naming reads well across the index.ts service-construction block

## Migration train so far

| PR | Service | Surface |
|---|---|---|
| #209 | DbClient factory | foundation |
| #210 | SwarmPinService | `.from()` chains + `defaultDeps()` widening |
| **#211 (this)** | **SkillsService** | RPC-only, per-call widening |
| next | TBD | likely `causal.ts` (151 LOC) or `relations.ts` (207 LOC) |

~15 services still on the legacy pattern.

## Related

- PR #210 — SwarmPin migration (parent)
- PR #209 — DbClient factory (grandparent)
- Issue #176 — Native standalone app epic (sub-task 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)